### PR TITLE
feat: frozen experiment plans, durable account ownership, and evidence-gated publication

### DIFF
--- a/.github/actions/artifact-runtime/action.yml
+++ b/.github/actions/artifact-runtime/action.yml
@@ -1,0 +1,28 @@
+name: Expose artifact runtime to scripts
+description: >-
+  Export the Actions artifact runtime (ACTIONS_RUNTIME_TOKEN + ACTIONS_RESULTS_URL) into the job
+  environment so a `run:` step can upload artifacts through @actions/artifact. GitHub injects that
+  runtime only into action steps, and the CLI's experiment store (apps/cli/src/lib/experiment-store.ts)
+  uploads each frozen plan and each attempt itself so the evidence is durable per attempt rather than
+  only at job end. Downloads need no runtime (they go through the REST API with the job token), so only
+  the uploading jobs use this: the matrix/smoke plan jobs and the bench job. The token is scoped to this
+  run's artifact and cache services and expires with the job; exporting it widens which steps of THIS
+  job can write artifacts, nothing else. It is registered as a secret so it never appears in logs.
+
+runs:
+  using: composite
+  steps:
+    # First-party action, pinned to a commit SHA like every other action in this repo.
+    - name: Export the artifact runtime
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      with:
+        script: |
+          for (const name of ["ACTIONS_RUNTIME_TOKEN", "ACTIONS_RESULTS_URL"]) {
+            const value = process.env[name];
+            if (!value) {
+              core.setFailed(`${name} is not available to this action step`);
+              continue;
+            }
+            if (name === "ACTIONS_RUNTIME_TOKEN") core.setSecret(value);
+            core.exportVariable(name, value);
+          }

--- a/.github/workflows/bench-account.yml
+++ b/.github/workflows/bench-account.yml
@@ -1,0 +1,48 @@
+name: Benchmark account (reusable)
+on:
+  workflow_call:
+    inputs:
+      account:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      axis: ${{ steps.plan.outputs.axis }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up workspace
+        uses: ./.github/actions/setup-workspace
+      - name: Read frozen account axis
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BENCH_ACCOUNT: ${{ inputs.account }}
+        run: bun apps/cli/src/bin/workflow-experiment.ts axes "$BENCH_ACCOUNT"
+  execute:
+    needs: plan
+    permissions:
+      contents: write
+      actions: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        round: ${{ fromJSON(needs.plan.outputs.axis) }}
+    uses: ./.github/workflows/bench-round.yml
+    with:
+      account: ${{ inputs.account }}
+      round: ${{ matrix.round }}
+    secrets: inherit

--- a/.github/workflows/bench-gpu.yml
+++ b/.github/workflows/bench-gpu.yml
@@ -29,11 +29,16 @@ permissions:
 concurrency:
   group: gpu-benchmark-${{ github.repository }}-shared-model-cache
   cancel-in-progress: false
+  queue: max
 
 jobs:
   prepare-assets:
     name: Prepare revision-pinned benchmark assets (CPU only)
     environment: privileged
+    concurrency:
+      group: benchmark-account-modal
+      cancel-in-progress: false
+      queue: max
     runs-on: ubuntu-24.04
     timeout-minutes: 300
     steps:
@@ -60,6 +65,10 @@ jobs:
     name: Seed revision-pinned SM120 kernel snapshot
     needs: prepare-assets
     environment: privileged
+    concurrency:
+      group: benchmark-account-modal
+      cancel-in-progress: false
+      queue: max
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
@@ -103,6 +112,10 @@ jobs:
       ${{ inputs.mode == 'full' && '20 replicates' || '1 replicate' }}
     needs: prepare-kernels
     environment: privileged
+    concurrency:
+      group: benchmark-account-modal
+      cancel-in-progress: false
+      queue: max
     runs-on: ubuntu-24.04
     # The job deadline is a final safety net; each replicate must complete creation through artifact
     # collection within ten minutes. That ceiling covers the whole sandbox lifecycle, not the measured

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -56,6 +56,10 @@ jobs:
           persist-credentials: false
       - name: Set up workspace
         uses: ./.github/actions/setup-workspace
+      # The CLI uploads the frozen plan itself (one immutable, run-scoped artifact), which needs the
+      # artifact runtime GitHub gives only to action steps.
+      - name: Expose artifact runtime to scripts
+        uses: ./.github/actions/artifact-runtime
       - name: Plan
         id: plan
         env:

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -119,6 +119,7 @@ permissions:
 concurrency:
   group: bench-matrix-${{ github.ref }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   # Compute both matrix axes once, as the single $GITHUB_OUTPUT contract the suite job reads. No

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -1,41 +1,5 @@
 name: CPU benchmark
 
-# Fan the live benchmark out across the provider × suite matrix using GitHub's native reusable-workflow
-# nesting. `plan` emits all three axes; a single suite-matrix job calls the reusable bench-suite.yml
-# once per suite (`name: ${{ matrix.suite }}`), and that reusable fans out over providers — so each cell
-# displays as "<suite> / <provider>" (e.g. "system / e2b") and cells nest under their suite in the
-# Actions UI. Adding a suite is a schema change only: the suite axis is
-# `fromJSON(needs.plan.outputs.suites)`, kept in lockstep by the workflow-registry-sync gate.
-#
-# This file owns only the matrix's SHAPE and its publish phase. Planning the axes
-# (./.github/actions/plan-bench-axes) and running a cell (bench-suite.yml) are shared verbatim with
-# bench-smoke.yml, which is this same pipeline narrowed to one provider × suite and stopped before
-# `publish` — so a smoke run exercises the real benchmarking code path, minus the dataset commit.
-#
-# The THIRD axis, replicates, is deliberately NOT a runner axis: `plan` hands each suite's replicate
-# index array to its cells as data, and one runner drives that cell's whole replicate fleet
-# concurrently in-process (`bench-suite --replicates`). A bench runner is ~100% idle waiting on its
-# sandbox, so a runner per replicate billed R idle runners to do one runner's work — at the shipped
-# defaults that is 324 runners where 54 suffice, with identical sandbox load and wall clock. See
-# bench-suite.yml's header for the failure-isolation contract inside a cell.
-#
-# Three configurable inputs tune the statistics, all defaulting to the schema/per-suite config so a bare
-# dispatch reproduces the configured run:
-#   * `suites`   — narrow the suite axis to a subset (blank = every registered suite): the targeted/
-#     pre-merge knob, so a validation dispatch can run just one suite instead of the whole matrix.
-#   * `replicas` — replicate sandboxes per (provider, suite) cell, the BETWEEN-machine axis (blank = each
-#     suite's Suite.defaultReplicas — synthetic R=3, realworld R=12; a number scales every suite). More
-#     replicates → tighter intervals on a provider's fleet variation, at proportional PROVIDER cost
-#     (sandbox minutes) but flat runner cost — the cell's runner drives them all concurrently.
-#   * `pts_passes` — timed PTS passes per case INSIDE a sandbox, the WITHIN-machine axis (blank = each
-#     suite's own policy: the cpu-node and memory suites converge, while every other suite (system, disk,
-#     pgbench, network, realworld) keeps a fixed count; a number or `converge` forces one policy across
-#     every suite).
-#
-# Off the PR path (real sandbox time + provider credentials); main is the default, while an explicit
-# allow_branch dispatch supports pre-merge validation. Every benchmark cell remains gated by Environment
-# `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md, declared inside
-# bench-suite.yml), and publishing stays main-only.
 on:
   workflow_dispatch:
     inputs:
@@ -43,63 +7,21 @@ on:
         description: 'Comma-separated providers to benchmark (blank = every registered provider).'
         required: false
         type: string
-        # The default set spans the isolation technologies compared here: e2b, daytona-vm (the LINUX_VM
-        # reference), modal-gvisor (Modal's default gVisor runtime), modal-vm (Modal's gVisor-free
-        # microVM), blaxel (stock base image), novita (its own pre-baked template), microsandbox-cloud,
-        # namespace (dedicated instance), and vercel (the shared toolchain base mirrored into VCR) have
-        # all produced comparable committed results. modal-vm + blaxel graduated into the default once
-        # committed runs validated them; microsandbox-cloud, vercel, and namespace followed. runloop and
-        # runcloud join the default WITHOUT a committed validation run — the matrix itself is how they
-        # get one, so until then they surface as pending providers / leaderboard coverage gaps rather
-        # than scores, and a cell whose credential is missing skips cleanly instead of failing the run.
-        # daytona-container and microsandbox-local are the registered variants still opt-in (pass either
-        # explicitly);
-        # `plan-providers` rejects any name that is not in the registry. Listed in registry order — the
-        # plan re-sorts to registry order regardless, so the spelling here is cosmetic.
-        #
-        # Vercel reports the fleet's smallest disk (~32 GB against the 40 GB target). That does not
-        # affect comparability — computeSpecMatched covers vCPUs and memory, the two axes providers are
-        # ranked on — but a disk-hungry suite will SKIP there and surface as a leaderboard coverage gap
-        # rather than a bad score. See packages/results/src/lib/specs.ts.
         default: e2b,daytona-vm,blaxel,microsandbox-cloud,modal-gvisor,modal-vm,novita,runloop,namespace,vercel,runcloud
       suites:
         description: 'Comma-separated suites to run (blank = every registered suite). E.g. "network" for a targeted pre-merge run.'
         required: false
         type: string
-        # Blank runs every registered suite (the main-publish default). A subset narrows the suite-matrix
-        # axis to just those suites — the pre-merge/targeted knob so a validation dispatch needn't spend
-        # the whole matrix. `plan-suites` rejects any name that is not in the registry, so a typo fails
-        # the plan.
         default: ''
       replicas:
         description: 'Replicate sandboxes per provider × suite cell — the between-machine axis (captures a provider fleet''s variation). Blank = each suite''s configured default (Suite.defaultReplicas); a whole number overrides every suite. Higher = tighter intervals at proportional runner cost; 1 = a quick single-sandbox pass.'
         required: false
         type: string
-        # Blank keeps each suite's schema default (long-synthetic suites R=3, realworld R=12 — sized from
-        # the committed dataset's between-machine variance so realworld provider CIs separate). A number
-        # scales ALL suites at once — this is the global override; per-category defaults live in the
-        # schema. plan-replicates rejects a non-positive/non-integer value, so a typo fails the plan.
         default: ''
       pts_passes:
-        description: 'Timed PTS passes per test INSIDE each sandbox — the within-machine axis. Blank = each suite''s default policy (the cpu-node and memory suites converge; every other suite — system, disk, pgbench, network, realworld — runs a fixed count). A whole number forces that many on every suite; "converge" forces PTS''s own statistical convergence everywhere.'
+        description: 'Fixed PTS passes per case. Blank preserves fixed suite defaults; convergence requires a separate diagnostic run.'
         required: false
         type: string
-        # Blank uses each suite's declared policy: cpu-node + memory converge (Suite.ptsConverge — both are
-        # cheap/stable enough that DynamicRunCount settles near its minimum and tightens the within-machine
-        # interval safely), while every other suite keeps a fixed count (convergence re-introduces fio's
-        # DynamicRunCount runaway on disk, timed system out on modal-gvisor in run #49, breaks iperf's
-        # fixed-trial rule, or overruns budgets sized for a fixed pass count; their spread is the replicas
-        # axis). A number or "converge" is the GLOBAL override applied to every suite. resolvePtsPassPolicy
-        # rejects any other non-numeric value.
-        default: ''
-      max_concurrency:
-        description: 'Cap replicate sandboxes in flight per (suite, provider) cell (blank = unbounded, i.e. all R at once). Set a number when a provider quota is smaller than R — an over-quota create retries for up to 60 min inside the cell, so an unbounded fan-out against a tight quota burns the job budget queueing. A cap serializes the cell into ceil(R / cap) waves, so wall clock grows proportionally; a cap whose waves cannot fit the cell job timeout (plus the host margin) is rejected before any sandbox is created, and the error names the smallest cap that would fit. Note the realworld suites leave no room to cap at all: R=12 over a 90-minute suite affords ONE wave inside a 180-minute job, so anything below 12 is refused — cap the synthetic suites, or raise the cell timeout first.'
-        required: false
-        type: string
-        # Blank preserves the old behaviour exactly: R separate runners each held one sandbox with
-        # nothing coordinating them, so the fan-out was already unbounded per provider. The difference
-        # now is that GitHub's concurrent-JOB limit no longer incidentally throttles it — see
-        # bench-suite.yml's header on peak provider concurrency.
         default: ''
       allow_branch:
         description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'
@@ -107,128 +29,71 @@ on:
         type: boolean
         default: false
 
-# Least privilege, workflow default: jobs only read the checked-out code and upload artifacts (publish
-# elevates to contents: write). `id-token: write` is deliberately NOT granted here — only the `suite`
-# fan-out needs it (it must pass the scope down to bench-suite.yml's cells for Namespace's GitHub OIDC
-# federation), so it is scoped to that job; zizmor flags a workflow-level id-token: write as overly
-# broad since `plan` and `publish` never touch it.
 permissions:
   contents: read
 
-# Serialize matrix runs on a ref so concurrent dispatches don't contend for provider quota.
 concurrency:
   group: bench-matrix-${{ github.ref }}
   cancel-in-progress: false
   queue: max
 
 jobs:
-  # Compute both matrix axes once, as the single $GITHUB_OUTPUT contract the suite job reads. No
-  # secrets — plan stays off the privileged environment so approval isn't needed just to dry-run the
-  # axes; a non-main run requires the explicit dispatch opt-in below. The suite job `needs: plan`, so
-  # this guard also gates the fan-out: a skipped plan (fork, or a non-main run without allow_branch)
-  # skips every cell.
   plan:
-    name: Plan matrix
+    name: Freeze experiment
     if: >
       github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
       (github.ref == 'refs/heads/main' || inputs.allow_branch)
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
     outputs:
-      providers: ${{ steps.plan.outputs.providers }}
-      suites: ${{ steps.plan.outputs.suites }}
-      # A JSON object mapping each selected suite to its replicate index array (e.g.
-      # {"cpu-node":[0,1,2],...}). The suite-matrix job indexes it by matrix.suite and passes that
-      # suite's slice down for the cell to fan out over in-process, so per-category replicate counts
-      # stay registry-driven like the suite axis.
-      replicates: ${{ steps.plan.outputs.replicates }}
+      accounts: ${{ steps.plan.outputs.axis }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Planning only reads code; don't persist the job token in .git/config.
           persist-credentials: false
       - name: Set up workspace
         uses: ./.github/actions/setup-workspace
-      # The shared planner (also used by bench-smoke.yml's plan job, which narrows the same axes to one
-      # provider × suite). plan-replicates reads the SAME BENCH_SUITES selection as plan-suites, so its
-      # map is keyed by exactly the emitted suite axis; `replicas` scales the per-suite counts (blank =
-      # each suite's Suite.defaultReplicas).
       - name: Plan
         id: plan
-        uses: ./.github/actions/plan-bench-axes
-        with:
-          providers: ${{ inputs.providers }}
-          suites: ${{ inputs.suites }}
-          replicas: ${{ inputs.replicas }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BENCH_PROVIDERS: ${{ inputs.providers }}
+          BENCH_SUITES: ${{ inputs.suites }}
+          BENCH_REPLICAS: ${{ inputs.replicas }}
+          BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
+          BENCH_ACCOUNT_CAPACITY: ${{ vars.BENCH_ACCOUNT_CAPACITY }}
+          BENCH_ARTIFACT_E2B: ${{ vars.E2B_TEMPLATE }}
+          BENCH_ARTIFACT_DAYTONA_VM: ${{ vars.DAYTONA_SNAPSHOT }}
+          BENCH_ARTIFACT_DAYTONA_CONTAINER: ${{ vars.DAYTONA_CONTAINER_SNAPSHOT }}
+          BENCH_ARTIFACT_VERCEL: ${{ vars.BENCH_ARTIFACT_VERCEL }}
+        run: bun apps/cli/src/bin/workflow-experiment.ts plan
 
-  # One matrix cell per selected suite → reusable workflow call. GitHub nests the reusable's provider
-  # matrix under each suite name, so the Actions UI shows expandable "<suite>" groups with "<provider>"
-  # children (display: "<suite> / <provider>"); each of those children drives its own R replicate
-  # sandboxes. fail-fast stays off so one bad suite doesn't cancel peers.
-  # The fork/branch guard is repeated here (not only inherited via `needs: plan`) so the job stays
-  # explicit when read in isolation — matching every other live-run job in the repo.
   suite:
-    name: ${{ matrix.suite }}
+    name: ${{ matrix.account }}
     needs: plan
-    if: >
-      github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
-      (github.ref == 'refs/heads/main' || inputs.allow_branch)
-    # A called workflow's token can never exceed its caller's, so the id-token: write that
-    # bench-suite.yml's cells need for Namespace's GitHub OIDC federation has to be granted here too.
-    # Scoped to this job, not the workflow level, per zizmor's excessive-permissions audit; `contents`
-    # is restated because a job-level `permissions:` replaces the workflow default rather than adding
-    # to it.
     permissions:
-      contents: read
+      contents: write
+      actions: read
       id-token: write
     strategy:
       fail-fast: false
       matrix:
-        suite: ${{ fromJSON(needs.plan.outputs.suites) }}
-    # `secrets: inherit` keeps repository secrets / token context available to the callee; Environment
-    # secrets on `privileged` are resolved by the reusable job's own `environment:` declaration (a
-    # `uses:` caller can't set `environment:`).
-    uses: ./.github/workflows/bench-suite.yml
+        account: ${{ fromJSON(needs.plan.outputs.accounts) }}
+    uses: ./.github/workflows/bench-account.yml
     with:
-      providers: ${{ needs.plan.outputs.providers }}
-      suite: ${{ matrix.suite }}
-      # Hand this suite its own replicate slice out of the plan's per-suite map (keyed by matrix.suite),
-      # re-serialized to the JSON array string each cell passes straight to `bench-suite --replicates`.
-      replicates: ${{ toJSON(fromJSON(needs.plan.outputs.replicates)[matrix.suite]) }}
-      # Forward the PTS passes-per-case override unchanged (blank = suite default, a number, or converge).
-      pts_passes: ${{ inputs.pts_passes }}
-      # Forward the per-cell replicate concurrency cap unchanged (blank = all R sandboxes at once).
-      max_concurrency: ${{ inputs.max_concurrency }}
+      account: ${{ matrix.account }}
     secrets: inherit
 
-  # Collect every shard Run, aggregate into one candidate, gate it (promote), and commit the machine-
-  # readable dataset onto main. This job only commits the dataset JSON — regenerating the public
-  # LEADERBOARD.md is a deliberate, separate step (the Update leaderboard workflow), so a matrix run
-  # grows the dataset without churning the comparison surface. The logic lives in the reusable
-  # commit-dataset.yml so a maintainer can also run it standalone (workflow_dispatch) to backfill a run
-  # whose commit failed. Environment `privileged` (the dataset release surface, `contents: write`) is
-  # declared inside that reusable workflow — a `uses:` caller can't set `environment:` itself.
-  #
-  # The job id stays `publish` because the workflow-registry-sync nesting gate asserts `publish` needs
-  # the suite-matrix caller (so aggregation waits for every cell); the display name reflects what it now
-  # does.
   publish:
-    name: Commit dataset
-    needs:
-      - plan
-      - suite
-    # Run even if some suite matrix cells failed (fail-fast is off) so the successful shards still
-    # commit: `aggregate` exits non-zero when zero shards are found and `promote` gates on >=1
-    # validated provider, so the quality bar is preserved. `!cancelled()` still lets an explicit cancel
-    # stop it. `!cancelled()` opts out of the implicit success() gate, so require `plan` explicitly: a
-    # skipped or failed plan means there is no provider axis, so there is nothing to commit.
+    name: Commit complete experiment
+    needs: [plan, suite]
     if: >
-      !cancelled() &&
-      needs.plan.result == 'success' &&
+      !cancelled() && needs.plan.result == 'success' &&
       github.ref == 'refs/heads/main' &&
       github.repository == 'starslingdev/hpc-sandbox-benchmarks'
-    # Grant the reusable workflow the token scopes it needs: commit/push the dataset (contents), open
-    # the PR (pull-requests), and download this run's shard artifacts by run-id (actions: read).
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/bench-round.yml
+++ b/.github/workflows/bench-round.yml
@@ -1,0 +1,53 @@
+name: Benchmark round (reusable)
+on:
+  workflow_call:
+    inputs:
+      account:
+        type: string
+        required: true
+      round:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      axis: ${{ steps.plan.outputs.axis }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up workspace
+        uses: ./.github/actions/setup-workspace
+      - name: Read frozen round axis
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BENCH_ACCOUNT: ${{ inputs.account }}
+          BENCH_ROUND: ${{ inputs.round }}
+        run: bun apps/cli/src/bin/workflow-experiment.ts axes "$BENCH_ACCOUNT" "$BENCH_ROUND"
+  execute:
+    needs: plan
+    permissions:
+      contents: write
+      actions: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.axis) }}
+    uses: ./.github/workflows/bench-suite.yml
+    with:
+      providers: ${{ toJSON(fromJSON(format('["{0}"]', matrix.provider))) }}
+      suite: ${{ matrix.suite }}
+      batch_id: ${{ matrix.batch }}
+    secrets: inherit

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -137,6 +137,7 @@ permissions:
 concurrency:
   group: bench-smoke-${{ github.ref }}-${{ inputs.provider }}-${{ inputs.suite }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   # The matrix's plan phase, narrowed to the dispatched cell: the same three planners re-validate the

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -82,6 +82,10 @@ jobs:
           persist-credentials: false
       - name: Set up workspace
         uses: ./.github/actions/setup-workspace
+      # The CLI uploads the frozen plan itself (one immutable, run-scoped artifact), which needs the
+      # artifact runtime GitHub gives only to action steps.
+      - name: Expose artifact runtime to scripts
+        uses: ./.github/actions/artifact-runtime
       - name: Plan
         id: plan
         env:

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -1,51 +1,9 @@
 name: Provider smoke test
 
-# A real benchmark run, narrowed to one provider × suite and stopped before the dataset is committed.
-#
-# This is bench-matrix.yml with two of its three phases: the same `plan` step
-# (./.github/actions/plan-bench-axes) with its axes narrowed to the dispatched provider and suite, then
-# the same suite-matrix job calling the same reusable bench-suite.yml — which spins up real sandboxes,
-# runs the suite, normalizes shard Run documents and uploads them as an artifact. What it does NOT do
-# is the third phase: no `publish` job, so nothing is aggregated, promoted or committed back to the
-# repo. That is the whole difference, and it is the point — a smoke run proves the live lane end to end
-# (credentials, runner routing, sandbox lifecycle, the in-sandbox producer, normalization, artifacts)
-# without moving the published dataset.
-#
-# Everything the run actually does therefore has exactly ONE implementation, shared with the matrix:
-# the credential wiring, the 180-minute cell budget, the microsandbox-local runner routing, the
-# Namespace OIDC mint, the replicate fan-out and the artifact contract all live in bench-suite.yml and
-# cannot drift between the lanes. Historically they were copy-pasted here and kept in sync by hand
-# (with a drift gate to catch the mistakes); now there is nothing to keep in sync.
-#
-# Two knobs differ in DEFAULT, not in kind:
-#   * `replicas` defaults to 1 — a smoke is a single sandbox per cell, where the matrix defaults to
-#     each suite's Suite.defaultReplicas (R=3 synthetic, R=12 realworld). Raise it to rehearse a real
-#     replicate fleet.
-#   * the dispatched provider is passed to bench-suite.yml as `require_providers`, so a missing or
-#     misnamed secret FAILS the job by name instead of being recorded as a skip. A green smoke must
-#     never hide that the provider was never actually smoked. The matrix deliberately leaves that
-#     blank so one unauthenticated cell doesn't sink a whole run.
-#
-# Off the PR path (it costs real sandbox time and needs provider credentials) — main is the default,
-# while an explicit `allow_branch` dispatch supports pre-merge validation of a change to the in-sandbox
-# producer (the sandbox clones this repo at the dispatched ref's SHA, so the mise tasks under test are
-# the branch's own). Every dispatch stays gated by Environment `privileged` (required reviewers +
-# environment secrets — see docs/ci-secrets.md), declared inside bench-suite.yml because a `uses:`
-# caller can't declare `environment:` itself.
-#
-# NOTE FOR OPERATORS — two things gate a branch dispatch besides the `if:` below:
-#   1. Environment `privileged` carries its own deployment-branch rule, so a branch dispatch is
-#      refused by GitHub ("Branch is not allowed to deploy to privileged") until that rule also
-#      admits the branch. See docs/ci-secrets.md → Environment `privileged`.
-#   2. GitHub reads the dispatch INPUT DEFINITIONS from the copy of this workflow on the default
-#      branch, so a newly added input is not offerable until this file is merged to `main` — the same
-#      constraint commit-dataset.yml carries. Merging it does not run anything; the inputs stay
-#      opt-in and the environment rule in (1) still has to admit the branch.
 on:
   workflow_dispatch:
     inputs:
       provider:
-        # Generated from PROVIDER_IDS; the plan step still parses it at the external input boundary.
         description: Provider to benchmark
         type: choice
         default: daytona-vm
@@ -66,13 +24,6 @@ on:
           - 'tama'
           # <<< end generated: provider-options
       suite:
-        # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the
-        # workflow-registry-sync drift gate keeps this list in lockstep, so a new suite must be added
-        # here too. Still passed through the plan step (never interpolated into a shell) as
-        # defense-in-depth.
-        # Defaults to `system` (PyBench + SQLite Speedtest + Git): a quick multi-probe suite that
-        # exercises the broadest slice of the lane in a couple of minutes of benchmark on top of setup.
-        # (`memory`/STREAM has a shorter budget but covers only a single dimension.)
         description: Suite to run
         type: choice
         default: system
@@ -89,146 +40,75 @@ on:
             realworld-openclaw,
           ]
       replicas:
-        # The between-machine axis, same spelling as bench-matrix.yml's input — but defaulting to 1
-        # rather than to each suite's schema default, because a smoke exists to prove the lane, not to
-        # tighten an interval, and R=12 on a realworld suite would spend a matrix cell's worth of
-        # provider quota to do it. Set it higher to rehearse a real replicate fleet (the cell drives
-        # them concurrently from its one runner, exactly as in the matrix).
         description: 'Replicate sandboxes for the cell — the between-machine axis. Default 1 (a single sandbox); a whole number raises it. Blank also means 1 in this lane, NOT the suite''s schema default.'
         required: false
         type: string
         default: '1'
       pts_passes:
-        # The within-machine axis, matched to bench-matrix.yml so a policy can be smoke-tested on one cell
-        # before spending the whole matrix. Blank uses the suite's own policy (the cpu-node and memory
-        # suites converge; every other suite keeps a fixed count); a whole number
-        # forces that many; "converge" forces PTS's convergence. Forwarded verbatim; harness-validated.
-        description: 'PTS passes per case: blank = suite default policy, a number, or "converge".'
-        required: false
-        type: string
-        default: ''
-      max_concurrency:
-        # Inert at the default replicas=1 (one sandbox can't exceed any cap), and forwarded verbatim so
-        # a raised `replicas` can still be held under a tight provider quota — the same knob, and the
-        # same up-front rejection of a cap whose serial waves cannot fit the cell budget, as the matrix.
-        description: 'Cap replicate sandboxes in flight (blank = unbounded, i.e. all at once). Only meaningful when replicas > 1.'
+        description: 'Fixed PTS passes per case. Blank preserves fixed suite defaults; convergence requires a separate diagnostic run.'
         required: false
         type: string
         default: ''
       allow_branch:
-        # Same name, type and default as bench-matrix.yml's input: one opt-in spelling across both
-        # live-benchmark dispatches. Default false keeps main the unsurprising target — dispatching
-        # from a branch is a deliberate act, and recording it in the run's inputs is the provenance
-        # that says the numbers came from unmerged code.
         description: 'Allow the smoke run on a non-main ref (for pre-merge validation of the in-sandbox producer).'
         required: false
         type: boolean
         default: false
 
-# Least privilege, workflow default: the plan job only reads the checked-out code. `id-token: write` is
-# deliberately NOT granted here — only the `suite` fan-out needs it (it must pass the scope down to
-# bench-suite.yml's cell for Namespace's GitHub OIDC federation), so it is scoped to that job; zizmor
-# flags a workflow-level id-token: write as overly broad since `plan` never touches it.
 permissions:
   contents: read
 
-# Serialize smoke runs per (ref, provider, suite) so two dispatches of the same cell don't contend for
-# the same provider quota; different cells still run in parallel.
 concurrency:
   group: bench-smoke-${{ github.ref }}-${{ inputs.provider }}-${{ inputs.suite }}
   cancel-in-progress: false
   queue: max
 
 jobs:
-  # The matrix's plan phase, narrowed to the dispatched cell: the same three planners re-validate the
-  # provider and suite against the registries (a stale dispatch option fails here rather than running
-  # nothing) and emit the replicate map. No secrets — plan stays off the privileged environment so
-  # approval isn't needed just to dry-run the axes. The suite job `needs: plan`, so this guard also
-  # gates the run: a skipped plan (fork, or a non-main run without allow_branch) skips the cell.
   plan:
-    name: Plan smoke
-    # The fork guard is unconditional; only the ref constraint is opt-out-able. A dispatch can only be
-    # triggered by someone with write access, and `workflow_dispatch` resolves refs in THIS repository
-    # (never a fork's branch), so widening the ref does not widen who can spend provider quota.
+    name: Freeze experiment
     if: >
       github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
       (github.ref == 'refs/heads/main' || inputs.allow_branch)
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
     outputs:
-      providers: ${{ steps.plan.outputs.providers }}
-      suites: ${{ steps.plan.outputs.suites }}
-      # A JSON object mapping the selected suite to its replicate index array (e.g. {"system":[0]}).
-      # The suite job indexes it by matrix.suite and passes that slice down, exactly as the matrix does.
-      replicates: ${{ steps.plan.outputs.replicates }}
+      accounts: ${{ steps.plan.outputs.axis }}
     steps:
-      # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
-      # moved/compromised tag can't silently change what runs.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Planning only reads code; don't persist the job token in .git/config.
           persist-credentials: false
       - name: Set up workspace
         uses: ./.github/actions/setup-workspace
-      # Single-element axes: the dispatched provider and suite. They reach the planners through the
-      # action's inputs (never interpolated into a shell), and an unregistered name fails the step.
       - name: Plan
         id: plan
-        uses: ./.github/actions/plan-bench-axes
-        with:
-          providers: ${{ inputs.provider }}
-          suites: ${{ inputs.suite }}
-          # `|| '1'` is load-bearing, not belt-and-braces: the `default:` above only applies when the
-          # field is ABSENT, and both the dispatch UI (clear the box) and an API dispatch can send an
-          # empty string. Blank reaches plan-replicates as an unset BENCH_REPLICAS, which means "each
-          # suite's Suite.defaultReplicas" — R=12 on every realworld suite. A cleared field would then
-          # quietly spend twelve real sandboxes on the lane whose entire premise is one. Blank means 1
-          # here; raising it is an explicit act. (workflow-registry-sync pins this expression.)
-          replicas: ${{ inputs.replicas || '1' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BENCH_PROVIDERS: ${{ inputs.provider }}
+          BENCH_SUITES: ${{ inputs.suite }}
+          BENCH_REPLICAS: ${{ inputs.replicas || '1' }}
+          BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
+          BENCH_ACCOUNT_CAPACITY: ${{ vars.BENCH_ACCOUNT_CAPACITY }}
+          BENCH_ARTIFACT_E2B: ${{ vars.E2B_TEMPLATE }}
+          BENCH_ARTIFACT_DAYTONA_VM: ${{ vars.DAYTONA_SNAPSHOT }}
+          BENCH_ARTIFACT_DAYTONA_CONTAINER: ${{ vars.DAYTONA_CONTAINER_SNAPSHOT }}
+          BENCH_ARTIFACT_VERCEL: ${{ vars.BENCH_ARTIFACT_VERCEL }}
+        run: bun apps/cli/src/bin/workflow-experiment.ts plan
 
-  # The matrix's benchmark phase, over a one-element suite axis → one reusable-workflow call → one
-  # provider cell. Structurally identical to bench-matrix.yml's `suite` job (same job id, same nesting
-  # wiring, same reusable) so the Actions UI reads the same "<suite> / <provider>", and so the
-  # workflow-registry-sync gate can hold both callers to one set of invariants.
-  # The fork/branch guard is repeated here (not only inherited via `needs: plan`) so the job stays
-  # explicit when read in isolation — matching every other live-run job in the repo.
   suite:
-    name: ${{ matrix.suite }}
+    name: ${{ matrix.account }}
     needs: plan
-    if: >
-      github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
-      (github.ref == 'refs/heads/main' || inputs.allow_branch)
-    # A called workflow's token can never exceed its caller's, so the id-token: write that
-    # bench-suite.yml's cell needs for Namespace's GitHub OIDC federation has to be granted here too.
-    # Scoped to this job, not the workflow level, per zizmor's excessive-permissions audit; `contents`
-    # is restated because a job-level `permissions:` replaces the workflow default rather than adding
-    # to it.
     permissions:
-      contents: read
+      contents: write
+      actions: read
       id-token: write
     strategy:
-      # A one-element axis today, kept as a matrix (rather than a bare call) so this caller is the same
-      # shape as the matrix lane's: `fromJSON(needs.plan.outputs.suites)` is what makes the suite axis
-      # registry-driven, and fail-fast off is what it means for a cell to own its own outcome.
       fail-fast: false
       matrix:
-        suite: ${{ fromJSON(needs.plan.outputs.suites) }}
-    # `secrets: inherit` keeps repository secrets / token context available to the callee; Environment
-    # secrets on `privileged` are resolved by the reusable job's own `environment:` declaration (a
-    # `uses:` caller can't set `environment:`).
-    uses: ./.github/workflows/bench-suite.yml
+        account: ${{ fromJSON(needs.plan.outputs.accounts) }}
+    uses: ./.github/workflows/bench-account.yml
     with:
-      providers: ${{ needs.plan.outputs.providers }}
-      suite: ${{ matrix.suite }}
-      # This suite's slice of the plan's per-suite map, re-serialized to the JSON array string the cell
-      # passes straight to `bench-suite --replicates` — the matrix expression, verbatim.
-      replicates: ${{ toJSON(fromJSON(needs.plan.outputs.replicates)[matrix.suite]) }}
-      # Forward the PTS passes-per-case override unchanged (blank = suite default, a number, or converge).
-      pts_passes: ${{ inputs.pts_passes }}
-      # Forward the replicate concurrency cap unchanged (blank = all replicates at once).
-      max_concurrency: ${{ inputs.max_concurrency }}
-      # The one input the matrix lane leaves blank: require the dispatched provider to reach
-      # "validated", so an absent or misnamed credential fails the job ("required providers did not
-      # pass") instead of being recorded as a skip on a job that still exits 0.
-      require_providers: ${{ inputs.provider }}
+      account: ${{ matrix.account }}
     secrets: inherit

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -24,7 +24,9 @@ permissions:
 jobs:
   bench:
     concurrency:
+      # >>> generated: provider-account-group-bench — bun run generate-provider-wiring
       group: benchmark-account-${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && 'daytona' || (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && 'modal' || matrix.provider }}
+      # <<< end generated: provider-account-group-bench
       cancel-in-progress: false
       queue: max
     name: ${{ matrix.provider }}

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -1,8 +1,5 @@
 name: Benchmark suite (reusable)
 
-# Shared benchmark execution for matrix and smoke lanes. Every selected provider is required.
-# Preserve every workflow attempt independently; a retry must never replace its predecessor's raw
-# evidence. Publication separately verifies a frozen experiment plan and terminal attempt receipts.
 on:
   workflow_call:
     inputs:
@@ -14,56 +11,14 @@ on:
         description: 'Suite to run — the bench-suite.ts arg and the artifact-name key. A registered SUITE_NAMES value.'
         required: true
         type: string
-      replicates:
-        description: >-
-          JSON array of replicate sandbox indices for THIS suite, e.g. "[0,1,2]" — the between-machine
-          fan-out axis. plan-replicates emits it per suite (Suite.defaultReplicas, or the BENCH_REPLICAS
-          override); the caller passes each suite its own slice. Handed to `bench-suite --replicates`
-          VERBATIM: one matrix cell per provider drives every index in the array concurrently, each
-          sandbox tagged with its `--replicate <idx>` so the aggregate folds them by index.
+      batch_id:
+        description: 'Immutable experiment batch identity.'
+        type: string
         required: true
-        type: string
-      max_concurrency:
-        description: >-
-          Cap on replicate sandboxes in flight per cell (BENCH_MAX_CONCURRENCY). Blank = unbounded, i.e.
-          all R at once — the fastest option and the one that matches what R separate runners used to do.
-          Set a number when a provider's account quota is smaller than R: an over-quota create is retried
-          for up to 60 minutes inside the cell, so an unbounded fan-out against a tight quota spends the
-          job budget queueing. A cap makes the cell run in ceil(R / cap) SERIAL waves, so the wall clock
-          becomes waves x suite runtime. A cap whose waves cannot fit the job's timeout-minutes is
-          REJECTED before any sandbox is created (BENCH_CELL_BUDGET_MINUTES below) — losing a whole
-          cell's fleet to a deterministic timeout is not a degradation worth discovering at 180 minutes.
-        required: false
-        type: string
-        default: ''
-      pts_passes:
-        description: >-
-          PTS passes-per-case override for the harness (BENCH_PTS_PASSES) — the within-machine axis.
-          Blank = each suite's own policy (the cpu-node and memory suites converge; every other suite keeps
-          a fixed count); a positive integer forces that many passes on every suite; "converge" forces PTS's
-          own convergence (DynamicRunCount) on every suite.
-        required: false
-        type: string
-        default: ''
-      require_providers:
-        description: >-
-          Comma-separated provider ids that MUST reach "validated" in this cell, or the cell fails
-          (REQUIRE_PROVIDERS). Blank — the MATRIX default — is the graceful posture: a provider whose
-          secret is absent or misnamed is recorded as a skip, so one unauthenticated cell doesn't sink a
-          whole matrix run. bench-smoke.yml sets its dispatched provider here instead, because the entire
-          point of a smoke run is to prove that one lane end to end: without it a missing credential
-          exits 0 having benchmarked nothing, and a green smoke would hide that the provider was never
-          actually smoked.
-        required: false
-        type: string
-        default: ''
 
-# Least privilege: the fan-out only reads the checked-out code and uploads artifacts, plus the OIDC
-# id-token the namespace cell exchanges for a Namespace login (no stored secret — see the
-# ./.github/actions/namespace-token step below). The caller must grant `id-token: write` too: a called
-# workflow's token can never exceed its caller's.
 permissions:
-  contents: read
+  contents: write
+  actions: read
   id-token: write
 
 jobs:
@@ -72,60 +27,22 @@ jobs:
       group: benchmark-account-${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && 'daytona' || (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && 'modal' || matrix.provider }}
       cancel-in-progress: false
       queue: max
-    # Display as "<caller suite job> / <provider>", e.g. "system / e2b" — the provider cells nest under
-    # their suite's job name in the Actions UI (GitHub-native reusable-workflow nesting). One cell owns
-    # all R replicate sandboxes of that (suite, provider), so there is no replicate suffix to
-    # disambiguate; the per-replicate breakdown lives in the cell's job summary + `[r<idx>]` log tags.
     name: ${{ matrix.provider }}
     environment: privileged
-    # The ephemeral self-hosted label is reaped after 70 minutes even while a step is healthy. The
-    # full CPU-generic and real-world matrices legitimately exceed that on slower providers, leaving
-    # the step stuck `in_progress` with no logs/artifact. Hosted runners honor timeout-minutes below;
-    # 180 minutes also leaves teardown/artifact margin around the longest 155-minute suite budget.
-    # (workflow-registry-sync asserts this stays above the longest registered sandbox lifetime.)
-    #
-    # Driving R replicates from one runner does not need a bigger budget WHEN THEY RUN CONCURRENTLY: the
-    # cell's wall clock is then the slowest replicate, not their sum — the same bound a single-replicate
-    # cell had. Two things break that assumption and both consume this one shared budget:
-    #   * a `max_concurrency` cap, which makes the cell run ceil(R / cap) serial waves; and
-    #   * provider capacity errors, which `createSuiteSandbox` retries for up to 60 minutes per replicate
-    #     before giving up, so a fan-out wider than the account quota queues inside the budget.
-    # At R=12 against a suite budgeted near 90 minutes, either can exceed 180. Raise this, or lower the
-    # fan-out, rather than discovering it as a cancelled cell that loses all R replicates at once.
-    # The local Microsandbox backend needs KVM; all remote providers only need a driver process. Routing
-    # it to the self-hosted label knowingly re-enters the 70-minute reaping described above — that is
-    # the trade for having any local backend at all — so it also declares BENCH_RUNNER_LIFETIME_MINUTES
-    # below, and bench-suite refuses a suite that cannot finish inside that window rather than letting
-    # the cell be reaped mid-run with no logs and every replicate lost. Keep the three paired.
     # >>> generated: provider-runner — bun run generate-provider-wiring
     runs-on: ${{ 'ubuntu-24.04' }}
     # <<< end generated: provider-runner
     timeout-minutes: 180
     strategy:
-      # One provider's failure (a flaky adapter, a dead account) must not cancel the rest of the matrix.
-      # Replicate-level isolation is handled INSIDE the cell — see the header note.
       fail-fast: false
       matrix:
         provider: ${{ fromJSON(inputs.providers) }}
     steps:
-      # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
-      # moved/compromised tag can't silently change what runs.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN when set, not the
-          # checkout's credentials), so don't persist the job token in .git/config.
           persist-credentials: false
 
-      # Bun + `bun install --frozen-lockfile --ignore-scripts` (bunfig.toml's supply-chain posture),
-      # from the repo's single setup action. Runs before any credential is introduced.
-      #
-      # no-cache is tied to the runner route above, not to a preference: the self-hosted label restores
-      # a setup-bun cache without a working ~/.bun/bin/bun, which fails the setup step outright — so the
-      # microsandbox-local cell, the one cell that lands there, must download Bun fresh. A hosted cell
-      # keeps the cache. (The cache is repo-scoped and OS/arch-keyed, so the entry a hosted cell saves
-      # is exactly what the self-hosted one would restore; ci.yml and setup-toolchain opt out for the
-      # same reason.)
       - name: Set up workspace
         uses: ./.github/actions/setup-workspace
         with:
@@ -133,13 +50,6 @@ jobs:
           no-cache: ${{ false && 'true' || 'false' }}
           # <<< end generated: provider-runner-cache
 
-      # Namespace is the one provider with no stored secret: it federates on this job's OIDC identity
-      # (id-token: write above) and mints a portable token file from the resulting CLI session — see
-      # the action for the grant and why a file is needed at all. The cell's suite + run attempt name
-      # the token, through the action's input rather than the shell.
-      #
-      # Keep normalization reachable after an admission failure so the reason is recorded. The
-      # required-provider gate below makes an unavailable Namespace credential fail this job.
       - name: Set up Namespace credentials
         # >>> generated: preauth-namespace-token-bench — bun run generate-provider-wiring
         if: matrix.provider == 'namespace'
@@ -150,15 +60,6 @@ jobs:
         with:
           token-name: sandbox-benchmarks-${{ inputs.suite }}-${{ github.run_id }}-${{ github.run_attempt }}
 
-      # tama publishes no SDK, so its adapter spawns the `tama` binary for every control-plane call and
-      # a runner without it fails at ENOENT on the first authentication probe — before a sandbox
-      # exists, and reported as a create failure rather than as the missing tool it is. Every other
-      # provider's client arrives with `bun install`; this one has to be put on the runner.
-      #
-      # NOT continue-on-error, unlike the two credential steps above: those degrade into the harness's
-      # missing-credentials skip, which is a real, legible outcome. A missing binary has no such
-      # outcome — the cell would run on to create sandboxes it cannot talk to. The install is
-      # checksum-pinned, so it fails loudly when tama cuts a release (see the action).
       - name: Set up the tama CLI
         if: matrix.provider == 'tama'
         uses: ./.github/actions/setup-tama
@@ -175,40 +76,15 @@ jobs:
           org-id: ${{ secrets.VERCEL_ORG_ID }}
           project-id: ${{ secrets.VERCEL_PROJECT_ID }}
 
-      # Drive the provider SDK to create this cell's R replicate sandboxes, run the suite in each,
-      # collect results, and normalize one shard Run per replicate. The cell's provider is a matrix value
-      # and its suite + replicate array are reusable inputs, all passed through the environment (never
-      # interpolated into the shell) so none can inject into the runner command. On success/failure the
-      # bin writes ONE job summary for the whole fleet (a row per replicate) + a run annotation.
       - name: Run suite and normalize
         env:
           BENCH_REPO_REF: ${{ github.sha }}
-          # Optional once the repo is public (anonymous clone works). Still passed so private forks and
-          # rate-limited clones keep working via the short-lived job token.
           BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BENCH_PROVIDER: ${{ matrix.provider }}
           BENCH_SUITE: ${{ inputs.suite }}
-          # The replicate index array this cell drives (the plan's per-suite slice, verbatim). Each index
-          # gets its own sandbox and its own shard Run, stamped with that index so the aggregate folds the
-          # R sandboxes of one (provider, suite) into per-metric replicate breakdowns rather than colliding.
-          BENCH_REPLICATES: ${{ inputs.replicates }}
-          # Blank = unbounded (all R sandboxes at once). See the max_concurrency input above: this is the
-          # control for a provider whose quota is smaller than R, and it trades wall clock for peak load.
-          BENCH_MAX_CONCURRENCY: ${{ inputs.max_concurrency }}
-          # This job's `timeout-minutes`, handed to the CLI so it can REFUSE a cap that cannot fit rather
-          # than be cancelled three hours in with every shard of the cell lost. A cap runs the fan-out in
-          # ceil(R / cap) serial waves, so the cell's worst case is waves x the suite's own budget — and
-          # at the realworld defaults (R=12, a 90-minute suite) the 180 below affords ONE wave once the
-          # host margin is set aside, so any cap short of the full 12 is refused. A literal, not an
-          # expression: `timeout-minutes` cannot be read from an expression context, so workflow-sync's
-          # Invariant 5 asserts the two stay equal instead.
           BENCH_CELL_BUDGET_MINUTES: '180'
-          # PTS passes-per-case policy: blank = the suite's own policy (cpu-node + memory converge, the rest
-          # fixed), a number or "converge" overrides every suite. Read by the harness preamble.
-          BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
-          # A selected provider with missing credentials is an admission failure in every lane.
-          REQUIRE_PROVIDERS: ${{ inputs.require_providers || matrix.provider }}
-          # Provider inputs are generated from metadata and scoped to their owning matrix cell.
+          BENCH_BATCH_ID: ${{ inputs.batch_id }}
+          GH_TOKEN: ${{ github.token }}
           # >>> generated: provider-inputs-bench — bun run generate-provider-wiring
           E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
           E2B_TEMPLATE: ${{ matrix.provider == 'e2b' && (env.E2B_TEMPLATE || vars.E2B_TEMPLATE || secrets.E2B_TEMPLATE) || '' }}
@@ -235,21 +111,15 @@ jobs:
           TAMA_TOKEN: ${{ matrix.provider == 'tama' && secrets.TAMA_TOKEN || '' }}
           TAMA_CLI: ${{ matrix.provider == 'tama' && (env.TAMA_CLI || vars.TAMA_CLI || secrets.TAMA_CLI) || '' }}
           # <<< end generated: provider-inputs-bench
-          # Paired with the microsandbox-local runner route above: that self-hosted label is reaped at
-          # 70 minutes regardless of timeout-minutes, which no expression can encode (the workflow gate
-          # requires a literal). Declaring it here lets bench-suite reject a suite that cannot finish
-          # inside it, before any sandbox is created. Empty on the hosted runner, which outlives the job.
           # >>> generated: provider-runner-lifetime — bun run generate-provider-wiring
           BENCH_RUNNER_LIFETIME_MINUTES: ${{ '' }}
           # <<< end generated: provider-runner-lifetime
-        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" --replicates "$BENCH_REPLICATES"
+        run: bun apps/cli/src/bin/workflow-experiment.ts execute
 
       - name: Upload Run + raw results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: bench-${{ inputs.suite }}-${{ matrix.provider }}-attempt-${{ github.run_attempt }}-${{ github.run_id }}
-          path: |
-            data/raw/${{ github.run_id }}/
-            data/runs/${{ github.run_id }}*.json
+          name: diagnostic-${{ inputs.batch_id }}-${{ matrix.provider }}-attempt-${{ github.run_attempt }}-${{ github.run_id }}
+          path: experiment/attempts/
           if-no-files-found: error

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -52,6 +52,12 @@ jobs:
           no-cache: ${{ false && 'true' || 'false' }}
           # <<< end generated: provider-runner-cache
 
+      # Each attempt's evidence is uploaded by the CLI as soon as that attempt ends (durable per
+      # attempt, not only at job end), which needs the artifact runtime GitHub gives only to action
+      # steps. The diagnostic bundle below still goes through actions/upload-artifact.
+      - name: Expose artifact runtime to scripts
+        uses: ./.github/actions/artifact-runtime
+
       - name: Set up Namespace credentials
         # >>> generated: preauth-namespace-token-bench — bun run generate-provider-wiring
         if: matrix.provider == 'namespace'

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -1,54 +1,8 @@
 name: Benchmark suite (reusable)
 
-# THE benchmark cell — the one implementation of "create real sandboxes, run a suite in them, collect
-# the raw results, normalize them into shard Run documents, upload them". Both live-benchmark
-# dispatches call it and neither has a second copy: bench-matrix.yml fans it out over the whole
-# provider × suite matrix and then commits the aggregated dataset, and bench-smoke.yml calls it with a
-# single provider × suite and stops after the upload. A smoke run is therefore the same code path as a
-# published run minus the commit phase — the credential wiring, the runner routing, the budget guard,
-# the artifact contract and the failure isolation below cannot drift between the two lanes, because
-# there is only one of each.
-#
-# ONE runner per (suite, provider) cell, which drives that cell's whole replicate fleet itself.
-# bench-matrix.yml calls this once per suite via its suite-matrix job (`name: ${{ matrix.suite }}`),
-# passing the plan's selected provider list AND that suite's replicate index array — so cells display
-# as "<suite> / <provider>" and nest under one suite label in the Actions UI. The replicate axis is the
-# BETWEEN-MACHINE knob: R sandboxes of one (provider, suite) capture a provider's fleet variation (two
-# can land on different host hardware), which the aggregate folds into per-metric replicate breakdowns.
-#
-# Replicates are NOT a matrix axis. A bench runner spends effectively all of its wall time waiting on a
-# sandbox (create → poll a detached step → poll again), so a runner-per-replicate matrix billed R idle
-# runners to do one runner's work: at the shipped defaults (6 providers × 9 suites, R=3 synthetic /
-# R=12 realworld) that is 324 runners for 54 runners' worth of driving. `bench-suite --replicates` now
-# creates the same R sandboxes concurrently from one process, so the TOTAL sandbox count is unchanged
-# while the runner-minutes bill stops scaling with R.
-#
-# PEAK provider concurrency is NOT unchanged, and that is the one cost of this design. Under the old
-# axis the 324 jobs contended for GitHub's account-wide concurrent-job limit, which incidentally
-# rate-limited how many sandboxes existed at once. 54 jobs fit under any plan's cap, so a matrix run
-# can now hold all 54 of a provider's replicate sandboxes simultaneously. Providers answer an over-quota
-# create with a capacity error, which `createSuiteSandbox` retries patiently for up to 60 minutes — so
-# the degradation is queueing, not failure, but it spends the job budget. `max_concurrency` below is the
-# control; `strategy.max-parallel` on the caller's suite matrix is the coarser alternative.
-#
-# Replicate-level failure isolation is preserved inside the process: every replicate runs to completion
-# and writes its shard even when a peer throws, and the cell goes red at the end if any did. Note this
-# is NARROWER than the old `fail-fast: false`, which also isolated whole-cell events — a job timeout,
-# runner eviction, OOM, or a "re-run failed jobs" click now costs all R replicates of the cell rather
-# than one. Sizing `max_concurrency` against `timeout-minutes` below is what keeps that risk bounded.
-#
-# The artifact name (bench-<suite>-<provider>-<run_id>) is load-bearing: commit-dataset.yml downloads
-# the shards by the `bench-*-<run_id>` pattern and aggregates them — keep the two in lockstep. One
-# artifact now carries the cell's R shards, each written to its own `data/runs/<run_id>-r<idx>.json`
-# (every shard of one run shares the same `runId` FIELD, so the `-r<idx>` filename suffix is what keeps
-# them distinct); the aggregate keys them by the --replicate index stamped on each Run. A smoke run
-# produces exactly the same shapes; nothing downstream aggregates them, which is the whole difference.
-#
-# Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md) lives on
-# the fan-out job here: a `uses:` caller can't declare `environment:`, so the approval gate and the
-# provider secrets are enforced at this layer for BOTH lanes. Environment secrets resolve from this
-# job's `environment:` declaration; the caller may still pass `secrets: inherit` for repository-level
-# secrets / token context.
+# Shared benchmark execution for matrix and smoke lanes. Every selected provider is required.
+# Preserve every workflow attempt independently; a retry must never replace its predecessor's raw
+# evidence. Publication separately verifies a frozen experiment plan and terminal attempt receipts.
 on:
   workflow_call:
     inputs:
@@ -114,6 +68,10 @@ permissions:
 
 jobs:
   bench:
+    concurrency:
+      group: benchmark-account-${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && 'daytona' || (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && 'modal' || matrix.provider }}
+      cancel-in-progress: false
+      queue: max
     # Display as "<caller suite job> / <provider>", e.g. "system / e2b" — the provider cells nest under
     # their suite's job name in the Actions UI (GitHub-native reusable-workflow nesting). One cell owns
     # all R replicate sandboxes of that (suite, provider), so there is no replicate suffix to
@@ -180,14 +138,8 @@ jobs:
       # the action for the grant and why a file is needed at all. The cell's suite + run attempt name
       # the token, through the action's input rather than the shell.
       #
-      # continue-on-error buys a LEGIBLE failure, not a passing job. It lives on the `uses:` step so the
-      # whole action degrades as a UNIT (the action's steps could each carry their own, and deliberately
-      # don't — see its header). A not-yet-registered trust relationship (or any
-      # transient mint failure) leaves `token-file` empty and the harness records the standard
-      # "missing credentials" skip, which is graceful in the matrix lane (no REQUIRE_PROVIDERS, so one
-      # unauthenticated cell doesn't sink the run) and fatal in the smoke lane (which requires its
-      # dispatched provider by name). What it avoids in both is the raw step abort, which would kill the
-      # cell with no Run document and no summary to diagnose from.
+      # Keep normalization reachable after an admission failure so the reason is recorded. The
+      # required-provider gate below makes an unavailable Namespace credential fail this job.
       - name: Set up Namespace credentials
         # >>> generated: preauth-namespace-token-bench — bun run generate-provider-wiring
         if: matrix.provider == 'namespace'
@@ -254,10 +206,8 @@ jobs:
           # PTS passes-per-case policy: blank = the suite's own policy (cpu-node + memory converge, the rest
           # fixed), a number or "converge" overrides every suite. Read by the harness preamble.
           BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
-          # Blank in the matrix lane (a skipped provider stays a skip); the smoke lane names its dispatched
-          # provider so a missing/misnamed secret fails the job by name instead of exiting 0 having
-          # benchmarked nothing. See the require_providers input above.
-          REQUIRE_PROVIDERS: ${{ inputs.require_providers }}
+          # A selected provider with missing credentials is an admission failure in every lane.
+          REQUIRE_PROVIDERS: ${{ inputs.require_providers || matrix.provider }}
           # Provider inputs are generated from metadata and scoped to their owning matrix cell.
           # >>> generated: provider-inputs-bench — bun run generate-provider-wiring
           E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
@@ -294,64 +244,12 @@ jobs:
           # <<< end generated: provider-runner-lifetime
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" --replicates "$BENCH_REPLICATES"
 
-      # Did THIS attempt actually produce shard Runs? The upload below overwrites the cell's artifact,
-      # and overwriting is only safe when there is something to put in its place.
-      #
-      # `if-no-files-found: error` cannot answer this. The cell uploads `path: data/`, and `data/dataset/`
-      # is CHECKED IN — so data/ is non-empty from the moment of checkout, on every attempt, whatever the
-      # benchmark did. That guard has therefore never been able to fire, and combining it with `overwrite`
-      # would be actively harmful: a retry that dies before writing a single shard (runner eviction, a
-      # failed install, an early crash) would still upload the checked-out dataset files, delete the
-      # previous attempt's good shards, and leave commit-dataset.yml to drop this (suite, provider) cell
-      # from the published run entirely. Losing a healthy first attempt to a broken second one is worse
-      # than the duplicate-name rejection `overwrite` exists to avoid.
-      #
-      # So: gate on the shard files by name. A pass that wrote shards replaces the attempt it retried; a
-      # pass that wrote none leaves the previous attempt's artifact standing. The job's own red/green is
-      # unaffected — bench-suite already decided that — this only governs what gets published.
-      #
-      # ...EXCEPT on the first attempt, where there is nothing to protect. The guard exists to stop a
-      # broken retry from deleting a healthy predecessor; at run_attempt 1 no predecessor exists, so
-      # applying it there is pure loss — a cell that dies before normalization (a failed install, a
-      # create that never succeeded, an early crash) would upload nothing at all, discarding the raw
-      # tree and the harness's failure markers. That is the diagnostic the smoke lane exists to
-      # produce, and it is what the old bench-smoke.yml's unconditional `if: always()` upload gave.
-      # Upload on attempt 1 regardless; from attempt 2 on, the shard gate rules.
-      - name: Check this attempt wrote shard Runs
-        id: shards
-        if: always()
-        run: |
-          shopt -s nullglob
-          shards=(data/runs/"$GITHUB_RUN_ID"*.json)
-          echo "count=${#shards[@]}" >> "$GITHUB_OUTPUT"
-          if [ ${#shards[@]} -eq 0 ]; then
-            echo "::warning title=No shards::this attempt wrote no shard Run; keeping any previous attempt's artifact"
-          else
-            echo "this attempt wrote ${#shards[@]} shard Run(s)"
-          fi
-
       - name: Upload Run + raw results
-        if: always() && (steps.shards.outputs.count != '0' || github.run_attempt == '1')
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # Per-cell artifact name so every (provider, suite) cell uploads independently, carrying its R
-          # replicate shards (data/runs/<run_id>-r<idx>.json — the filename suffix keeps them distinct,
-          # since every shard's Run carries the same `runId` field). commit-dataset.yml matches these by
-          # `bench-*-<run_id>` and globs both the `-r<idx>` shards and the legacy un-suffixed name.
-          # `if: always()` is what preserves failure isolation across the upload boundary: a cell that
-          # goes red because ONE replicate failed still uploads every shard its healthy peers wrote.
-          name: bench-${{ inputs.suite }}-${{ matrix.provider }}-${{ github.run_id }}
-          path: data/
-          # A "Re-run failed jobs" keeps github.run_id and only bumps run_attempt, so this name is
-          # unchanged on the retry — and upload-artifact@v4+ REJECTS a duplicate name by default, which
-          # would compute the retry's whole fleet and then throw it away at the upload boundary. Overwrite
-          # so the replacement fleet supersedes the attempt it retried; the step condition above is what
-          # keeps that replacement from ever being an empty one. Scope is exactly this cell: the name
-          # carries (suite, provider, run_id), so replacing it cannot disturb another cell's artifact.
-          # commit-dataset.yml's per-cell shard preference (see its "Aggregate + promote" step) then
-          # reads one shape per cell, never a mix.
-          overwrite: true
-          # Kept as a backstop, though the step condition above now owns the "did this attempt produce
-          # anything" question — data/ also carries the checked-in data/dataset/ tree, so this alone can
-          # never see an empty upload.
+          name: bench-${{ inputs.suite }}-${{ matrix.provider }}-attempt-${{ github.run_attempt }}-${{ github.run_id }}
+          path: |
+            data/raw/${{ github.run_id }}/
+            data/runs/${{ github.run_id }}*.json
           if-no-files-found: error

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -59,8 +59,12 @@ jobs:
       # With no path args actionlint scans .github/workflows automatically; .github/actionlint.yaml
       # (the self-hosted runner registry) is picked up from the repo root. shellcheck comes from mise,
       # so actionlint's embedded shell linting runs against the same pinned version as `lint:shell`.
+      - name: Set up queue validation
+        uses: ./.github/actions/setup-workspace
+        with:
+          no-cache: 'true'
       - name: Run actionlint
-        run: mise exec -- actionlint -no-color
+        run: bun run lint:workflows
 
   zizmor:
     name: Audit workflows (zizmor)

--- a/.github/workflows/commit-dataset.yml
+++ b/.github/workflows/commit-dataset.yml
@@ -43,6 +43,7 @@ permissions:
 concurrency:
   group: publish-dataset
   cancel-in-progress: false
+  queue: max
 
 jobs:
   commit:
@@ -73,90 +74,16 @@ jobs:
       - name: Set up workspace
         uses: ./.github/actions/setup-workspace
 
-      # Pull every per-cell shard artifact for the target run into ./shards (each in its own subdir).
-      # run-id + github-token make this work across runs: for a matrix call run-id is the current run,
-      # for a backfill it is the older run whose commit failed. (Downloading by run-id needs the
-      # actions: read scope granted above.)
-      - name: Download shard artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: shards
-          pattern: bench-*-${{ inputs.run_id }}
-          merge-multiple: false
-          run-id: ${{ inputs.run_id }}
-          github-token: ${{ github.token }}
+      - name: Download immutable experiment evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BENCH_EXPERIMENT_ID: ${{ inputs.run_id }}
+        run: bun apps/cli/src/bin/workflow-experiment.ts collect
 
-      # Aggregate the shards' Run documents into one candidate, then promote (gate on >=1 validated
-      # provider) and publish into the committed dataset at data/dataset/. The run-id matches the shards.
-      #
-      # The globs name the Run documents EXACTLY and must not gain a `data/` segment: the bench cell
-      # uploads `path: data/`, and upload-artifact roots the artifact at the least common ancestor of the
-      # matched files — so a shard unpacks as `shards/<artifact>/runs/<runId>...json`, with no `data/`
-      # prefix. Two decoys ride along in the artifact that a looser wildcard would sweep in: the local
-      # run index (`index.json`, at the artifact root since it sits at the root of data/ — an index, not
-      # a Run), and `dataset/runs/<oldRunId>.json` (the committed dataset, which rides along because it
-      # lives under data/, and which the `runs/` segment excludes). Both would poison the aggregate;
-      # anchoring every glob on "$RUN_ID" is what keeps them out.
-      #
-      # TWO shard shapes exist, and they are selected with a PREFERENCE, never unioned:
-      #   * `<runId>-r<idx>.json` — the current per-replicate shards (one runner drives all R replicates
-      #     of a (suite, provider) cell, so they share an artifact and are told apart by the suffix).
-      #   * `<runId>.json` — the un-suffixed single-shard name written by a run that predates the
-      #     fan-out change. Keeping it is what lets a backfill dispatch re-aggregate an older run's
-      #     still-retained artifacts.
-      #
-      # Preference, not union, because run ids are PRESERVED across re-runs: a run whose first attempt
-      # predates the change and whose retry postdates it leaves BOTH shapes under one run id. Unioning
-      # them would hand `aggregate` two shards describing the SAME sandbox — a shard with no
-      # replicateIndex normalizes to index 0, colliding with `-r0` — and its documented first-wins
-      # rule would silently drop one sandbox's whole measured set while leaving no replicate breakdown,
-      # making the result indistinguishable from a genuine single-replicate run.
-      #
-      # The preference is applied PER CELL, never run-wide, because the collision it guards against is
-      # per-cell: the two shapes describe the same sandbox only when they came from the same
-      # (suite, provider) artifact. `merge-multiple: false` above unpacks each cell into its own
-      # `shards/<artifact>/` subdir, so that subdir IS the cell boundary — loop over it and ask each cell
-      # which shape it wrote. A run-wide preference reads the shapes as a single global choice, and a
-      # mixed-shape run (retry a cell that failed on the old code, and only that cell re-runs on the new)
-      # then publishes ONLY the retried cell: every other provider/suite of the run, still legacy-only,
-      # is silently discarded and the dataset is promoted a fraction of the size it should be. Per cell,
-      # the retried cell contributes its `-r<idx>` fleet and its untouched peers contribute their legacy
-      # shard, which is the union across cells and the preference within one — exactly the intent.
-      #
-      # (Both shapes under ONE cell needs `overwrite: true` on the cell's upload — see bench-suite.yml —
-      # to be reachable at all, since a re-run otherwise cannot claim the name. The per-cell preference
-      # is the belt to that suspenders: it stays correct for artifacts uploaded before that fix and for
-      # a backfill dispatch reaching back to any older run.)
-      #
-      # The per-shape cell counts are echoed so a short or lopsided set is visible in the log rather
-      # than inferred.
       - name: Aggregate + promote
         run: |
-          shopt -s nullglob
-          shards=()
-          fanout_cells=0
-          legacy_cells=0
-          for cell in shards/*/; do
-            # The `-r*` probe is a real glob, so nullglob empties it when the cell wrote no fleet. The
-            # legacy name has NO wildcard left once "$cell" is an expanded literal, and nullglob only
-            # ever rewrites words that ARE patterns — so it must be probed with `-f`, or every cell
-            # would contribute a non-existent path and be miscounted as legacy.
-            cell_shards=("$cell"runs/"$RUN_ID"-r*.json)
-            if [ ${#cell_shards[@]} -gt 0 ]; then
-              fanout_cells=$((fanout_cells + 1))
-            elif [ -f "$cell"runs/"$RUN_ID".json ]; then
-              cell_shards=("$cell"runs/"$RUN_ID".json)
-              legacy_cells=$((legacy_cells + 1))
-            else
-              cell_shards=()
-            fi
-            shards+=("${cell_shards[@]}")
-          done
-          if [ ${#shards[@]} -eq 0 ]; then echo "no shard Run documents found for run $RUN_ID" >&2; exit 1; fi
-          echo "aggregating ${#shards[@]} shard(s) for run $RUN_ID" \
-            "from $fanout_cells per-replicate + $legacy_cells legacy single-shard cell(s)"
-          bun apps/cli/src/bin/aggregate.ts "$RUN_ID" data/candidate "${shards[@]}"
-          bun apps/cli/src/bin/promote.ts "data/candidate/runs/$RUN_ID.json" data/dataset
+          bun apps/cli/src/bin/aggregate-experiment.ts experiment/manifest/plan.json experiment/attempts data/candidate
+          bun apps/cli/src/bin/promote.ts "data/candidate/runs/$RUN_ID.json" data/dataset experiment/manifest/plan.json experiment/attempts
 
       # Canonicalize the promoted dataset to Biome's format before the gate + commit. The promote
       # writer emits `JSON.stringify(run, null, 2)` (every array element on its own line), but Biome's

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -373,6 +373,10 @@ jobs:
   # per-cell `if:` to keep in sync with the scope, and an out-of-scope provider's job never exists.
   bake:
     name: Bake + verify (${{ matrix.provider }})
+    concurrency:
+      group: benchmark-account-${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && 'daytona' || (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && 'modal' || matrix.provider }}
+      cancel-in-progress: false
+      queue: max
     needs: [plan, build]
     # `build` is skippable (`build: skip`), and a skipped `needs` would normally skip this job too — so
     # the condition is spelled out rather than left to the default. `!cancelled()` re-enables the job

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -374,7 +374,9 @@ jobs:
   bake:
     name: Bake + verify (${{ matrix.provider }})
     concurrency:
+      # >>> generated: provider-account-group-bake — bun run generate-provider-wiring
       group: benchmark-account-${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && 'daytona' || (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && 'modal' || matrix.provider }}
+      # <<< end generated: provider-account-group-bake
       cancel-in-progress: false
       queue: max
     needs: [plan, build]

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -14,7 +14,7 @@ rules:
       - update-leaderboard.yml
   secrets-inherit:
     ignore:
-      # bench-matrix.yml's and bench-smoke.yml's suite-matrix jobs both call the reusable
+      # Matrix/smoke delegate through account and round workflows to the reusable
       # bench-suite.yml with `secrets: inherit` (the smoke lane is the same pipeline narrowed to one
       # provider × suite and stopped before the dataset commit, so it reaches the cell the same way).
       # The reusable's fan-out job declares `environment: privileged`, which raises the approval gate and
@@ -23,6 +23,8 @@ rules:
       # ''`). `inherit` hands the reusable the caller's secret / token context in one line instead of
       # enumerating each secret as a `workflow_call` input (a `uses:` caller can't declare the
       # environment to resolve them itself). The workflow-hardening drift gate independently verifies the
-      # callee self-gates on `privileged`. (Filename-scoped, not repo-wide.)
+      # entire local call chain reaches a worker gated on `privileged`. (Filename-scoped, not repo-wide.)
       - bench-matrix.yml
       - bench-smoke.yml
+      - bench-account.yml
+      - bench-round.yml

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -2,6 +2,8 @@
 
 ## Contexts
 
+- [Benchmark experiments](./packages/schema/CONTEXT.md): planned work, attempts and comparison cohorts.
+
 - [Sandbox drivers](./packages/driver/CONTEXT.md): sandbox sessions and their observable behavior.
 - [Benchmark execution](./packages/harness/CONTEXT.md): benchmark steps, lifecycle measurements,
   and result gaps.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,7 +20,10 @@
     "stability": "./src/bin/stability.ts",
     "leaderboard": "./src/bin/leaderboard.ts",
     "reprice-dataset": "./src/bin/reprice-dataset.ts",
-    "driver-check": "./src/bin/driver-check.ts"
+    "driver-check": "./src/bin/driver-check.ts",
+    "plan-experiment": "./src/bin/plan-experiment.ts",
+    "evaluate-experiment": "./src/bin/evaluate-experiment.ts",
+    "aggregate-experiment": "./src/bin/aggregate-experiment.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -23,7 +23,8 @@
     "driver-check": "./src/bin/driver-check.ts",
     "plan-experiment": "./src/bin/plan-experiment.ts",
     "evaluate-experiment": "./src/bin/evaluate-experiment.ts",
-    "aggregate-experiment": "./src/bin/aggregate-experiment.ts"
+    "aggregate-experiment": "./src/bin/aggregate-experiment.ts",
+    "workflow-experiment": "./src/bin/workflow-experiment.ts"
   },
   "scripts": {
     "test": "bun test",
@@ -32,6 +33,7 @@
     "bake": "bun src/bin/bake.ts"
   },
   "dependencies": {
+    "@actions/artifact": "6.2.1",
     "@actions/core": "1.11.1",
     "@sandbox-benchmarks/schema": "workspace:*",
     "@sandbox-benchmarks/driver": "workspace:*",

--- a/apps/cli/src/bin/aggregate-experiment.ts
+++ b/apps/cli/src/bin/aggregate-experiment.ts
@@ -1,11 +1,7 @@
 #!/usr/bin/env bun
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import {
-	aggregateExperiment,
-	evaluateExperiment,
-	writeRunDocument,
-} from "@sandbox-benchmarks/results";
+import { aggregateExperiment, writeRunDocument } from "@sandbox-benchmarks/results";
 import { readExperimentAttempts, readExperimentPlan } from "../lib/experiment-artifacts.ts";
 
 if (import.meta.main) {
@@ -16,16 +12,17 @@ if (import.meta.main) {
 		);
 	const plan = readExperimentPlan(planFile);
 	const attempts = readExperimentAttempts(attemptsRoot);
-	const coverage = evaluateExperiment(plan, attempts);
+	// One evaluation: the coverage report is written either way, and the Run exists only when it is
+	// complete.
+	const { coverage, run } = aggregateExperiment(plan, attempts);
 	mkdirSync(output, { recursive: true });
 	writeFileSync(join(output, "coverage.json"), `${JSON.stringify(coverage, null, 2)}\n`);
-	if (!coverage.complete) {
+	if (!run) {
 		console.error(
 			"Experiment is incomplete; retained attempt artifacts and coverage report are diagnostic evidence.",
 		);
 		process.exitCode = 1;
 	} else {
-		const run = aggregateExperiment(plan, attempts);
 		writeRunDocument(run, join(output, "runs", `${run.runId}.json`), join(output, "index.json"));
 	}
 }

--- a/apps/cli/src/bin/aggregate-experiment.ts
+++ b/apps/cli/src/bin/aggregate-experiment.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bun
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	aggregateExperiment,
+	evaluateExperiment,
+	writeRunDocument,
+} from "@sandbox-benchmarks/results";
+import { readExperimentAttempts, readExperimentPlan } from "../lib/experiment-artifacts.ts";
+
+if (import.meta.main) {
+	const [planFile, attemptsRoot, output] = process.argv.slice(2);
+	if (!planFile || !attemptsRoot || !output)
+		throw new Error(
+			"usage: aggregate-experiment <plan.json> <attempts-directory> <candidate-directory>",
+		);
+	const plan = readExperimentPlan(planFile);
+	const attempts = readExperimentAttempts(attemptsRoot);
+	const coverage = evaluateExperiment(plan, attempts);
+	mkdirSync(output, { recursive: true });
+	writeFileSync(join(output, "coverage.json"), `${JSON.stringify(coverage, null, 2)}\n`);
+	if (!coverage.complete) {
+		console.error(
+			"Experiment is incomplete; retained attempt artifacts and coverage report are diagnostic evidence.",
+		);
+		process.exitCode = 1;
+	} else {
+		const run = aggregateExperiment(plan, attempts);
+		writeRunDocument(run, join(output, "runs", `${run.runId}.json`), join(output, "index.json"));
+	}
+}

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -13,6 +13,11 @@
 // either way, so one flaky sandbox can't discard the rest of the fleet's results.
 
 import { join } from "node:path";
+import type { ReplicateOutcome } from "../lib/run-replicate.ts";
+import { replicateLabel, runReplicate } from "../lib/run-replicate.ts";
+
+export type { ReplicateOutcome } from "../lib/run-replicate.ts";
+
 import * as core from "@actions/core";
 import { describeDriverFailure as projectDriverFailure } from "@sandbox-benchmarks/driver";
 import { diagnosticSecretsFromEnv } from "@sandbox-benchmarks/driver/env";
@@ -21,15 +26,10 @@ const describeDriverFailure = (error: unknown): string =>
 	projectDriverFailure(error, diagnosticSecretsFromEnv(process.env));
 
 import {
-	CREATE_FAILURE_PREFIX,
 	exitAfterSandboxCleanup,
 	requiredProviders,
-	runSuite,
-	SuiteUsageError,
 	shutdownOwnedSandboxes,
-	unmetRequirements,
 } from "@sandbox-benchmarks/harness";
-import { writeNormalizedRun } from "@sandbox-benchmarks/results";
 import type { Run, SuiteName } from "@sandbox-benchmarks/schema";
 import {
 	expectedRuntimeIdentity,
@@ -42,7 +42,6 @@ import {
 	fail,
 	inActions,
 	logInfo,
-	logProviderStatuses,
 	logWarning,
 	providerSummaryRows,
 	renderCell,
@@ -51,7 +50,6 @@ import {
 	writeJobSummary,
 } from "../lib/actions-log.ts";
 import { handleDiscovery } from "../lib/discovery.ts";
-import { runDriverSuite, usesDriverSuite } from "../lib/driver-run.ts";
 import { installLineTagging, withLineTag } from "../lib/log-prefix.ts";
 import {
 	fleetBudgetError,
@@ -149,28 +147,6 @@ Next: render the Run with \`leaderboard data/runs/<runId>.json\`.`;
 
 /** What one replicate produced. Returned, never exited on: a replicate that dies must not take its
  *  peers' sandboxes down with it, so the fleet driver decides the process exit code once, at the end. */
-export interface ReplicateOutcome {
-	/** The replicate index, or undefined for the single un-indexed run (local/smoke). */
-	index?: number;
-	/** Where this replicate's shard Run belongs. Always set — including on a failure that never got as
-	 *  far as writing it — so the fleet table can name the missing shard rather than blanking the cell. */
-	outFile: string;
-	/** The normalized shard Run, absent when normalization itself failed. */
-	run?: Run;
-	failed: boolean;
-	/** Why it failed (or a note about a recorded gap) — the annotation/summary text. */
-	detail?: string;
-	/**
-	 * Wall-clock milliseconds this replicate took, end to end.
-	 *
-	 * Recorded because collapsing the runner axis DELETED it: when every replicate was its own job,
-	 * the Actions UI listed R durations for free, and a straggler was obvious. Driven from one runner
-	 * they share a single job duration, so without this a report cannot say which sandbox was slow —
-	 * and a straggler is precisely what puts the cell near its `timeout-minutes`, where the whole
-	 * fleet's shards are lost at once rather than one replicate's.
-	 */
-	durationMs: number;
-}
 
 /** Elapsed wall clock, rendered for a summary cell: sub-minute stays in seconds, longer reads as
  *  `m` + `s` so a straggler is legible against a job budget quoted in minutes. */
@@ -181,9 +157,6 @@ export function formatDuration(ms: number): string {
 }
 
 /** A short, stable label for one replicate in logs and summary tables. */
-function replicateLabel(index: number | undefined): string {
-	return index === undefined ? "single" : `r${index}`;
-}
 
 /**
  * Parse `--replicate <idx>` / `--replicate=<idx>` into a non-negative integer, or `undefined` when the
@@ -445,177 +418,6 @@ async function reportFleet(
 		...(detail ? { detail } : {}),
 		annotationMessage: fleetAnnotationMessage(failures, opts.outcomes.length, validated),
 	});
-}
-
-/** Everything one replicate needs; `replicateIndex` undefined is the single un-indexed run. */
-interface ReplicateContext {
-	provider: string;
-	suite: string;
-	runId: string;
-	sha: string;
-	rawRoot: string;
-	outFile: string;
-	indexFile: string;
-	replicateIndex?: number;
-	/** Force the DriverModule path. Registered ids already take that path; waived ids error. */
-	driverPath?: boolean;
-	/** Providers that must reach "validated" for this replicate to count as a success. */
-	required: readonly string[];
-}
-
-/**
- * Run ONE replicate end to end — suite → normalize → gap verification → require gate — and report
- * what happened. Total by construction: it never throws and never exits, because a `--replicates`
- * fan-out has R of these in flight and one replicate's failure must not abort its peers or skip
- * their shard writes (the per-replicate matrix cells had `fail-fast: false` for the same reason).
- */
-export async function runReplicate(ctx: ReplicateContext): Promise<ReplicateOutcome> {
-	const { provider, suite, runId, sha, rawRoot, outFile, indexFile, replicateIndex } = ctx;
-	// Annotations are emitted as `::warning::` workflow commands, which bypass the `[rN]` line tagging
-	// by necessity (a tagged command stops being an annotation). So the replicate has to ride in the
-	// TITLE instead — otherwise a 12-way fan-out puts up to 12 byte-identical warnings in the panel
-	// with nothing saying which sandbox each came from.
-	const cell =
-		cellTitle(suite, provider) +
-		(replicateIndex === undefined ? "" : ` ${replicateLabel(replicateIndex)}`);
-	const startedAt = Bun.nanoseconds();
-	// A getter, so every `...base` spread below stamps the elapsed time AT ITS OWN return rather than
-	// freezing it here, before the suite has even started.
-	const base = {
-		index: replicateIndex,
-		outFile,
-		get durationMs() {
-			return Math.round((Bun.nanoseconds() - startedAt) / 1e6);
-		},
-	};
-
-	// A suite that RAN AND BROKE is a result — the harness has already written its `--failed.json` marker
-	// into the raw tree — so the error is held, not thrown. Normalizing anyway is what turns that marker
-	// into a recorded `failed` gap on this shard's Run document; rethrowing here would skip the write, the
-	// shard would contribute nothing for the aggregate to merge, and the only trace of the failure would
-	// die inside the CI artifact. The replicate still reports failed at the bottom of this block.
-	let suiteError: unknown;
-	let usageError: string | undefined;
-	await withGroup(`Run suite ${suite} on ${provider}`, async () => {
-		try {
-			const executeSuite = usesDriverSuite(provider, ctx.driverPath === true)
-				? runDriverSuite
-				: runSuite;
-			await executeSuite({
-				runId,
-				replicateIndex,
-				providerName: provider,
-				suiteName: suite,
-				// Tag the raw tree by suite: `<rawRoot>/<provider>/<suite>/`. The normalizer reads each suite
-				// subdirectory independently and rejects any catalogued metric a suite emits off its declared
-				// Dimensions (the runtime half of the suite↔dimension↔metric contract).
-				resultsDir: join(rawRoot, provider, suite),
-			});
-			logInfo(`Suite "${suite}" completed on ${provider}`);
-		} catch (err) {
-			// A usage error (unknown provider/suite) produced no raw tree and no marker: there is nothing to
-			// normalize, and pretending otherwise would write an empty Run for a cell that never existed.
-			if (err instanceof SuiteUsageError) {
-				usageError = err.message;
-				return;
-			}
-			suiteError = err;
-			logWarning(
-				`Suite "${suite}" threw on ${provider} — will normalize any failed marker into a gap: ${describeDriverFailure(
-					err,
-				)}`,
-				{ title: cell },
-			);
-		}
-	});
-	if (usageError !== undefined) return { ...base, failed: true, detail: usageError };
-
-	let run: Run | undefined;
-	let normalizeError: unknown;
-	await withGroup("Normalize Run document", async () => {
-		try {
-			run = writeNormalizedRun({
-				rawRoot,
-				runId,
-				sha,
-				outFile,
-				updateIndexFile: indexFile,
-				...(replicateIndex !== undefined ? { replicateIndex } : {}),
-			});
-			logInfo(`Normalized Run ${runId} → ${outFile}`);
-			// Already inside withGroup — don't nest another ::group::.
-			await logProviderStatuses(run, { grouped: false });
-		} catch (err) {
-			// Prefer the suite failure that caused a bad tree; otherwise keep the normalize error.
-			normalizeError = suiteError ?? err;
-		}
-	});
-	if (!run) {
-		const detail =
-			normalizeError instanceof Error
-				? normalizeError.message
-				: normalizeError
-					? String(normalizeError)
-					: "normalize produced no Run document";
-		return { ...base, failed: true, detail };
-	}
-	const normalized = run;
-
-	if (suiteError) {
-		const message = describeDriverFailure(suiteError);
-		// Verify before claiming: the harness writes the failed marker, but a throw can predate it (or
-		// the marker can be lost before normalize), leaving this shard's Run EMPTY for the cell. Saying
-		// "recorded as a failed gap" then would launder the loss — the aggregate would show a bare
-		// pending provider while every job log claims the gap exists — so check the normalized Run itself.
-		//
-		// Match the gap's REASON against THIS run's error, not just its (scope, id, outcome): the harness
-		// records the marker reason verbatim (`message`) for a post-run failure, or under the
-		// `Failed to create sandbox: ` prefix for a creation failure. A bare shape check would also accept
-		// a stale `--failed.json` from an earlier error, or an independently-derived suite gap (a disk
-		// shortfall, a dedup twin) — none of which prove the marker THIS run tried to write survived.
-		const gapRecorded = normalized.providers
-			.find((p) => p.providerId === provider)
-			?.gaps.some(
-				(g) =>
-					g.scope === "suite" &&
-					g.id === suite &&
-					g.outcome === "failed" &&
-					(g.reason === message || g.reason === `${CREATE_FAILURE_PREFIX}${message}`),
-			);
-		const detail = gapRecorded
-			? `Suite "${suite}" failed on ${provider} — recorded as a failed gap in ${outFile}: ${message}`
-			: `Suite "${suite}" failed on ${provider} but no gap could be recorded in ${outFile} ` +
-				`(no failed marker survived into the raw tree; this job log is the only trace): ${message}`;
-		return { ...base, run: normalized, failed: true, detail };
-	}
-
-	// Missing credentials (and an unusable sandbox) are recorded as a skip, not a throw — the lenient
-	// local-dev default. That would make a smoke run whose secret is missing/misnamed exit 0 having
-	// benchmarked nothing, so CI passes `--require <provider>` (or REQUIRE_PROVIDERS) to assert the
-	// provider actually reached `validated` — i.e. produced at least one catalogued metric.
-	if (ctx.required.length > 0) {
-		const reports = normalized.providers.map((p) => ({
-			provider: p.providerId,
-			status: p.validationStatus === "validated" ? "ok" : p.validationStatus,
-		}));
-		const unmet = unmetRequirements(reports, ctx.required);
-		if (unmet.length > 0) {
-			const details: string[] = [];
-			for (const providerId of unmet) {
-				// The gaps ARE the explanation for "no metrics", and their outcome is the important half of
-				// it: a required provider that skipped on a precondition is a configuration problem, one that
-				// failed is an outage, and the operator reading this line needs to know which they have.
-				const gaps = normalized.providers.find((p) => p.providerId === providerId)?.gaps ?? [];
-				const gapDetail = gaps.map((g) => `${g.id} ${g.outcome}: ${g.reason}`).join("; ");
-				const line = `Required provider "${providerId}" produced no metrics${gapDetail ? ` — ${gapDetail}` : " and was absent from the Run"}`;
-				details.push(line);
-			}
-			return { ...base, run: normalized, failed: true, detail: details.join("\n") };
-		}
-	}
-
-	logInfo(`Cell ${cell} succeeded → ${outFile}`);
-	return { ...base, run: normalized, failed: false };
 }
 
 if (import.meta.main) {

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -14,6 +14,12 @@
 
 import { join } from "node:path";
 import * as core from "@actions/core";
+import { describeDriverFailure as projectDriverFailure } from "@sandbox-benchmarks/driver";
+import { diagnosticSecretsFromEnv } from "@sandbox-benchmarks/driver/env";
+
+const describeDriverFailure = (error: unknown): string =>
+	projectDriverFailure(error, diagnosticSecretsFromEnv(process.env));
+
 import {
 	CREATE_FAILURE_PREFIX,
 	exitAfterSandboxCleanup,
@@ -515,9 +521,9 @@ export async function runReplicate(ctx: ReplicateContext): Promise<ReplicateOutc
 			}
 			suiteError = err;
 			logWarning(
-				`Suite "${suite}" threw on ${provider} — will normalize any failed marker into a gap: ${
-					err instanceof Error ? err.message : String(err)
-				}`,
+				`Suite "${suite}" threw on ${provider} — will normalize any failed marker into a gap: ${describeDriverFailure(
+					err,
+				)}`,
 				{ title: cell },
 			);
 		}
@@ -556,7 +562,7 @@ export async function runReplicate(ctx: ReplicateContext): Promise<ReplicateOutc
 	const normalized = run;
 
 	if (suiteError) {
-		const message = suiteError instanceof Error ? suiteError.message : String(suiteError);
+		const message = describeDriverFailure(suiteError);
 		// Verify before claiming: the harness writes the failed marker, but a throw can predate it (or
 		// the marker can be lost before normalize), leaving this shard's Run EMPTY for the cell. Saying
 		// "recorded as a failed gap" then would launder the loss — the aggregate would show a bare
@@ -665,7 +671,7 @@ if (import.meta.main) {
 		cellBudgetMinutes = resolveCellBudgetMinutes();
 		runnerLifetimeMinutes = resolveRunnerLifetimeMinutes();
 	} catch (err) {
-		fail(err instanceof Error ? err.message : String(err), {
+		fail(describeDriverFailure(err), {
 			properties: { title: "bench-suite usage" },
 			exitCode: 2,
 		});
@@ -781,7 +787,7 @@ if (import.meta.main) {
 				}
 			}
 		} catch (err) {
-			const msg = `Could not describe suite tasks for "${suite}": ${err instanceof Error ? err.message : String(err)}`;
+			const msg = `Could not describe suite tasks for "${suite}": ${describeDriverFailure(err)}`;
 			logWarning(msg, { title: cell });
 		}
 	});
@@ -895,9 +901,7 @@ if (import.meta.main) {
 			durationMs: Math.round(
 				(Bun.nanoseconds() - (startedAt.get(replicateIndex) ?? Bun.nanoseconds())) / 1e6,
 			),
-			detail: `replicate threw outside the reporting path: ${
-				error instanceof Error ? (error.stack ?? error.message) : String(error)
-			}`,
+			detail: `replicate threw outside the reporting path: ${describeDriverFailure(error)}`,
 		}),
 	);
 

--- a/apps/cli/src/bin/evaluate-experiment.ts
+++ b/apps/cli/src/bin/evaluate-experiment.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+import { evaluateExperiment } from "@sandbox-benchmarks/results";
+import { readExperimentAttempt, readExperimentPlan } from "../lib/experiment-artifacts.ts";
+
+if (import.meta.main) {
+	const [planFile, ...directories] = process.argv.slice(2);
+	if (!planFile) throw new Error("usage: evaluate-experiment <plan.json> [attempt-directory...]");
+	const coverage = evaluateExperiment(
+		readExperimentPlan(planFile),
+		directories.map(readExperimentAttempt),
+	);
+	console.log(JSON.stringify(coverage, null, 2));
+	if (!coverage.complete) process.exitCode = 1;
+}

--- a/apps/cli/src/bin/plan-experiment.ts
+++ b/apps/cli/src/bin/plan-experiment.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+import { accountCapacityPolicySchema, experimentRequestSchema } from "@sandbox-benchmarks/schema";
+import { writeImmutableJson } from "../lib/experiment-artifacts.ts";
+import { planExperiment } from "../lib/experiment-plan.ts";
+
+if (import.meta.main) {
+	const [requestFile, output, policyFile] = process.argv.slice(2);
+	if (!requestFile || !output)
+		throw new Error("usage: plan-experiment <request.json> <plan.json> [capacity-policy.json]");
+	const request = experimentRequestSchema.assert(JSON.parse(readFileSync(requestFile, "utf8")));
+	const policy = policyFile
+		? accountCapacityPolicySchema.assert(JSON.parse(readFileSync(policyFile, "utf8")))
+		: {};
+	const plan = planExperiment(request, policy);
+	writeImmutableJson(output, plan);
+	console.log(
+		JSON.stringify({
+			digest: plan.digest,
+			domains: [...new Set(plan.cells.map((cell) => cell.quotaDomain))],
+			batches: plan.batches.length,
+		}),
+	);
+}

--- a/apps/cli/src/bin/promote.ts
+++ b/apps/cli/src/bin/promote.ts
@@ -79,7 +79,10 @@ if (import.meta.main) {
 			readExperimentPlan(planFile),
 			readExperimentAttempts(attemptsRoot),
 		);
-		if (evidenceDigest(run) !== evidenceDigest(verified)) {
+		if (!verified.run) {
+			fail(`experiment is incomplete: ${JSON.stringify(verified.coverage)}`);
+		}
+		if (evidenceDigest(run) !== evidenceDigest(verified.run)) {
 			fail("candidate does not match the verified experiment attempts");
 		}
 		outFile = join(datasetDir, "runs", `${run.runId}.json`);

--- a/apps/cli/src/bin/promote.ts
+++ b/apps/cli/src/bin/promote.ts
@@ -1,14 +1,13 @@
 #!/usr/bin/env bun
 // `promote` — validate a candidate Run and publish it into the committed dataset. The promote half of
-// candidate→promote: it gates on at least one validated provider (so a partial collection with no real
-// metrics can't publish an empty run), then writes the Run into the published dataset + its index. With
-// no publish target it stays a pure validation gate (the original behavior).
+// candidate→promote: dataset writes require the original plan and attempt artifacts, and recompute
+// complete coverage independently. Without a publish target this retains legacy validation behavior.
 // Uses @actions/core for groups, annotations, and a job summary in CI.
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import * as core from "@actions/core";
-import { writeRunDocument } from "@sandbox-benchmarks/results";
+import { aggregateExperiment, evidenceDigest, writeRunDocument } from "@sandbox-benchmarks/results";
 import { parseRun } from "@sandbox-benchmarks/schema";
 import {
 	fail,
@@ -19,11 +18,12 @@ import {
 	withGroup,
 	writeJobSummary,
 } from "../lib/actions-log.ts";
+import { readExperimentAttempts, readExperimentPlan } from "../lib/experiment-artifacts.ts";
 
 if (import.meta.main) {
-	const [runFile, datasetDir] = process.argv.slice(2);
+	const [runFile, datasetDir, planFile, attemptsRoot] = process.argv.slice(2);
 	if (!runFile) {
-		fail("usage: promote <candidateRun.json> [datasetDir]", {
+		fail("usage: promote <candidateRun.json> [datasetDir plan.json attemptsRoot]", {
 			properties: { title: "promote usage" },
 			exitCode: 2,
 		});
@@ -70,6 +70,18 @@ if (import.meta.main) {
 	let outFile = "";
 	// Publish into the committed dataset (data/dataset/runs/<id>.json + index.json), newest-first index.
 	if (datasetDir) {
+		if (!planFile || !attemptsRoot) {
+			fail(
+				"publication requires an immutable experiment plan and original attempt artifacts; historical completeness is unverified",
+			);
+		}
+		const verified = aggregateExperiment(
+			readExperimentPlan(planFile),
+			readExperimentAttempts(attemptsRoot),
+		);
+		if (evidenceDigest(run) !== evidenceDigest(verified)) {
+			fail("candidate does not match the verified experiment attempts");
+		}
 		outFile = join(datasetDir, "runs", `${run.runId}.json`);
 		const indexFile = join(datasetDir, "index.json");
 		await withGroup(`Publish ${outFile}`, async () => {

--- a/apps/cli/src/bin/workflow-experiment.ts
+++ b/apps/cli/src/bin/workflow-experiment.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { describeDriverFailure } from "@sandbox-benchmarks/driver";
+import { diagnosticSecretsFromEnv } from "@sandbox-benchmarks/driver/env";
+import { exitAfterSandboxCleanup } from "@sandbox-benchmarks/harness";
+import { batchIsComplete, executeExperimentBatch } from "../lib/execute-experiment.ts";
+import { writeImmutableJson } from "../lib/experiment-artifacts.ts";
+import { githubExperimentStore } from "../lib/experiment-store.ts";
+import { downloadExperimentAttempts, downloadExperimentPlan } from "../lib/experiment-transfer.ts";
+import { githubAccountJournal, githubGitRequest } from "../lib/github-account-journal.ts";
+import { workflowAxes, workflowExperiment } from "../lib/workflow-experiment.ts";
+
+if (import.meta.main) {
+	try {
+		const [command, account, round] = process.argv.slice(2);
+		const id = process.env.BENCH_EXPERIMENT_ID ?? process.env.GITHUB_RUN_ID;
+		if (!id) throw new Error("experiment id is required");
+		const store = githubExperimentStore();
+		const root = "experiment";
+		const planRoot = join(root, "manifest");
+		mkdirSync(planRoot, { recursive: true });
+		let plan: ReturnType<typeof workflowExperiment>;
+		if (command === "plan" && process.env.GITHUB_RUN_ATTEMPT === "1") {
+			plan = workflowExperiment(process.env, new Date().toISOString().slice(0, 10));
+			writeImmutableJson(join(planRoot, "plan.json"), plan);
+			await store.upload(`experiment-plan-${plan.id}`, planRoot);
+		} else plan = await downloadExperimentPlan(store, id, planRoot);
+		if (command !== "collect" && plan.sha !== process.env.GITHUB_SHA)
+			throw new Error("checkout revision differs from frozen experiment");
+		if (command === "plan" || command === "axes") {
+			const axis = workflowAxes(plan, account, round);
+			if (!process.env.GITHUB_OUTPUT) throw new Error("workflow output file is required");
+			appendFileSync(process.env.GITHUB_OUTPUT, `axis=${JSON.stringify(axis)}\n`);
+		} else if (command === "execute") {
+			if (process.env.BENCH_CELL_BUDGET_MINUTES !== "180")
+				throw new Error("worker must preserve the 180-minute job ceiling");
+			const batchId = process.env.BENCH_BATCH_ID;
+			if (!batchId) throw new Error("batch id is required");
+			const batch = plan.batches.find((entry) => entry.id === batchId);
+			if (
+				!batch ||
+				batch.cells.some(
+					(id) =>
+						plan.cells.find((cell) => cell.id === id)?.provider !== process.env.BENCH_PROVIDER,
+				)
+			)
+				throw new Error("worker provider differs from frozen batch");
+			const attempts = await executeExperimentBatch({
+				plan,
+				batchId,
+				root: join(root, "attempts"),
+				workflowAttempt: Number(process.env.GITHUB_RUN_ATTEMPT),
+				job: process.env.GITHUB_JOB ?? "unknown",
+				store,
+				journal: githubAccountJournal(githubGitRequest()),
+			});
+			await exitAfterSandboxCleanup(
+				batchIsComplete(plan, join(root, "attempts"), attempts) ? 0 : 1,
+			);
+		} else if (command === "collect") {
+			await downloadExperimentAttempts(
+				store,
+				githubAccountJournal(githubGitRequest()),
+				plan,
+				join(root, "attempts"),
+			);
+		} else
+			throw new Error(
+				"usage: workflow-experiment plan | axes [account] [round] | execute | collect",
+			);
+	} catch (error) {
+		console.error(describeDriverFailure(error, diagnosticSecretsFromEnv(process.env)));
+		await exitAfterSandboxCleanup(1);
+	}
+}

--- a/apps/cli/src/lib/account-journal.test.ts
+++ b/apps/cli/src/lib/account-journal.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import type { SandboxDriver } from "@sandbox-benchmarks/driver";
+import type { AccountRecord } from "./account-journal.ts";
+import { recoverAccount } from "./account-journal.ts";
+
+const intent = {
+	version: "1",
+	kind: "intent",
+	account: "tama",
+	attempt: "attempt-1",
+	cellId: "tama-system-r0",
+	planDigest: `sha256:${"a".repeat(64)}`,
+} as const;
+const ref = { provider: "tama", id: "sandbox-1" } as const;
+function fixture(records: AccountRecord[]) {
+	let present = true;
+	const events: string[] = [];
+	const driver: SandboxDriver = {
+		create: async () => {
+			throw new Error("recovery must not allocate");
+		},
+		probes: {
+			observe: async () => {
+				events.push("observe");
+				return { state: present ? "running" : "absent" };
+			},
+		},
+		destroyById: async () => {
+			events.push("destroy");
+			present = false;
+		},
+	};
+	const journal = {
+		read: async () => records,
+		append: async (record: AccountRecord) => {
+			records.push(record);
+			events.push("release");
+		},
+	};
+	return { driver, journal, events };
+}
+test("interrupted known allocation is released only after observed removal", async () => {
+	const records: AccountRecord[] = [intent, { ...intent, kind: "allocated", ref }];
+	const { driver, journal, events } = fixture(records);
+	await recoverAccount("tama", new Map([["tama", driver]]), journal, AbortSignal.timeout(1000));
+	expect(events).toEqual(["observe", "destroy", "observe", "release"]);
+	expect(records.at(-1)).toMatchObject({ kind: "released", outcome: "absent", ref });
+});
+test("an empty inventory cannot resolve an interrupted create without identity", async () => {
+	const { driver, journal, events } = fixture([intent]);
+	await expect(
+		recoverAccount("tama", new Map([["tama", driver]]), journal, AbortSignal.timeout(1000)),
+	).rejects.toThrow("vendor-confirmed recovery required");
+	expect(events).toEqual([]);
+});
+test("conflicting release and allocation evidence blocks admission", async () => {
+	const { driver, journal } = fixture([
+		intent,
+		{ ...intent, kind: "allocated", ref },
+		{ ...intent, kind: "released", outcome: "not-allocated" },
+	]);
+	await expect(
+		recoverAccount("tama", new Map([["tama", driver]]), journal, AbortSignal.timeout(1000)),
+	).rejects.toThrow("contradicts");
+});
+test("unavailable observation does not append a release", async () => {
+	const { driver, journal, events } = fixture([intent, { ...intent, kind: "allocated", ref }]);
+	const unavailable = {
+		...driver,
+		probes: {
+			observe: async () => {
+				throw new Error("observation unavailable");
+			},
+		},
+	};
+	await expect(
+		recoverAccount("tama", new Map([["tama", unavailable]]), journal, AbortSignal.timeout(1000)),
+	).rejects.toThrow("unavailable");
+	expect(events).toEqual([]);
+});

--- a/apps/cli/src/lib/account-journal.ts
+++ b/apps/cli/src/lib/account-journal.ts
@@ -1,0 +1,136 @@
+import type { ProviderId, SandboxDriver, SandboxRef } from "@sandbox-benchmarks/driver";
+import { providerIdSchema } from "@sandbox-benchmarks/schema";
+import { type } from "arktype";
+
+const identity = type(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/);
+const refSchema = type({ provider: providerIdSchema, id: "string >= 1" });
+const base = {
+	version: "'1'",
+	account: identity,
+	attempt: identity,
+	cellId: identity,
+	planDigest: /^sha256:[a-f0-9]{64}$/,
+} as const;
+export const accountRecordSchema = type.or(
+	type({ ...base, kind: "'intent'" }).onUndeclaredKey("reject"),
+	type({ ...base, kind: "'allocated'", ref: refSchema }).onUndeclaredKey("reject"),
+	type({ ...base, kind: "'released'", outcome: "'absent'", ref: refSchema }).onUndeclaredKey(
+		"reject",
+	),
+	type({ ...base, kind: "'released'", outcome: "'not-allocated'" }).onUndeclaredKey("reject"),
+);
+export type AccountRecord = typeof accountRecordSchema.infer;
+export interface AccountJournal {
+	read(account: string): Promise<readonly AccountRecord[]>;
+	append(record: AccountRecord): Promise<void>;
+}
+
+/** Queues provide exclusion; this journal preserves ownership facts, never allocation claims. */
+export async function recoverAccount(
+	account: string,
+	drivers: ReadonlyMap<ProviderId, SandboxDriver>,
+	journal: AccountJournal,
+	signal: AbortSignal,
+): Promise<void> {
+	const attempts = new Map<string, AccountRecord[]>();
+	for (const raw of await withinSignal(signal, () => journal.read(account))) {
+		const record = accountRecordSchema.assert(raw);
+		if (record.account !== account) throw new Error("account journal identity mismatch");
+		const records = attempts.get(record.attempt) ?? [];
+		if (records.some((entry) => entry.kind === record.kind))
+			throw new Error("conflicting account journal records");
+		records.push(record);
+		attempts.set(record.attempt, records);
+	}
+	for (const records of attempts.values()) {
+		signal.throwIfAborted();
+		const intent = records.find((entry) => entry.kind === "intent");
+		const allocated = records.find((entry) => entry.kind === "allocated");
+		const released = records.find((entry) => entry.kind === "released");
+		if (!intent || records.some((entry) => entry.planDigest !== intent.planDigest))
+			throw new Error("incomplete account journal provenance");
+		if (released) {
+			if (
+				released.outcome === "not-allocated"
+					? allocated !== undefined
+					: !allocated ||
+						allocated.ref.provider !== released.ref.provider ||
+						allocated.ref.id !== released.ref.id
+			)
+				throw new Error("account release contradicts allocation evidence");
+			continue;
+		}
+		if (!allocated)
+			throw new Error(
+				`unresolved create ${intent.attempt}: no durable sandbox identity; vendor-confirmed recovery required`,
+			);
+		const driver = drivers.get(allocated.ref.provider);
+		if (!driver?.destroyById || !driver.probes)
+			throw new Error("interrupted allocation has no recovery driver");
+		await confirmRemoval(driver, allocated.ref, signal);
+		await withinSignal(signal, () =>
+			journal.append({ ...intent, kind: "released", outcome: "absent", ref: allocated.ref }),
+		);
+	}
+}
+
+/** Only observed absence releases a known allocation. Transport failures preserve ownership. */
+export async function confirmRemoval(
+	driver: SandboxDriver,
+	ref: SandboxRef,
+	signal: AbortSignal,
+): Promise<void> {
+	if (!driver.probes || !driver.destroyById)
+		throw new Error("driver cannot observe allocation removal");
+	const bounded = async <T>(operation: Promise<T>): Promise<T> => {
+		signal.throwIfAborted();
+		let unsubscribe = () => {};
+		try {
+			return await Promise.race([
+				operation,
+				new Promise<never>((_resolve, reject) => {
+					const listener = () => reject(signal.reason);
+					signal.addEventListener("abort", listener, { once: true });
+					unsubscribe = () => signal.removeEventListener("abort", listener);
+					if (signal.aborted) listener();
+				}),
+			]);
+		} finally {
+			unsubscribe();
+		}
+	};
+	signal.throwIfAborted();
+	if ((await bounded(driver.probes.observe(ref))).state === "absent") return;
+	signal.throwIfAborted();
+	await bounded(driver.destroyById(ref, { signal }));
+	for (;;) {
+		signal.throwIfAborted();
+		if ((await bounded(driver.probes.observe(ref))).state === "absent") return;
+		await bounded(new Promise((resolve) => setTimeout(resolve, 100)));
+	}
+}
+
+/** Bound observation and persistence; a late operation never authorizes subsequent allocation. */
+export async function withinSignal<T>(
+	signal: AbortSignal,
+	operation: () => Promise<T>,
+): Promise<T> {
+	signal.throwIfAborted();
+	let unsubscribe = () => {};
+	try {
+		return await Promise.race([
+			Promise.resolve().then(() => {
+				signal.throwIfAborted();
+				return operation();
+			}),
+			new Promise<never>((_resolve, reject) => {
+				const listener = () => reject(signal.reason);
+				signal.addEventListener("abort", listener, { once: true });
+				unsubscribe = () => signal.removeEventListener("abort", listener);
+				if (signal.aborted) listener();
+			}),
+		]);
+	} finally {
+		unsubscribe();
+	}
+}

--- a/apps/cli/src/lib/account-reconciliation.test.ts
+++ b/apps/cli/src/lib/account-reconciliation.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test";
+import type { SandboxDriver, SandboxRef } from "@sandbox-benchmarks/driver";
+import { reconcileAccount } from "./account-reconciliation.ts";
+
+const ref: SandboxRef = { provider: "tama", id: "machine-owned" };
+function driver(overrides: Partial<SandboxDriver> = {}): SandboxDriver {
+	let present = true;
+	return {
+		create: async () => {
+			throw new Error("reconciliation must never allocate");
+		},
+		inventory: { list: async () => ({ owned: present ? [ref] : [], foreignCount: 0 }) },
+		destroyById: async () => {
+			present = false;
+		},
+		probes: { observe: async () => ({ state: present ? "running" : "absent" }) },
+		...overrides,
+	};
+}
+test("reconciles owned allocations and confirms absence before admission", async () => {
+	const result = await reconcileAccount([{ id: "tama", driver: driver() }], { timeoutMs: 100 });
+	expect(result.removed).toEqual([ref]);
+});
+test("unavailable inventory, foreign resources and uncertain destroy block admission", async () => {
+	for (const candidate of [
+		driver({ inventory: undefined }),
+		driver({
+			inventory: {
+				list: async () => {
+					throw new Error("list unavailable");
+				},
+			},
+		}),
+		driver({ inventory: { list: async () => ({ owned: [], foreignCount: 1 }) } }),
+		driver({
+			destroyById: async () => {
+				throw new Error("delete outcome unknown");
+			},
+		}),
+	])
+		await expect(
+			reconcileAccount([{ id: "tama", driver: candidate }], { timeoutMs: 100 }),
+		).rejects.toThrow();
+});
+test("a successful delete response cannot replace observed absence", async () => {
+	const candidate = driver({
+		destroyById: async () => {},
+		probes: { observe: async () => ({ state: "terminal" }) },
+	});
+	await expect(
+		reconcileAccount([{ id: "tama", driver: candidate }], { timeoutMs: 15, pollMs: 1 }),
+	).rejects.toThrow("deadline exceeded");
+});
+test("cancellation cannot turn an unobserved account into an admitted one", async () => {
+	const controller = new AbortController();
+	controller.abort(new Error("cancelled"));
+	await expect(
+		reconcileAccount([{ id: "tama", driver: driver() }], {
+			timeoutMs: 100,
+			signal: controller.signal,
+		}),
+	).rejects.toThrow("cancelled");
+});
+
+test("an unavailable variant blocks deletion through every other variant", async () => {
+	let deletes = 0;
+	await expect(
+		reconcileAccount(
+			[
+				{
+					id: "tama",
+					driver: driver({
+						destroyById: async () => {
+							deletes++;
+						},
+					}),
+				},
+				{
+					id: "novita",
+					driver: driver({
+						inventory: {
+							list: async () => {
+								throw new Error("second inventory unavailable");
+							},
+						},
+					}),
+				},
+			],
+			{ timeoutMs: 100 },
+		),
+	).rejects.toThrow("second inventory unavailable");
+	expect(deletes).toBe(0);
+});
+
+test("a resource appearing after deletion prevents admission", async () => {
+	let scans = 0;
+	const candidate = driver({
+		inventory: {
+			list: async () => ({
+				owned: [scans++ === 0 ? ref : { ...ref, id: "late-allocation" }],
+				foreignCount: 0,
+			}),
+		},
+	});
+	await expect(
+		reconcileAccount([{ id: "tama", driver: candidate }], { timeoutMs: 100 }),
+	).rejects.toThrow("inventory changed");
+});

--- a/apps/cli/src/lib/account-reconciliation.ts
+++ b/apps/cli/src/lib/account-reconciliation.ts
@@ -1,0 +1,112 @@
+import type {
+	InventorySnapshot,
+	ProviderId,
+	SandboxDriver,
+	SandboxRef,
+} from "@sandbox-benchmarks/driver";
+
+export interface AccountDriver {
+	id: ProviderId;
+	driver: SandboxDriver;
+}
+
+export interface ReconciliationEvidence {
+	confirmedAt: string;
+	removed: SandboxRef[];
+}
+
+/** Must run under the account's workflow queue, before any new allocation. */
+export async function reconcileAccount(
+	drivers: readonly AccountDriver[],
+	options: { timeoutMs: number; signal?: AbortSignal; pollMs?: number },
+): Promise<ReconciliationEvidence> {
+	if (drivers.length === 0) throw new Error("account reconciliation requires at least one driver");
+	if (!Number.isSafeInteger(options.timeoutMs) || options.timeoutMs <= 0)
+		throw new Error("invalid reconciliation budget");
+	for (const { id, driver } of drivers) {
+		if (!driver.inventory || !driver.destroyById || !driver.probes)
+			throw new Error(`${id} has no complete managed inventory/recovery capability`);
+	}
+	const controller = new AbortController();
+	const abort = () =>
+		controller.abort(options.signal?.reason ?? new Error("account reconciliation cancelled"));
+	options.signal?.addEventListener("abort", abort, { once: true });
+	if (options.signal?.aborted) abort();
+	const timer = setTimeout(
+		() =>
+			controller.abort(
+				new Error("account reconciliation deadline exceeded; allocation remains blocked"),
+			),
+		options.timeoutMs,
+	);
+	const removed: SandboxRef[] = [];
+	const bounded = async <T>(operation: () => Promise<T>): Promise<T> => {
+		controller.signal.throwIfAborted();
+		let unsubscribe = () => {};
+		try {
+			return await Promise.race([
+				Promise.resolve().then(() => {
+					controller.signal.throwIfAborted();
+					return operation();
+				}),
+				new Promise<never>((_resolve, reject) => {
+					const listener = () => reject(controller.signal.reason);
+					controller.signal.addEventListener("abort", listener, { once: true });
+					unsubscribe = () => controller.signal.removeEventListener("abort", listener);
+					if (controller.signal.aborted) listener();
+				}),
+			]);
+		} finally {
+			unsubscribe();
+		}
+	};
+	const list = async ({ id, driver }: AccountDriver): Promise<InventorySnapshot> => {
+		const inventory = driver.inventory;
+		if (!inventory) throw new Error(`${id} inventory disappeared`);
+		const snapshot = await bounded(() => inventory.list({ signal: controller.signal }));
+		if (
+			!Number.isSafeInteger(snapshot.foreignCount) ||
+			snapshot.foreignCount < 0 ||
+			!Array.isArray(snapshot.owned)
+		)
+			throw new Error(`${id} returned invalid account inventory`);
+		if (snapshot.foreignCount > 0)
+			throw new Error(`${id} dedicated account contains unowned resources; allocation blocked`);
+		const ids = new Set<string>();
+		for (const ref of snapshot.owned) {
+			if (ref.provider !== id || typeof ref.id !== "string" || ref.id === "" || ids.has(ref.id))
+				throw new Error(`${id} inventory returned invalid or duplicate ownership`);
+			ids.add(ref.id);
+		}
+		return snapshot;
+	};
+	try {
+		// Inspect every variant before destructive recovery. An incomplete view of one variant
+		// cannot authorize deleting resources found through another variant's inventory.
+		const snapshots = [];
+		for (const entry of drivers) snapshots.push({ entry, snapshot: await list(entry) });
+		for (const { entry, snapshot } of snapshots) {
+			const { driver } = entry;
+			const destroy = driver.destroyById;
+			const probes = driver.probes;
+			if (!destroy || !probes) throw new Error("managed recovery capability disappeared");
+			for (const ref of snapshot.owned) {
+				await bounded(() => destroy.call(driver, ref, { signal: controller.signal }));
+				while ((await bounded(() => probes.observe(ref))).state !== "absent") {
+					await bounded(
+						() => new Promise((resolve) => setTimeout(resolve, options.pollMs ?? 1000)),
+					);
+				}
+				removed.push(ref);
+			}
+		}
+		for (const entry of drivers) {
+			if ((await list(entry)).owned.length > 0)
+				throw new Error(`${entry.id} inventory changed during reconciliation; allocation blocked`);
+		}
+		return { removed, confirmedAt: new Date().toISOString() };
+	} finally {
+		clearTimeout(timer);
+		options.signal?.removeEventListener("abort", abort);
+	}
+}

--- a/apps/cli/src/lib/execute-experiment.test.ts
+++ b/apps/cli/src/lib/execute-experiment.test.ts
@@ -1,0 +1,213 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExecResult, SandboxSession } from "@sandbox-benchmarks/driver";
+import { loadDriverModule } from "@sandbox-benchmarks/drivers";
+import { evaluateExperiment } from "@sandbox-benchmarks/results";
+import { TOOLCHAIN_VERSION } from "@sandbox-benchmarks/schema/toolchain";
+import type { AccountRecord } from "./account-journal.ts";
+import type { OpenedDriver } from "./driver-run.ts";
+import { resolveDriverArtifact } from "./driver-run.ts";
+import { batchIsComplete, executeExperimentBatch } from "./execute-experiment.ts";
+import { readExperimentAttempt } from "./experiment-artifacts.ts";
+import { workflowExperiment } from "./workflow-experiment.ts";
+
+const root = mkdtempSync(join(tmpdir(), "experiment-integration-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+const plan = workflowExperiment(
+	{
+		GITHUB_RUN_ID: "123",
+		GITHUB_SHA: "a".repeat(40),
+		BENCH_PROVIDERS: "tama",
+		BENCH_SUITES: "cpu-node",
+		BENCH_REPLICAS: "2",
+		BENCH_PTS_PASSES: "2",
+		BENCH_ACCOUNT_CAPACITY: '{"tama":{"sandboxes":2}}',
+	},
+	"2026-09-10",
+);
+const ok = (stdout = "", code = 0): ExecResult => ({
+	stdout,
+	stderr: "",
+	exit: { kind: "exited", code },
+	durationMs: 1,
+	truncated: false,
+});
+async function fixture(name: string, failCleanup = false) {
+	const directory = join(root, name);
+	mkdirSync(directory, { recursive: true });
+	const payloadRoot = join(directory, "payload");
+	mkdirSync(join(payloadRoot, "benchmark-results"), { recursive: true });
+	writeFileSync(
+		join(payloadRoot, "benchmark-results", "pts_node-web-tooling.xml"),
+		readFileSync(
+			new URL(
+				"../../../../packages/results/src/lib/__fixtures__/daytona-vm/pts_node-web-tooling.xml",
+				import.meta.url,
+			),
+		),
+	);
+	const tar = Bun.spawnSync(["tar", "-czf", "-", "benchmark-results"], { cwd: payloadRoot });
+	if (tar.exitCode !== 0) throw new Error("fixture archive failed");
+	const payload = `__BENCH_RESULTS_TGZ_BEGIN__\n${tar.stdout.toString("base64")}\n__BENCH_RESULTS_TGZ_END__\n`;
+	const records: AccountRecord[] = [];
+	const events: string[] = [];
+	const present = new Set<string>();
+	let sequence = 0;
+	let peak = 0;
+	const artifact = resolveDriverArtifact("tama");
+	const module = await loadDriverModule("tama");
+	const opened: OpenedDriver = {
+		artifact,
+		module: {
+			id: module.id,
+			provenance: module.provenance,
+			driver: () => {
+				throw new Error("fixture is already opened");
+			},
+			readiness: { startup: "create-returns-ready" },
+			execution: { syncCapMs: null, durable: "none" },
+		},
+		transport: { syncCapMs: null, detachedPoll: false, streaming: false },
+		driver: {
+			inventory: {
+				list: async () => ({
+					owned: [...present].map((id) => ({ provider: "tama" as const, id })),
+					foreignCount: 0,
+				}),
+			},
+			probes: { observe: async (ref) => ({ state: present.has(ref.id) ? "running" : "absent" }) },
+			destroyById: async (ref) => {
+				present.delete(ref.id);
+			},
+			create: async () => {
+				const id = `sandbox-${++sequence}`;
+				expect(records.filter((record) => record.kind === "intent").length).toBeGreaterThanOrEqual(
+					sequence,
+				);
+				present.add(id);
+				peak = Math.max(peak, present.size);
+				events.push("create");
+				const session: SandboxSession = {
+					sandboxRef: { provider: "tama", id },
+					artifact,
+					native: undefined,
+					exec: async (command) => {
+						if (command.includes("/toolchain-manifest.json"))
+							return ok(
+								JSON.stringify({
+									image_name: "sandbox-benchmarks-toolchain",
+									image_version: TOOLCHAIN_VERSION,
+								}),
+							);
+						if (command.includes("base64")) return ok(payload);
+						if (command.includes("benchmark:cpu"))
+							expect(
+								records.some((record) => record.kind === "allocated" && record.ref.id === id),
+							).toBe(true);
+						return ok();
+					},
+					destroy: async () => {
+						events.push("destroy");
+						if (failCleanup) throw new Error("cleanup unavailable");
+						present.delete(id);
+					},
+				};
+				return session;
+			},
+		},
+	};
+	const options = {
+		plan,
+		batchId: "batch-0",
+		root: join(directory, "attempts"),
+		workflowAttempt: 1,
+		job: "bench",
+		open: async () => opened,
+		journal: {
+			read: async () => records,
+			append: async (record: AccountRecord) => {
+				records.push(record);
+				events.push(record.kind);
+			},
+		},
+		store: {
+			upload: async (_name: string, path: string) => {
+				readExperimentAttempt(path);
+				events.push("upload");
+			},
+		},
+	};
+	return { options, records, events, present, peak: () => peak };
+}
+
+test("planned batch crosses the real harness, raw collector, normalizer and publication evaluator", async () => {
+	const f = await fixture("complete");
+	const attempts = await executeExperimentBatch(f.options);
+	expect(attempts).toHaveLength(2);
+	expect(f.peak()).toBeLessThanOrEqual(2);
+	expect(f.present.size).toBe(0);
+	expect(f.records.filter((record) => record.kind === "released")).toHaveLength(2);
+	expect(batchIsComplete(plan, f.options.root, attempts)).toBe(true);
+	expect(
+		evaluateExperiment(
+			plan,
+			attempts.map((attempt) => readExperimentAttempt(join(f.options.root, attempt.id))),
+		).complete,
+	).toBe(true);
+});
+
+test("cleanup failure retains account ownership and blocks publication", async () => {
+	const f = await fixture("cleanup", true);
+	const attempts = await executeExperimentBatch(f.options);
+	expect(
+		attempts.every((attempt) => attempt.cleanup === "unresolved" && attempt.outcome === "failed"),
+	).toBe(true);
+	expect(f.records.filter((record) => record.kind === "released")).toHaveLength(0);
+	expect(batchIsComplete(plan, f.options.root, attempts)).toBe(false);
+});
+
+test("missing inventory fails each planned replicate without creating", async () => {
+	const f = await fixture("admission");
+	const opened = await f.options.open();
+	const attempts = await executeExperimentBatch({
+		...f.options,
+		open: async () => ({ ...opened, driver: { create: opened.driver.create } }),
+	});
+	expect(
+		attempts.every(
+			(attempt) => attempt.outcome === "failed" && attempt.cleanup === "not-allocated",
+		),
+	).toBe(true);
+	expect(f.events).not.toContain("create");
+});
+
+test("workflow reruns cannot silently measure a planned sample again", async () => {
+	const f = await fixture("rerun");
+	await executeExperimentBatch(f.options);
+	const creates = f.events.filter((event) => event === "create").length;
+	const rerun = await executeExperimentBatch({ ...f.options, workflowAttempt: 2 });
+	expect(f.events.filter((event) => event === "create")).toHaveLength(creates);
+	expect(
+		rerun.every((attempt) => attempt.outcome === "failed" && !attempt.measurementStarted),
+	).toBe(true);
+});
+
+test("a failed terminal upload does not discard its local immutable evidence or repeat allocation", async () => {
+	const f = await fixture("upload-failure");
+	await expect(
+		executeExperimentBatch({
+			...f.options,
+			store: {
+				upload: async () => {
+					throw new Error("upload unavailable");
+				},
+			},
+		}),
+	).rejects.toThrow("upload unavailable");
+	expect(f.present.size).toBe(0);
+	expect(f.records.filter((record) => record.kind === "released")).toHaveLength(2);
+	const retry = await executeExperimentBatch({ ...f.options, workflowAttempt: 2 });
+	expect(retry.every((attempt) => !attempt.measurementStarted)).toBe(true);
+});

--- a/apps/cli/src/lib/execute-experiment.ts
+++ b/apps/cli/src/lib/execute-experiment.ts
@@ -1,0 +1,303 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import type { SandboxDriver, SandboxRef } from "@sandbox-benchmarks/driver";
+import { describeDriverFailure } from "@sandbox-benchmarks/driver";
+import { diagnosticSecretsFromEnv } from "@sandbox-benchmarks/driver/env";
+import { executeSuite } from "@sandbox-benchmarks/harness";
+import {
+	evaluateExperiment,
+	evidenceDigest,
+	verifyExperimentPlan,
+} from "@sandbox-benchmarks/results";
+import type {
+	ExperimentAttempt,
+	ExperimentPlan,
+	ProviderId,
+	SuiteName,
+} from "@sandbox-benchmarks/schema";
+import {
+	experimentAttemptSchema,
+	PROVIDERS,
+	SUITES,
+	TARGET_SPEC,
+} from "@sandbox-benchmarks/schema";
+import type { AccountJournal, AccountRecord } from "./account-journal.ts";
+import { recoverAccount, withinSignal } from "./account-journal.ts";
+import { reconcileAccount } from "./account-reconciliation.ts";
+import type { OpenedDriver } from "./driver-run.ts";
+import { isDriverProviderId, openDriver } from "./driver-run.ts";
+import {
+	rawTreeDigest,
+	readAttemptReceipts,
+	readExperimentAttempt,
+	writeImmutableJson,
+} from "./experiment-artifacts.ts";
+import type { ExperimentStore } from "./experiment-store.ts";
+import { runReplicate } from "./run-replicate.ts";
+import { quotaDomain } from "./workflow-experiment.ts";
+
+export interface BatchExecution {
+	plan: ExperimentPlan;
+	batchId: string;
+	root: string;
+	workflowAttempt: number;
+	job: string;
+	journal: AccountJournal;
+	store: Pick<ExperimentStore, "upload">;
+	open?: (provider: ProviderId) => Promise<OpenedDriver>;
+}
+
+/** One account-owned wave. Ownership is durable before create, and lasts through observed removal. */
+export async function executeExperimentBatch(
+	options: BatchExecution,
+): Promise<ExperimentAttempt[]> {
+	const plan = verifyExperimentPlan(options.plan);
+	const batch = plan.batches.find((entry) => entry.id === options.batchId);
+	if (!batch) throw new Error("batch is absent from experiment plan");
+	const cells = batch.cells.map((id) => {
+		const cell = plan.cells.find((entry) => entry.id === id);
+		if (!cell || quotaDomain(cell.provider) !== batch.quotaDomain)
+			throw new Error("batch account mismatch");
+		return cell;
+	});
+	if (cells.length > batch.maxConcurrency) throw new Error("batch exceeds frozen concurrency");
+	const startupDeadline =
+		Date.now() + Math.min(...cells.map((cell) => cell.startupMinutes)) * 60_000;
+	const drivers = new Map<ProviderId, OpenedDriver>();
+	let admissionFailure: unknown;
+	let history: readonly AccountRecord[] = [];
+	const startupSignal = AbortSignal.timeout(Math.max(1, startupDeadline - Date.now()));
+	try {
+		for (const { id } of PROVIDERS.filter(
+			(provider) => quotaDomain(provider.id) === batch.quotaDomain,
+		)) {
+			if (!isDriverProviderId(id) && !options.open)
+				throw new Error(`${id}: managed driver admission is unavailable`);
+			const opened = await withinSignal(startupSignal, () =>
+				options.open
+					? options.open(id)
+					: isDriverProviderId(id)
+						? openDriver(id)
+						: Promise.reject(new Error("driver unavailable")),
+			);
+			if (!opened.driver.inventory || !opened.driver.destroyById || !opened.driver.probes)
+				throw new Error(`${id}: managed inventory and recovery are required`);
+			drivers.set(id, opened);
+		}
+		const recoveryMs = startupDeadline - Date.now();
+		if (recoveryMs <= 0) throw new Error("startup deadline exceeded before account recovery");
+		const signal = AbortSignal.timeout(recoveryMs);
+		await recoverAccount(
+			batch.quotaDomain,
+			new Map([...drivers].map(([id, opened]) => [id, opened.driver])),
+			options.journal,
+			signal,
+		);
+		history = await withinSignal(startupSignal, () => options.journal.read(batch.quotaDomain));
+		await reconcileAccount(
+			[...drivers].map(([id, opened]) => ({ id, driver: opened.driver })),
+			{ timeoutMs: Math.max(1, startupDeadline - Date.now()), signal },
+		);
+	} catch (error) {
+		admissionFailure = error;
+	}
+	const results = await Promise.allSettled(
+		cells.map(async (cell) => {
+			const id = `${cell.id}-a${options.workflowAttempt}-${randomUUID()}`;
+			const directory = join(options.root, id);
+			const raw = join(directory, "raw");
+			mkdirSync(raw, { recursive: true });
+			const intent: AccountRecord = {
+				version: "1",
+				kind: "intent",
+				account: cell.quotaDomain,
+				attempt: id,
+				cellId: cell.id,
+				planDigest: plan.digest,
+			};
+			let createStarted = false;
+			let allocated: SandboxRef | undefined;
+			let allocationRecorded = false;
+			let failure = admissionFailure;
+			let runDigest: string | undefined;
+			try {
+				if (
+					history.some((record) => record.planDigest === plan.digest && record.cellId === cell.id)
+				)
+					throw new Error(
+						"this planned cell already has an attempt; retries require an authorized lineage or a fresh experiment",
+					);
+				if (failure !== undefined) throw failure;
+				const opened = drivers.get(cell.provider);
+				if (!opened) throw new Error("driver was not admitted");
+				if (!(cell.suite in SUITES)) throw new Error("suite was not admitted");
+				const suite = SUITES[cell.suite as SuiteName];
+				if (
+					cell.gpu !== undefined ||
+					evidenceDigest(opened.artifact) !== cell.artifactIdentity ||
+					cell.environmentRevision !== plan.sha ||
+					evidenceDigest({ sha: plan.sha, suite, passes: cell.passes }) !== cell.workloadRevision ||
+					evidenceDigest(cell.target) !== evidenceDigest(TARGET_SPEC)
+				)
+					throw new Error("resolved execution inputs differ from frozen plan");
+				if (Date.now() >= startupDeadline)
+					throw new Error("startup deadline exceeded before allocation");
+				await withinSignal(startupSignal, () => options.journal.append(intent));
+				const driver: SandboxDriver = {
+					...opened.driver,
+					async create(request, createOptions) {
+						createOptions?.signal?.throwIfAborted();
+						if (Date.now() >= startupDeadline)
+							throw new Error("startup deadline exceeded before create");
+						createStarted = true;
+						const session = await opened.driver.create(request, createOptions);
+						allocated = session.sandboxRef;
+						try {
+							await withinSignal(startupSignal, () =>
+								options.journal.append({ ...intent, kind: "allocated", ref: session.sandboxRef }),
+							);
+							allocationRecorded = true;
+						} catch (error) {
+							// The harness has not received this session yet. Retain the original journal failure.
+							try {
+								const signal = AbortSignal.timeout(15_000);
+								await withinSignal(signal, () => session.destroy({ signal }));
+							} catch {
+								/* journal stays unresolved */
+							}
+							throw error;
+						}
+						return session;
+					},
+				};
+				const outcome = await runReplicate({
+					provider: cell.provider,
+					suite: cell.suite,
+					runId: plan.id,
+					sha: plan.sha,
+					rawRoot: raw,
+					outFile: join(directory, "run.json"),
+					replicateIndex: cell.replicate,
+					required: [cell.provider],
+					execute: async (runOptions) =>
+						executeSuite({
+							allocation: {
+								module: opened.module,
+								driver,
+								request: { spec: cell.target, artifact: opened.artifact },
+							},
+							runId: plan.id,
+							replicateIndex: cell.replicate,
+							suiteName: cell.suite as SuiteName,
+							resultsDir: runOptions.resultsDir,
+							// The remaining finish allowance covers teardown, cleanup observation and cost evidence.
+							managed: {
+								sourceRevision: plan.sha,
+								passes: cell.passes,
+								startupDeadline,
+								workloadMs: cell.workloadMinutes * 60_000,
+								collectionMs: Math.max(1, cell.finishMinutes * 60_000 - 120_000),
+							},
+						}),
+				});
+				if (outcome.run) runDigest = evidenceDigest(outcome.run);
+				if (outcome.failed) failure = new Error(outcome.detail ?? "suite failed");
+			} catch (error) {
+				failure = error;
+			}
+			let receipts: ReturnType<typeof readAttemptReceipts> = {};
+			try {
+				receipts = readAttemptReceipts(raw);
+			} catch (error) {
+				failure ??= error;
+			}
+			const cleanup =
+				receipts.cleanup?.completed && receipts.cleanup.confirmedAbsent
+					? "confirmed"
+					: createStarted
+						? "unresolved"
+						: "not-allocated";
+			try {
+				if (allocationRecorded && allocated && cleanup === "confirmed")
+					await options.journal.append({
+						...intent,
+						kind: "released",
+						outcome: "absent",
+						ref: allocated,
+					});
+				// No intent exists for admission failures. A pre-create deadline can leave a safely closable intent.
+				else if (!createStarted && admissionFailure === undefined && drivers.has(cell.provider)) {
+					const records = await options.journal.read(cell.quotaDomain);
+					if (records.some((entry) => entry.kind === "intent" && entry.attempt === id))
+						await options.journal.append({ ...intent, kind: "released", outcome: "not-allocated" });
+				}
+			} catch (error) {
+				failure ??= error;
+			}
+			const diagnostic =
+				failure === undefined
+					? undefined
+					: describeDriverFailure(failure, diagnosticSecretsFromEnv(process.env));
+			writeImmutableJson(join(raw, "attempt-diagnostic.json"), { diagnostic: diagnostic ?? null });
+			const measurementStarted =
+				!!receipts.execution?.steps.some((step) => step.phase === "benchmark") ||
+				!!receipts.execution?.detached.some((step) => step.phase === "benchmark");
+			const evidence = experimentAttemptSchema.assert({
+				schemaVersion: "1",
+				id,
+				cellId: cell.id,
+				planDigest: plan.digest,
+				sha: plan.sha,
+				workloadRevision: cell.workloadRevision,
+				environmentRevision: cell.environmentRevision,
+				artifactIdentity: cell.artifactIdentity,
+				passes: cell.passes,
+				workflowRun: plan.id,
+				workflowAttempt: options.workflowAttempt,
+				job: options.job,
+				sequence: 0,
+				outcome: failure === undefined && cleanup === "confirmed" ? "completed" : "failed",
+				measurementStarted,
+				retryable: false,
+				cleanup,
+				completion:
+					failure === undefined && measurementStarted
+						? "known-success"
+						: receipts.execution?.steps.some(
+									(step) => step.exitCode !== null && step.exitCode !== 0,
+								)
+							? "known-failure"
+							: "unknown",
+				...(runDigest ? { runDigest } : {}),
+				rawDigest: rawTreeDigest(raw),
+				...(diagnostic ? { diagnostic } : {}),
+			});
+			writeImmutableJson(join(directory, "attempt.json"), evidence);
+			await withinSignal(AbortSignal.timeout(5 * 60_000), () =>
+				options.store.upload(`experiment-attempt-${plan.id}-${id}`, directory),
+			);
+			return evidence;
+		}),
+	);
+	const failedUpload = results.find((result) => result.status === "rejected");
+	if (failedUpload?.status === "rejected") throw failedUpload.reason;
+	return results.flatMap((result) => (result.status === "fulfilled" ? [result.value] : []));
+}
+
+export function batchIsComplete(
+	plan: ExperimentPlan,
+	root: string,
+	attempts: readonly ExperimentAttempt[],
+): boolean {
+	const report = evaluateExperiment(
+		plan,
+		attempts.map((attempt) => readExperimentAttempt(join(root, attempt.id))),
+	);
+	return (
+		report.conflicts.length === 0 &&
+		report.cells
+			.filter((cell) => attempts.some((attempt) => attempt.cellId === cell.id))
+			.every((cell) => cell.status === "complete")
+	);
+}

--- a/apps/cli/src/lib/execute-experiment.ts
+++ b/apps/cli/src/lib/execute-experiment.ts
@@ -19,6 +19,7 @@ import type {
 import {
 	experimentAttemptSchema,
 	PROVIDERS,
+	quotaDomain,
 	SUITES,
 	TARGET_SPEC,
 } from "@sandbox-benchmarks/schema";
@@ -35,7 +36,6 @@ import {
 } from "./experiment-artifacts.ts";
 import type { ExperimentStore } from "./experiment-store.ts";
 import { runReplicate } from "./run-replicate.ts";
-import { quotaDomain } from "./workflow-experiment.ts";
 
 export interface BatchExecution {
 	plan: ExperimentPlan;

--- a/apps/cli/src/lib/experiment-artifacts.test.ts
+++ b/apps/cli/src/lib/experiment-artifacts.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	rawTreeDigest,
+	readExperimentAttempts,
+	writeImmutableJson,
+} from "./experiment-artifacts.ts";
+
+const directories: string[] = [];
+function temporary() {
+	const directory = mkdtempSync(join(tmpdir(), "experiment-evidence-"));
+	directories.push(directory);
+	return directory;
+}
+afterEach(() => {
+	for (const directory of directories.splice(0))
+		rmSync(directory, { recursive: true, force: true });
+});
+
+test("published evidence is immutable and failed overwrite preserves the original", () => {
+	const path = join(temporary(), "attempt.json");
+	writeImmutableJson(path, { outcome: "failed" });
+	expect(() => writeImmutableJson(path, { outcome: "completed" })).toThrow();
+	expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({ outcome: "failed" });
+});
+
+test("raw digest binds both paths and bytes, independently of creation order", () => {
+	const a = temporary();
+	const b = temporary();
+	writeFileSync(join(a, "one.xml"), "one");
+	writeFileSync(join(a, "two.xml"), "two");
+	writeFileSync(join(b, "two.xml"), "two");
+	writeFileSync(join(b, "one.xml"), "one");
+	expect(rawTreeDigest(a)).toBe(rawTreeDigest(b));
+	writeFileSync(join(b, "one.xml"), "changed");
+	expect(rawTreeDigest(a)).not.toBe(rawTreeDigest(b));
+	rmSync(join(b, "one.xml"));
+	writeFileSync(join(b, "renamed.xml"), "one");
+	expect(rawTreeDigest(a)).not.toBe(rawTreeDigest(b));
+});
+
+test("empty raw trees and symlinked evidence fail closed", () => {
+	const root = temporary();
+	expect(() => rawTreeDigest(root)).toThrow("empty");
+	symlinkSync(temporary(), join(root, "outside"));
+	expect(() => rawTreeDigest(root)).toThrow("symbolic");
+	expect(() => readExperimentAttempts(join(root, "outside"))).toThrow("symbolic");
+});
+
+test("interrupted launch intent is not a terminal attempt", () => {
+	const root = temporary();
+	mkdirSync(join(root, "attempt-one"));
+	writeImmutableJson(join(root, "attempt-one", "intent.json"), { started: true });
+	expect(() => readExperimentAttempts(root)).toThrow("unterminated allocation intent");
+});

--- a/apps/cli/src/lib/experiment-artifacts.ts
+++ b/apps/cli/src/lib/experiment-artifacts.ts
@@ -1,0 +1,145 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+	closeSync,
+	fsyncSync,
+	linkSync,
+	lstatSync,
+	openSync,
+	readdirSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import type { AttemptWithRun } from "@sandbox-benchmarks/results";
+import { evidenceDigest, verifyExperimentPlan } from "@sandbox-benchmarks/results";
+import {
+	cleanupReceiptSchema,
+	executionReceiptSchema,
+	experimentAttemptSchema,
+	parseRun,
+} from "@sandbox-benchmarks/schema";
+
+/** Stable path-and-content binding; links cannot smuggle evidence from outside the raw tree. */
+export function rawTreeDigest(directory: string): string {
+	const files: Array<{ path: string; digest: string }> = [];
+	const visit = (relative: string): void => {
+		const path = join(directory, relative);
+		const stat = lstatSync(path);
+		if (stat.isSymbolicLink()) throw new Error("raw evidence must not contain symbolic links");
+		if (stat.isDirectory()) {
+			for (const entry of readdirSync(path).sort())
+				visit(relative ? `${relative}/${entry}` : entry);
+		} else if (stat.isFile()) {
+			files.push({
+				path: relative,
+				digest: createHash("sha256").update(readFileSync(path)).digest("hex"),
+			});
+		} else throw new Error("raw evidence must contain only regular files and directories");
+	};
+	visit("");
+	if (files.length === 0) throw new Error("raw evidence is empty");
+	return evidenceDigest(files);
+}
+
+export function readExperimentPlan(path: string) {
+	if (!lstatSync(path).isFile() || lstatSync(path).isSymbolicLink())
+		throw new Error("plan must be a regular file");
+	return verifyExperimentPlan(JSON.parse(readFileSync(path, "utf8")));
+}
+
+export function readExperimentAttempt(directory: string): AttemptWithRun {
+	if (lstatSync(directory).isSymbolicLink())
+		throw new Error("attempt directory must not be a symbolic link");
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		if (entry.isSymbolicLink())
+			throw new Error("attempt artifacts must not contain symbolic links");
+	}
+	const evidence = experimentAttemptSchema.assert(
+		JSON.parse(readFileSync(join(directory, "attempt.json"), "utf8")),
+	);
+	const run =
+		evidence.runDigest === undefined
+			? undefined
+			: parseRun(JSON.parse(readFileSync(join(directory, "run.json"), "utf8")));
+	if (run && evidenceDigest(run) !== evidence.runDigest)
+		throw new Error(`shard digest mismatch: ${evidence.id}`);
+	if (
+		evidence.rawDigest !== undefined &&
+		rawTreeDigest(join(directory, "raw")) !== evidence.rawDigest
+	) {
+		throw new Error(`raw digest mismatch: ${evidence.id}`);
+	}
+	return {
+		evidence,
+		...(run ? { run } : {}),
+		...(evidence.rawDigest ? readAttemptReceipts(join(directory, "raw")) : {}),
+	};
+}
+
+export function readAttemptReceipts(
+	directory: string,
+): Pick<AttemptWithRun, "execution" | "cleanup"> {
+	const executionFiles: string[] = [];
+	const cleanupFiles: string[] = [];
+	const scan = (path: string): void => {
+		for (const entry of readdirSync(path, { withFileTypes: true })) {
+			const child = join(path, entry.name);
+			if (entry.isSymbolicLink()) throw new Error("receipt must not be a symbolic link");
+			if (entry.isDirectory()) scan(child);
+			else if (/^execution-.*\.json$/.test(entry.name)) executionFiles.push(child);
+			else if (/^cleanup-.*\.json$/.test(entry.name)) cleanupFiles.push(child);
+		}
+	};
+	scan(directory);
+	if (executionFiles.length > 1 || cleanupFiles.length > 1)
+		throw new Error("conflicting attempt receipts");
+	const execution = executionFiles[0]
+		? executionReceiptSchema.assert(JSON.parse(readFileSync(executionFiles[0], "utf8")))
+		: undefined;
+	const cleanup = cleanupFiles[0]
+		? cleanupReceiptSchema.assert(JSON.parse(readFileSync(cleanupFiles[0], "utf8")))
+		: undefined;
+	return { ...(execution ? { execution } : {}), ...(cleanup ? { cleanup } : {}) };
+}
+
+/** Refuse overwrites even if a caller accidentally reuses an attempt identity. */
+export function writeImmutableJson(path: string, value: unknown): void {
+	const temporary = `${path}.${randomUUID()}.tmp`;
+	const descriptor = openSync(temporary, "wx", 0o600);
+	try {
+		writeFileSync(descriptor, `${JSON.stringify(value, null, 2)}\n`);
+		fsyncSync(descriptor);
+		// link is atomic and refuses an existing destination; rename would overwrite it.
+		linkSync(temporary, path);
+	} finally {
+		closeSync(descriptor);
+		unlinkSync(temporary);
+	}
+}
+
+/** Discover only terminal attempt directories; launch intents cannot masquerade as receipts. */
+export function readExperimentAttempts(root: string): AttemptWithRun[] {
+	const attempts: AttemptWithRun[] = [];
+	const visit = (directory: string): void => {
+		if (lstatSync(directory).isSymbolicLink())
+			throw new Error("attempt directory must not be a symbolic link");
+		const entries = readdirSync(directory, { withFileTypes: true });
+		if (entries.some((entry) => entry.name === "attempt.json" && entry.isFile())) {
+			attempts.push(readExperimentAttempt(directory));
+			return;
+		}
+		if (entries.some((entry) => entry.name === "intent.json")) {
+			throw new Error(
+				"unterminated allocation intent; experiment completeness and cleanup remain unresolved",
+			);
+		}
+		for (const entry of entries.toSorted((a, b) => a.name.localeCompare(b.name))) {
+			if (entry.isSymbolicLink())
+				throw new Error("attempt artifacts must not contain symbolic links");
+			if (entry.isDirectory()) visit(join(directory, entry.name));
+		}
+	};
+	visit(root);
+	return attempts;
+}

--- a/apps/cli/src/lib/experiment-plan.test.ts
+++ b/apps/cli/src/lib/experiment-plan.test.ts
@@ -1,0 +1,434 @@
+import { expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { AttemptWithRun } from "@sandbox-benchmarks/results";
+import {
+	aggregateExperiment,
+	evaluateExperiment,
+	evidenceDigest,
+	verifyExperimentPlan,
+} from "@sandbox-benchmarks/results";
+import type { ExperimentCell, Run } from "@sandbox-benchmarks/schema";
+import { aggregate, parseRun } from "@sandbox-benchmarks/schema";
+import { rawTreeDigest, writeImmutableJson } from "./experiment-artifacts.ts";
+import { planExperiment } from "./experiment-plan.ts";
+
+const sha = "a".repeat(40);
+const digest = `sha256:${"b".repeat(64)}`;
+function cell(replicate = 0): ExperimentCell {
+	return {
+		id: `e2b-memory-r${replicate}`,
+		provider: "e2b",
+		quotaDomain: "e2b-benchmark",
+		suite: "memory",
+		replicate,
+		workloadRevision: "memory-fixed-v1",
+		artifactIdentity: evidenceDigest({ kind: "baked", ref: "template-pinned" }),
+		environmentRevision: "env-1",
+		target: { vcpus: 4, memoryGb: 8 },
+		metrics: ["stream_type_copy", "stream_type_scale"],
+		exclusions: [],
+		passes: 2,
+		startupMinutes: 20,
+		workloadMinutes: 40,
+		finishMinutes: 10,
+	};
+}
+function plan(count = 1) {
+	return planExperiment({
+		id: "experiment-1",
+		sha,
+		createdOn: "2026-09-10",
+		cells: Array.from({ length: count }, (_, i) => cell(i)),
+	});
+}
+function successful(): AttemptWithRun {
+	const run: Run = {
+		schemaVersion: "6",
+		runId: "experiment-1",
+		sha,
+		generatedAt: "2026-09-10T00:00:00Z",
+		replicateIndex: 0,
+		targetSpec: { vcpus: 4, memoryGb: 8 },
+		providers: [
+			{
+				providerId: "e2b",
+				costEvidence: [],
+				artifactEvidence: [
+					{
+						cell: { runId: "experiment-1", providerId: "e2b", suite: "memory", replicateIndex: 0 },
+						sandboxId: "sandbox-1",
+						provenance: {
+							source: "driver-reported",
+							requested: { kind: "baked", ref: "template-pinned" },
+							reported: { kind: "baked", ref: "template-pinned" },
+						},
+					},
+				],
+				validationStatus: "validated",
+				observedSpecs: {},
+				metrics: cell().metrics.map((metricId) => ({
+					metricId,
+					samples: [1, 2],
+					aggregates: aggregate([1, 2]),
+				})),
+				suitesCovered: ["memory"],
+				gaps: [],
+				uncatalogued: [],
+			},
+		],
+	};
+	return {
+		run,
+		execution: {
+			schemaVersion: "1",
+			executionId: "execution-1",
+			runId: "experiment-1",
+			replicateIndex: 0,
+			provider: "e2b",
+			suite: "memory",
+			sandboxId: "sandbox-1",
+			primaryFailure: null,
+			detached: [],
+			steps: [
+				{ phase: "benchmark", label: "memory", ms: 1, exitCode: 0 },
+				{ phase: "collect", label: "collect", ms: 1, exitCode: 0 },
+			],
+		},
+		cleanup: {
+			schemaVersion: "1",
+			executionId: "execution-1",
+			completed: true,
+			confirmedAbsent: true,
+			attemptedAt: "2026-09-10T00:00:00Z",
+		},
+		evidence: {
+			schemaVersion: "1",
+			id: "attempt-1",
+			cellId: cell().id,
+			planDigest: plan().digest,
+			sha,
+			workloadRevision: cell().workloadRevision,
+			environmentRevision: cell().environmentRevision,
+			artifactIdentity: cell().artifactIdentity,
+			passes: cell().passes,
+			workflowRun: "123",
+			workflowAttempt: 1,
+			job: "memory",
+			sequence: 0,
+			outcome: "completed",
+			measurementStarted: true,
+			retryable: false,
+			cleanup: "confirmed",
+			completion: "known-success",
+			runDigest: evidenceDigest(run),
+			rawDigest: digest,
+		},
+	};
+}
+
+test("normalizer placeholder rows are allowed but foreign provider observations are not", () => {
+	const attempt = successful();
+	if (!attempt.run) throw new Error("fixture has no run");
+	attempt.run.providers.push({
+		providerId: "tama",
+		validationStatus: "pending",
+		observedSpecs: {},
+		metrics: [],
+		suitesCovered: [],
+		gaps: [],
+		uncatalogued: [],
+		costEvidence: [],
+		artifactEvidence: [],
+	});
+	attempt.evidence.runDigest = evidenceDigest(attempt.run);
+	expect(evaluateExperiment(plan(), [attempt]).complete).toBe(true);
+	const foreign = attempt.run.providers.at(-1);
+	if (!foreign) throw new Error("fixture has no foreign row");
+	foreign.suitesCovered.push("memory");
+	attempt.evidence.runDigest = evidenceDigest(attempt.run);
+	expect(evaluateExperiment(plan(), [attempt]).complete).toBe(false);
+});
+
+test("default capacity preserves twelve replicates in bounded individual batches", () => {
+	const result = plan(12);
+	expect(result.batches).toHaveLength(12);
+	expect(result.batches.flatMap((batch) => batch.cells)).toEqual(
+		result.cells.map((entry) => entry.id),
+	);
+	expect(result.accounts[0]?.sandboxes).toBe(1);
+});
+test("resource budgets constrain an explicit sandbox cap", () => {
+	const result = planExperiment(
+		{ id: "experiment-1", sha, createdOn: "2026-09-10", cells: [cell(0), cell(1), cell(2)] },
+		{ "e2b-benchmark": { sandboxes: 12, vcpus: 8, memoryGb: 16 } },
+	);
+	expect(result.batches.map((batch) => batch.cells.length)).toEqual([2, 1]);
+});
+test("rejects infeasible work, duplicate logical replicates, and mutated plans", () => {
+	expect(() =>
+		planExperiment({
+			id: "x",
+			sha,
+			createdOn: "2026-09-10",
+			cells: [{ ...cell(), workloadMinutes: 180 }],
+		}),
+	).toThrow("cannot fit");
+	expect(() =>
+		planExperiment({ id: "x", sha, createdOn: "2026-09-10", cells: [cell(), cell()] }),
+	).toThrow("duplicate");
+	const changed = plan();
+	changed.cells[0]?.metrics.pop();
+	expect(() => verifyExperimentPlan(changed)).toThrow("digest mismatch");
+});
+test("all-skipped, missing, partial, unknown completion, and unresolved cleanup cannot publish", () => {
+	expect(evaluateExperiment(plan(), []).complete).toBe(false);
+	for (const change of [
+		{ outcome: "failed" as const },
+		{ completion: "unknown" as const },
+		{ cleanup: "unresolved" as const },
+	]) {
+		const attempt = successful();
+		Object.assign(attempt.evidence, change);
+		expect(evaluateExperiment(plan(), [attempt]).complete).toBe(false);
+	}
+	const partial = successful();
+	partial.run?.providers[0]?.metrics.pop();
+	partial.evidence.runDigest = evidenceDigest(partial.run);
+	expect(evaluateExperiment(plan(), [partial]).cells[0]?.missingMetrics).toEqual([
+		"stream_type_scale",
+	]);
+	expect(evaluateExperiment(plan(), [successful()]).complete).toBe(true);
+});
+test("provenance, duplicate attempts, and measured reruns cannot satisfy coverage", () => {
+	const valid = successful();
+	expect(evaluateExperiment(plan(), [valid, valid]).complete).toBe(false);
+	const wrong = successful();
+	wrong.evidence.sha = "c".repeat(40);
+	expect(evaluateExperiment(plan(), [wrong]).complete).toBe(false);
+	const retry = successful();
+	retry.evidence.id = "attempt-2";
+	retry.evidence.sequence = 1;
+	retry.evidence.previousAttempt = valid.evidence.id;
+	expect(evaluateExperiment(plan(), [valid, retry])).toEqual(
+		evaluateExperiment(plan(), [retry, valid]),
+	);
+	expect(evaluateExperiment(plan(), [valid, retry]).complete).toBe(false);
+});
+test("only a reconciled premeasurement refusal authorizes the next attempt", () => {
+	const reviewed = planExperiment({
+		id: "experiment-1",
+		sha,
+		createdOn: "2026-09-10",
+		cells: [cell()],
+		maxPremeasurementRetries: 1,
+	});
+	const refusal = successful();
+	refusal.run = undefined;
+	const { runDigest: _runDigest, ...refusalEvidence } = refusal.evidence;
+	refusal.evidence = refusalEvidence;
+	Object.assign(refusal.evidence, {
+		outcome: "failed",
+		measurementStarted: false,
+		retryable: true,
+		cleanup: "not-allocated",
+		completion: "unknown",
+	});
+	const retry = successful();
+	Object.assign(retry.evidence, { id: "attempt-2", sequence: 1, previousAttempt: "attempt-1" });
+	expect(evaluateExperiment(plan(), [retry, refusal]).complete).toBe(false);
+	refusal.evidence.planDigest = reviewed.digest;
+	retry.evidence.planDigest = reviewed.digest;
+	expect(evaluateExperiment(reviewed, [retry, refusal]).complete).toBe(true);
+});
+
+test("publication requires receipts and restricts measurements to planned eligibility", () => {
+	for (const mutate of [
+		(a: AttemptWithRun) => {
+			a.execution = undefined;
+		},
+		(a: AttemptWithRun) => {
+			a.cleanup = undefined;
+		},
+		(a: AttemptWithRun) => {
+			if (a.cleanup) a.cleanup.confirmedAbsent = false;
+		},
+		(a: AttemptWithRun) => {
+			if (a.execution?.steps[0]) a.execution.steps[0].exitCode = 7;
+		},
+		(a: AttemptWithRun) => {
+			if (a.execution) a.execution.sandboxId = "another-allocation";
+		},
+	]) {
+		const attempt = successful();
+		mutate(attempt);
+		expect(evaluateExperiment(plan(), [attempt]).complete).toBe(false);
+	}
+	const attempt = successful();
+	const provider = attempt.run?.providers[0];
+	if (!provider?.metrics[0]) throw new Error("fixture missing metric");
+	provider.metrics.push({ ...provider.metrics[0], metricId: "stream_type_triad" });
+	attempt.evidence.runDigest = evidenceDigest(attempt.run);
+	expect(
+		aggregateExperiment(plan(), [attempt]).providers[0]?.metrics.some(
+			(m) => m.metricId === "stream_type_triad",
+		),
+	).toBe(false);
+});
+
+test("aggregation produces readable v7 linkage only from a complete experiment", () => {
+	const attempt = successful();
+	if (attempt.run) parseRun(attempt.run);
+	const result = aggregateExperiment(plan(), [attempt]);
+	expect(parseRun(result).experiment?.planDigest).toBe(plan().digest);
+	expect(() => aggregateExperiment(plan(2), [attempt])).toThrow("incomplete");
+});
+
+test("wrong resources, artifact identity, workload revision and pass policy block coverage", () => {
+	for (const field of ["workloadRevision", "environmentRevision", "artifactIdentity"] as const) {
+		const attempt = successful();
+		attempt.evidence[field] = "wrong";
+		expect(evaluateExperiment(plan(), [attempt]).complete).toBe(false);
+	}
+	const attempt = successful();
+	if (attempt.run) attempt.run.targetSpec = { vcpus: 8, memoryGb: 16 };
+	attempt.evidence.runDigest = evidenceDigest(attempt.run);
+	expect(evaluateExperiment(plan(), [attempt]).complete).toBe(false);
+});
+
+test("real aggregate and promote commands require intact original evidence", () => {
+	const root = mkdtempSync(join(tmpdir(), "experiment-promotion-"));
+	try {
+		const attempt = successful();
+		const directory = join(root, "attempts", attempt.evidence.id);
+		mkdirSync(join(directory, "raw"), { recursive: true });
+		writeFileSync(join(directory, "raw", "result.xml"), "<result>fixture</result>");
+		writeImmutableJson(join(directory, "raw", "execution-execution-1.json"), attempt.execution);
+		writeImmutableJson(join(directory, "raw", "cleanup-execution-1.json"), attempt.cleanup);
+		attempt.evidence.rawDigest = rawTreeDigest(join(directory, "raw"));
+		writeImmutableJson(join(directory, "attempt.json"), attempt.evidence);
+		writeImmutableJson(join(directory, "run.json"), attempt.run);
+		const planPath = join(root, "plan.json");
+		writeImmutableJson(planPath, plan());
+		const invoke = (bin: string, args: string[]) =>
+			Bun.spawnSync([process.execPath, resolve(import.meta.dir, "../bin", `${bin}.ts`), ...args], {
+				stdout: "pipe",
+				stderr: "pipe",
+				env: { ...process.env, GITHUB_ACTIONS: "false" },
+			});
+		const candidate = join(root, "candidate");
+		const aggregateResult = invoke("aggregate-experiment", [
+			planPath,
+			join(root, "attempts"),
+			candidate,
+		]);
+		expect(aggregateResult.exitCode).toBe(0);
+		const runFile = join(candidate, "runs", "experiment-1.json");
+		const dataset = join(root, "published");
+		expect(invoke("promote", [runFile, dataset]).exitCode).toBe(1);
+		expect(invoke("promote", [runFile, dataset, planPath, join(root, "attempts")]).exitCode).toBe(
+			0,
+		);
+		expect(
+			JSON.parse(readFileSync(join(dataset, "runs", "experiment-1.json"), "utf8")).schemaVersion,
+		).toBe("7");
+		writeFileSync(join(directory, "raw", "result.xml"), "tampered");
+		expect(
+			invoke("promote", [runFile, join(root, "tampered"), planPath, join(root, "attempts")])
+				.exitCode,
+		).toBe(1);
+		// Even recomputing valid byte digests cannot replace missing command evidence.
+		writeFileSync(join(directory, "raw", "result.xml"), "<result>fixture</result>");
+		rmSync(join(directory, "raw", "execution-execution-1.json"));
+		attempt.evidence.rawDigest = rawTreeDigest(join(directory, "raw"));
+		writeFileSync(join(directory, "attempt.json"), JSON.stringify(attempt.evidence));
+		const missingReceipt = invoke("aggregate-experiment", [
+			planPath,
+			join(root, "attempts"),
+			join(root, "missing-receipt"),
+		]);
+		expect(missingReceipt.exitCode).not.toBe(0);
+		expect(missingReceipt.stderr.toString()).toContain("Experiment is incomplete");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("large experiments retain every batch in explicit collection rounds", () => {
+	const result = plan(257);
+	expect(result.rounds.map((round) => round.batches.length)).toEqual([256, 1]);
+	expect(result.rounds.flatMap((round) => round.batches)).toEqual(
+		result.batches.map((batch) => batch.id),
+	);
+});
+
+test("exclusions cannot vary between providers in one workload cohort", () => {
+	const first = cell();
+	const second = {
+		...cell(),
+		id: "novita-memory-r0",
+		provider: "novita" as const,
+		quotaDomain: "novita-benchmark",
+		exclusions: [
+			{
+				metricId: "stream_type_scale",
+				workloadRevision: first.workloadRevision,
+				reason: "fixture failure",
+				owner: "benchmark maintainers",
+				issue: "https://github.com/starslingdev/hpc-sandbox-benchmarks/issues/1",
+				expires: "2026-10-01",
+			},
+		],
+	};
+	expect(() =>
+		planExperiment({ id: "x", sha, createdOn: "2026-09-10", cells: [first, second] }),
+	).toThrow("inconsistent comparison cohort");
+});
+
+test("a fully quarantined suite is reported separately and consumes no batch capacity", () => {
+	const quarantined = {
+		...cell(),
+		id: "e2b-quarantine-r0",
+		suite: "quarantined-suite",
+		exclusions: cell().metrics.map((metricId) => ({
+			metricId,
+			workloadRevision: cell().workloadRevision,
+			reason: "fixture",
+			owner: "maintainers",
+			issue: "https://github.com/starslingdev/hpc-sandbox-benchmarks/issues/1",
+			expires: "2026-10-01",
+		})),
+	};
+	const planned = planExperiment({
+		id: "experiment-1",
+		sha,
+		createdOn: "2026-09-10",
+		cells: [cell(), quarantined],
+	});
+	expect(planned.batches.flatMap((batch) => batch.cells)).toEqual([cell().id]);
+	const attempt = successful();
+	attempt.evidence.planDigest = planned.digest;
+	const report = evaluateExperiment(planned, [attempt]);
+	expect(report.complete).toBe(true);
+	expect(report.cells[1]?.status).toBe("excluded");
+});
+
+test("unverified GPU capacity and mixed workload revisions fail admission", () => {
+	expect(() =>
+		planExperiment({
+			id: "x",
+			sha,
+			createdOn: "2026-09-10",
+			cells: [{ ...cell(), gpu: { model: "test-gpu", count: 1 } }],
+		}),
+	).toThrow("target exceeds");
+	expect(() =>
+		planExperiment({
+			id: "x",
+			sha,
+			createdOn: "2026-09-10",
+			cells: [cell(), { ...cell(1), workloadRevision: "changed" }],
+		}),
+	).toThrow("inconsistent comparison cohort");
+});

--- a/apps/cli/src/lib/experiment-plan.test.ts
+++ b/apps/cli/src/lib/experiment-plan.test.ts
@@ -271,7 +271,7 @@ test("publication requires receipts and restricts measurements to planned eligib
 	provider.metrics.push({ ...provider.metrics[0], metricId: "stream_type_triad" });
 	attempt.evidence.runDigest = evidenceDigest(attempt.run);
 	expect(
-		aggregateExperiment(plan(), [attempt]).providers[0]?.metrics.some(
+		aggregateExperiment(plan(), [attempt]).run?.providers[0]?.metrics.some(
 			(m) => m.metricId === "stream_type_triad",
 		),
 	).toBe(false);
@@ -281,8 +281,65 @@ test("aggregation produces readable v7 linkage only from a complete experiment",
 	const attempt = successful();
 	if (attempt.run) parseRun(attempt.run);
 	const result = aggregateExperiment(plan(), [attempt]);
-	expect(parseRun(result).experiment?.planDigest).toBe(plan().digest);
-	expect(() => aggregateExperiment(plan(2), [attempt])).toThrow("incomplete");
+	expect(result.coverage.complete).toBe(true);
+	if (!result.run) throw new Error("complete experiment produced no Run");
+	expect(parseRun(result.run).experiment?.planDigest).toBe(plan().digest);
+	const incomplete = aggregateExperiment(plan(2), [attempt]);
+	expect(incomplete.coverage.complete).toBe(false);
+	expect(incomplete.run).toBeUndefined();
+});
+
+test("a retried step, a tolerated probe, and a re-collected detached step still publish", () => {
+	const attempt = successful();
+	if (!attempt.execution) throw new Error("fixture has no execution receipt");
+	// The harness logs one entry per attempt: setup steps declare retries, the observed-specs probe
+	// runs allowFailure, and the collect loop re-runs its (detached) step through read-back blips.
+	attempt.execution.steps = [
+		{ phase: "setup", label: "install mise", ms: 1, exitCode: 1 },
+		{ phase: "setup", label: "install mise", ms: 1, exitCode: null },
+		{ phase: "setup", label: "install mise", ms: 1, exitCode: 0 },
+		{ phase: "setup", label: "capture observed specs", ms: 1, exitCode: 1, allowFailure: true },
+		{ phase: "benchmark", label: "memory", ms: 1, exitCode: 0 },
+		{ phase: "collect", label: "collect", ms: 1, exitCode: 0 },
+		{ phase: "collect", label: "collect", ms: 1, exitCode: 0 },
+	];
+	attempt.execution.detached = [
+		{
+			identity: "bench-1",
+			label: "collect",
+			phase: "collect",
+			state: "collection-failed",
+			exitCode: 0,
+		},
+		{ identity: "bench-2", label: "collect", phase: "collect", state: "completed", exitCode: 0 },
+	];
+	expect(evaluateExperiment(plan(), [attempt]).complete).toBe(true);
+
+	// The final attempt still decides: a step whose last try failed cannot publish.
+	const lastTryFailed = successful();
+	if (!lastTryFailed.execution) throw new Error("fixture has no execution receipt");
+	lastTryFailed.execution.steps = [
+		...attempt.execution.steps,
+		{ phase: "setup", label: "install mise", ms: 1, exitCode: 1 },
+	];
+	lastTryFailed.execution.detached = attempt.execution.detached;
+	expect(evaluateExperiment(plan(), [lastTryFailed]).complete).toBe(false);
+
+	// A detached step whose last attempt never completed cannot publish either.
+	const lastCollectLost = successful();
+	if (!lastCollectLost.execution) throw new Error("fixture has no execution receipt");
+	lastCollectLost.execution.steps = attempt.execution.steps;
+	lastCollectLost.execution.detached = [...attempt.execution.detached].reverse();
+	expect(evaluateExperiment(plan(), [lastCollectLost]).complete).toBe(false);
+
+	// Tolerance covers a reported non-zero exit, never an unobserved completion.
+	const probeNeverExited = successful();
+	if (!probeNeverExited.execution) throw new Error("fixture has no execution receipt");
+	probeNeverExited.execution.steps = [
+		...(successful().execution?.steps ?? []),
+		{ phase: "setup", label: "capture observed specs", ms: 1, exitCode: null, allowFailure: true },
+	];
+	expect(evaluateExperiment(plan(), [probeNeverExited]).complete).toBe(false);
 });
 
 test("wrong resources, artifact identity, workload revision and pass policy block coverage", () => {

--- a/apps/cli/src/lib/experiment-plan.ts
+++ b/apps/cli/src/lib/experiment-plan.ts
@@ -1,0 +1,96 @@
+import { evidenceDigest, verifyExperimentPlan } from "@sandbox-benchmarks/results";
+import type { ExperimentCell, ExperimentPlan } from "@sandbox-benchmarks/schema";
+import { experimentCellSchema } from "@sandbox-benchmarks/schema";
+
+export interface AccountCapacity {
+	sandboxes: number;
+	vcpus?: number;
+	memoryGb?: number;
+	gpus?: number;
+}
+
+/** Pure admission planning. No credential reads, remote calls, or implicit wall-clock input. */
+export function planExperiment(
+	request: {
+		id: string;
+		sha: string;
+		createdOn: string;
+		cells: readonly ExperimentCell[];
+		maxPremeasurementRetries?: number;
+	},
+	policy: Readonly<Record<string, AccountCapacity>> = {},
+): ExperimentPlan {
+	const cells = request.cells.map((cell) => experimentCellSchema.assert(structuredClone(cell)));
+	const batches: ExperimentPlan["batches"] = [];
+	for (const cell of cells) {
+		if (cell.metrics.every((metric) => cell.exclusions.some((entry) => entry.metricId === metric)))
+			continue;
+		const capacity = policy[cell.quotaDomain] ?? { sandboxes: 1 };
+		if (
+			!Number.isSafeInteger(capacity.sandboxes) ||
+			capacity.sandboxes < 1 ||
+			(capacity.vcpus !== undefined && (!Number.isFinite(capacity.vcpus) || capacity.vcpus <= 0)) ||
+			(capacity.memoryGb !== undefined &&
+				(!Number.isFinite(capacity.memoryGb) || capacity.memoryGb <= 0))
+		) {
+			throw new Error(`invalid account capacity: ${cell.quotaDomain}`);
+		}
+		const cap = Math.min(
+			capacity.sandboxes,
+			Math.floor((capacity.vcpus ?? Infinity) / cell.target.vcpus),
+			Math.floor((capacity.memoryGb ?? Infinity) / cell.target.memoryGb),
+			cell.gpu ? Math.floor((capacity.gpus ?? 0) / cell.gpu.count) : Infinity,
+		);
+		if (cap < 1) throw new Error(`target exceeds account capacity: ${cell.id}`);
+		const budgetMinutes = cell.startupMinutes + cell.workloadMinutes + cell.finishMinutes + 15;
+		if (budgetMinutes > 180) throw new Error(`replicate cannot fit a 180-minute job: ${cell.id}`);
+		// A batch is one simultaneous wave of identical requests. Never hide serial waves in a job.
+		const previous = batches.at(-1);
+		const first = cells.find((entry) => entry.id === previous?.cells[0]);
+		if (
+			previous &&
+			first &&
+			previous.quotaDomain === cell.quotaDomain &&
+			previous.cells.length < cap &&
+			first.provider === cell.provider &&
+			first.suite === cell.suite &&
+			evidenceDigest({ ...first, id: "", replicate: 0 }) ===
+				evidenceDigest({ ...cell, id: "", replicate: 0 })
+		) {
+			previous.cells.push(cell.id);
+		} else {
+			batches.push({
+				id: `batch-${batches.length}`,
+				quotaDomain: cell.quotaDomain,
+				cells: [cell.id],
+				maxConcurrency: cap,
+				budgetMinutes,
+			});
+		}
+	}
+	const rounds: ExperimentPlan["rounds"] = [];
+	for (const quotaDomain of new Set(cells.map((cell) => cell.quotaDomain))) {
+		const domainBatches = batches.filter((batch) => batch.quotaDomain === quotaDomain);
+		for (let offset = 0; offset < domainBatches.length; offset += 256)
+			rounds.push({
+				id: `round-${rounds.length}`,
+				quotaDomain,
+				batches: domainBatches.slice(offset, offset + 256).map((batch) => batch.id),
+			});
+	}
+	const accounts = [...new Set(cells.map((cell) => cell.quotaDomain))].map((quotaDomain) => ({
+		quotaDomain,
+		...(policy[quotaDomain] ?? { sandboxes: 1 }),
+	}));
+	const body = {
+		schemaVersion: "1" as const,
+		...request,
+		cells,
+		batches,
+		accounts,
+		rounds,
+		retryPolicy: "premeasurement-only" as const,
+		maxPremeasurementRetries: request.maxPremeasurementRetries ?? 0,
+	};
+	return verifyExperimentPlan({ ...body, digest: evidenceDigest(body) });
+}

--- a/apps/cli/src/lib/experiment-store.test.ts
+++ b/apps/cli/src/lib/experiment-store.test.ts
@@ -1,5 +1,12 @@
 import { expect, test } from "bun:test";
-import { scanArtifactPages } from "./experiment-store.ts";
+import { githubExperimentStore, scanArtifactPages } from "./experiment-store.ts";
+
+test("an upload outside the artifact runtime names the step that provides it", async () => {
+	const store = githubExperimentStore({ GITHUB_REPOSITORY: "owner/repo", GH_TOKEN: "token" });
+	await expect(store.upload("experiment-plan-1", ".")).rejects.toThrow(
+		"run .github/actions/artifact-runtime before this step",
+	);
+});
 
 const artifact = (id: number) => ({
 	id,

--- a/apps/cli/src/lib/experiment-store.test.ts
+++ b/apps/cli/src/lib/experiment-store.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { scanArtifactPages } from "./experiment-store.ts";
+
+const artifact = (id: number) => ({
+	id,
+	name: `artifact-${id}`,
+	expired: false,
+	workflow_run: { id: 1 },
+});
+test("artifact scans require complete stable pagination", async () => {
+	expect(
+		(
+			await scanArtifactPages(async (page) => ({ total_count: 2, artifacts: [artifact(page)] }))
+		).map((entry) => entry.id),
+	).toEqual([1, 2]);
+	await expect(
+		scanArtifactPages(async (page) => ({ total_count: page + 1, artifacts: [artifact(page)] })),
+	).rejects.toThrow("changed");
+	await expect(
+		scanArtifactPages(async () => ({ total_count: 2, artifacts: [artifact(1)] })),
+	).rejects.toThrow("repeated");
+	await expect(scanArtifactPages(async () => ({ total_count: 1, artifacts: [] }))).rejects.toThrow(
+		"incomplete",
+	);
+});

--- a/apps/cli/src/lib/experiment-store.ts
+++ b/apps/cli/src/lib/experiment-store.ts
@@ -1,0 +1,106 @@
+import { lstatSync, mkdirSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { DefaultArtifactClient } from "@actions/artifact";
+import { type } from "arktype";
+
+const artifactPage = type({
+	total_count: "number.integer >= 0",
+	artifacts: type({
+		id: "number.integer > 0",
+		name: "string",
+		expired: "boolean",
+		workflow_run: { id: "number.integer > 0" },
+	}).array(),
+});
+export type StoredArtifact = (typeof artifactPage.infer.artifacts)[number];
+export interface ExperimentStore {
+	list(prefix: string): Promise<readonly StoredArtifact[]>;
+	upload(name: string, directory: string): Promise<void>;
+	download(artifact: StoredArtifact, directory: string): Promise<void>;
+}
+
+/** The account queue is the exclusive writer. Concurrent repository changes invalidate a scan. */
+export async function scanArtifactPages(
+	read: (page: number) => Promise<unknown>,
+): Promise<StoredArtifact[]> {
+	const artifacts: StoredArtifact[] = [];
+	const ids = new Set<number>();
+	let total: number | undefined;
+	for (let page = 1; page <= 100; page++) {
+		const response = artifactPage.assert(await read(page));
+		total ??= response.total_count;
+		if (response.total_count !== total)
+			throw new Error("artifact inventory changed during scan; retry admission");
+		for (const artifact of response.artifacts) {
+			if (ids.has(artifact.id))
+				throw new Error("artifact inventory pagination repeated an identity");
+			ids.add(artifact.id);
+			artifacts.push(artifact);
+		}
+		if (artifacts.length === total) return artifacts;
+		if (artifacts.length > total || response.artifacts.length === 0)
+			throw new Error("artifact inventory is incomplete");
+	}
+	throw new Error("artifact history exceeds supported scan; archival reconciliation is required");
+}
+
+export function githubExperimentStore(env: NodeJS.ProcessEnv = process.env): ExperimentStore {
+	const repository = env.GITHUB_REPOSITORY;
+	const token = env.GH_TOKEN || env.GITHUB_TOKEN;
+	if (!repository || !/^[\w.-]+\/[\w.-]+$/.test(repository) || !token)
+		throw new Error("GitHub artifact access requires repository and token");
+	const [repositoryOwner, repositoryName] = repository.split("/");
+	if (!repositoryOwner || !repositoryName) throw new Error("invalid repository identity");
+	const client = new DefaultArtifactClient();
+	return {
+		async list(prefix) {
+			const entries = await scanArtifactPages(async (page) => {
+				const response = await fetch(
+					`https://api.github.com/repos/${repository}/actions/artifacts?per_page=100&page=${page}`,
+					{
+						headers: {
+							Authorization: `Bearer ${token}`,
+							Accept: "application/vnd.github+json",
+							"X-GitHub-Api-Version": "2022-11-28",
+						},
+						signal: AbortSignal.timeout(20_000),
+					},
+				);
+				if (!response.ok) throw new Error(`artifact inventory HTTP ${response.status}`);
+				return response.json();
+			});
+			const selected = entries.filter((entry) => entry.name.startsWith(prefix));
+			if (selected.some((entry) => entry.expired))
+				throw new Error(
+					"required artifact history expired; vendor-confirmed recovery or retained archive is required",
+				);
+			if (new Set(selected.map((entry) => entry.name)).size !== selected.length)
+				throw new Error("conflicting immutable artifact names");
+			return selected.toSorted((a, b) => a.name.localeCompare(b.name));
+		},
+		async upload(name, directory) {
+			const files: string[] = [];
+			const visit = (path: string) => {
+				for (const entry of readdirSync(path, { withFileTypes: true })) {
+					const child = join(path, entry.name);
+					if (entry.isSymbolicLink()) throw new Error("artifact contains a symbolic link");
+					if (entry.isDirectory()) visit(child);
+					else if (entry.isFile()) files.push(child);
+					else throw new Error("artifact contains a non-regular file");
+				}
+			};
+			if (lstatSync(directory).isSymbolicLink())
+				throw new Error("artifact root is a symbolic link");
+			visit(directory);
+			const result = await client.uploadArtifact(name, files, resolve(directory));
+			if (!result.id) throw new Error("artifact upload was not acknowledged");
+		},
+		async download(artifact, directory) {
+			mkdirSync(directory, { recursive: true });
+			await client.downloadArtifact(artifact.id, {
+				path: resolve(directory),
+				findBy: { token, repositoryOwner, repositoryName, workflowRunId: artifact.workflow_run.id },
+			});
+		},
+	};
+}

--- a/apps/cli/src/lib/experiment-store.ts
+++ b/apps/cli/src/lib/experiment-store.ts
@@ -79,6 +79,13 @@ export function githubExperimentStore(env: NodeJS.ProcessEnv = process.env): Exp
 			return selected.toSorted((a, b) => a.name.localeCompare(b.name));
 		},
 		async upload(name, directory) {
+			// @actions/artifact uploads through the run-scoped artifact runtime, which GitHub injects
+			// only into action steps; a `run:` step gets it from .github/actions/artifact-runtime. Fail
+			// before walking the tree so the message names the fix, not the library's bare env lookup.
+			if (!env.ACTIONS_RUNTIME_TOKEN || !env.ACTIONS_RESULTS_URL)
+				throw new Error(
+					"artifact upload requires the Actions artifact runtime (ACTIONS_RUNTIME_TOKEN and ACTIONS_RESULTS_URL); run .github/actions/artifact-runtime before this step",
+				);
 			const files: string[] = [];
 			const visit = (path: string) => {
 				for (const entry of readdirSync(path, { withFileTypes: true })) {

--- a/apps/cli/src/lib/experiment-transfer.test.ts
+++ b/apps/cli/src/lib/experiment-transfer.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readExperimentAttempts, writeImmutableJson } from "./experiment-artifacts.ts";
+import { downloadExperimentAttempts, downloadExperimentPlan } from "./experiment-transfer.ts";
+import { workflowExperiment } from "./workflow-experiment.ts";
+
+const root = mkdtempSync(join(tmpdir(), "experiment-transfer-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+const plan = workflowExperiment(
+	{
+		GITHUB_RUN_ID: "123",
+		GITHUB_SHA: "a".repeat(40),
+		BENCH_PROVIDERS: "tama",
+		BENCH_SUITES: "system",
+		BENCH_REPLICAS: "1",
+	},
+	"2026-09-10",
+);
+const store = { list: async () => [], upload: async () => {}, download: async () => {} };
+test("missing plan artifacts never regenerate a smaller experiment", async () => {
+	await expect(downloadExperimentPlan(store, "123", root)).rejects.toThrow("one immutable");
+});
+test("interrupted attempts survive collection even when every terminal artifact is absent", async () => {
+	const directory = join(root, "interrupted");
+	await downloadExperimentAttempts(
+		store,
+		{
+			read: async () => [
+				{
+					version: "1",
+					kind: "intent",
+					account: "tama",
+					attempt: "lost",
+					cellId: "tama-system-r0",
+					planDigest: plan.digest,
+				},
+			],
+			append: async () => {},
+		},
+		plan,
+		directory,
+	);
+	expect(() => readExperimentAttempts(directory)).toThrow("unterminated");
+});
+test("a plan artifact from another workflow cannot supply experiment provenance", async () => {
+	await expect(
+		downloadExperimentPlan(
+			{
+				...store,
+				list: async () => [
+					{ id: 1, name: "experiment-plan-123", expired: false, workflow_run: { id: 456 } },
+				],
+				download: async (_artifact, directory) => {
+					mkdirSync(directory, { recursive: true });
+					writeImmutableJson(join(directory, "plan.json"), plan);
+				},
+			},
+			"123",
+			join(root, "wrong-workflow"),
+		),
+	).rejects.toThrow("workflow provenance");
+});

--- a/apps/cli/src/lib/experiment-transfer.ts
+++ b/apps/cli/src/lib/experiment-transfer.ts
@@ -1,0 +1,92 @@
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import type { ExperimentPlan } from "@sandbox-benchmarks/schema";
+import type { AccountJournal } from "./account-journal.ts";
+import {
+	readExperimentAttempt,
+	readExperimentPlan,
+	writeImmutableJson,
+} from "./experiment-artifacts.ts";
+import type { ExperimentStore } from "./experiment-store.ts";
+
+export async function downloadExperimentPlan(
+	store: ExperimentStore,
+	id: string,
+	root: string,
+): Promise<ExperimentPlan> {
+	if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(id)) throw new Error("invalid experiment identity");
+	const artifacts = (await store.list(`experiment-plan-${id}`)).filter(
+		(entry) => entry.name === `experiment-plan-${id}`,
+	);
+	if (artifacts.length !== 1 || !artifacts[0])
+		throw new Error("one immutable experiment plan is required");
+	await store.download(artifacts[0], root);
+	const plan = readExperimentPlan(join(root, "plan.json"));
+	if (plan.id !== id || String(artifacts[0].workflow_run.id) !== id)
+		throw new Error("plan artifact workflow provenance mismatch");
+	return plan;
+}
+
+/** Recover every attempt, including launch intents whose worker disappeared before terminal upload. */
+export async function downloadExperimentAttempts(
+	store: ExperimentStore,
+	journal: AccountJournal,
+	plan: ExperimentPlan,
+	root: string,
+): Promise<void> {
+	mkdirSync(root, { recursive: true });
+	const terminals = new Map<string, ReturnType<typeof readExperimentAttempt>>();
+	for (const artifact of await store.list(`experiment-attempt-${plan.id}-`)) {
+		const directory = join(root, String(artifact.id));
+		await store.download(artifact, directory);
+		const attempt = readExperimentAttempt(directory);
+		const { evidence } = attempt;
+		if (
+			evidence.planDigest !== plan.digest ||
+			artifact.name !== `experiment-attempt-${plan.id}-${evidence.id}` ||
+			String(artifact.workflow_run.id) !== plan.id ||
+			terminals.has(evidence.id)
+		)
+			throw new Error("attempt artifact provenance conflict");
+		terminals.set(evidence.id, attempt);
+	}
+	for (const account of plan.accounts) {
+		const records = await journal.read(account.quotaDomain);
+		for (const attempt of terminals.values()) {
+			const cell = plan.cells.find((cell) => cell.id === attempt.evidence.cellId);
+			if (cell?.quotaDomain !== account.quotaDomain || attempt.evidence.outcome !== "completed")
+				continue;
+			const owned = records.filter((record) => record.attempt === attempt.evidence.id);
+			const intent = owned.find((record) => record.kind === "intent");
+			const allocated = owned.find((record) => record.kind === "allocated");
+			const released = owned.find((record) => record.kind === "released");
+			if (
+				owned.length !== 3 ||
+				!intent ||
+				!allocated ||
+				!released ||
+				released.outcome !== "absent" ||
+				owned.some(
+					(record) =>
+						record.planDigest !== plan.digest ||
+						record.cellId !== cell.id ||
+						record.account !== cell.quotaDomain,
+				) ||
+				allocated.ref.id !== released.ref.id ||
+				allocated.ref.provider !== released.ref.provider ||
+				allocated.ref.provider !== cell.provider ||
+				allocated.ref.id !== attempt.execution?.sandboxId
+			)
+				throw new Error("completed attempt lacks durable allocation and release evidence");
+		}
+
+		for (const record of records.filter(
+			(record) => record.kind === "intent" && record.planDigest === plan.digest,
+		)) {
+			if (terminals.has(record.attempt)) continue;
+			const directory = join(root, `interrupted-${record.attempt}`);
+			mkdirSync(directory, { recursive: true });
+			writeImmutableJson(join(directory, "intent.json"), record);
+		}
+	}
+}

--- a/apps/cli/src/lib/github-account-journal.test.ts
+++ b/apps/cli/src/lib/github-account-journal.test.ts
@@ -83,6 +83,22 @@ test("missing journal and truncated history cannot become an empty account", asy
 		).read("tama"),
 	).rejects.toThrow("incomplete");
 });
+test("a transient append failure does not poison later appends or reads", async () => {
+	const f = fixture();
+	let blip = true;
+	const journal = githubAccountJournal((method, path, body) => {
+		if (method === "PATCH" && blip) {
+			blip = false;
+			throw new Error("HTTP 502");
+		}
+		return f.request(method, path, body);
+	});
+	await expect(journal.append(intent)).rejects.toThrow("502");
+	// The same client keeps working: the next cell's record lands and reads see it.
+	await journal.append({ ...intent, attempt: "attempt-2" });
+	expect(await journal.read("tama")).toEqual([{ ...intent, attempt: "attempt-2" }]);
+	expect(f.writes).toHaveLength(1);
+});
 test("a competing writer rejects the append rather than forcing the journal ref", async () => {
 	const f = fixture();
 	const journal = githubAccountJournal((method, path, body) => {

--- a/apps/cli/src/lib/github-account-journal.test.ts
+++ b/apps/cli/src/lib/github-account-journal.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test";
+import { type } from "arktype";
+import type { GitRequest } from "./github-account-journal.ts";
+import { githubAccountJournal } from "./github-account-journal.ts";
+
+const intent = {
+	version: "1",
+	kind: "intent",
+	account: "tama",
+	attempt: "attempt-1",
+	cellId: "tama-system-r0",
+	planDigest: `sha256:${"a".repeat(64)}`,
+} as const;
+const requestTree = type({ tree: [{ path: "string", content: "string" }] });
+function fixture() {
+	let head = "a".repeat(40);
+	let next = 1;
+	const entries: Array<{ path: string; type: string; sha: string }> = [
+		{ path: "journal.json", type: "blob", sha: head },
+	];
+	const blobs = new Map<string, string>([
+		[head, JSON.stringify({ schemaVersion: "1", account: "tama", records: [] })],
+	]);
+	let pending: { path: string; content: string } | undefined;
+	const writes: unknown[] = [];
+	const request: GitRequest = async (method, path, body) => {
+		if (method === "GET" && path.startsWith("/git/ref/")) return { object: { sha: head } };
+		if (method === "GET" && path.startsWith("/git/commits/")) return { tree: { sha: head } };
+		if (method === "GET" && path.startsWith("/git/trees/"))
+			return { truncated: false, tree: entries };
+		if (method === "GET" && path.startsWith("/git/blobs/"))
+			return {
+				encoding: "base64",
+				content: Buffer.from(blobs.get(path.slice(11)) ?? "").toString("base64"),
+			};
+		if (method === "POST" && path === "/git/trees") {
+			pending = requestTree.assert(body).tree[0];
+			return { sha: "b".repeat(40) };
+		}
+		if (method === "POST" && path === "/git/commits")
+			return { sha: (++next).toString(16).padStart(40, "0") };
+		if (method === "PATCH") {
+			writes.push(body);
+			const update = type({ sha: "string", force: "false" }).assert(body);
+			if (!pending) throw new Error("missing tree");
+			head = update.sha;
+			blobs.set(head, pending.content);
+			entries.splice(0, entries.length, { path: pending.path, type: "blob", sha: head });
+			pending = undefined;
+			return { object: { sha: head } };
+		}
+		throw new Error("unexpected Git request");
+	};
+	return { request, writes };
+}
+
+test("journal survives new clients and refuses replacing an earlier immutable record", async () => {
+	const f = fixture();
+	await githubAccountJournal(f.request).append(intent);
+	expect(await githubAccountJournal(f.request).read("tama")).toEqual([intent]);
+	await expect(githubAccountJournal(f.request).append(intent)).rejects.toThrow("already exists");
+	expect(f.writes).toHaveLength(1);
+});
+test("concurrent attempts append serially without losing records", async () => {
+	const f = fixture();
+	const journal = githubAccountJournal(f.request);
+	await Promise.all([journal.append(intent), journal.append({ ...intent, attempt: "attempt-2" })]);
+	expect(await githubAccountJournal(f.request).read("tama")).toHaveLength(2);
+	expect(f.writes).toHaveLength(2);
+});
+test("missing journal and truncated history cannot become an empty account", async () => {
+	await expect(
+		githubAccountJournal(async () => {
+			throw new Error("HTTP 404");
+		}).read("tama"),
+	).rejects.toThrow("404");
+	const f = fixture();
+	await expect(
+		githubAccountJournal((method, path, body) =>
+			path.startsWith("/git/trees/")
+				? Promise.resolve({ truncated: true, tree: [] })
+				: f.request(method, path, body),
+		).read("tama"),
+	).rejects.toThrow("incomplete");
+});
+test("a competing writer rejects the append rather than forcing the journal ref", async () => {
+	const f = fixture();
+	const journal = githubAccountJournal((method, path, body) => {
+		if (method === "PATCH") {
+			expect(body).toMatchObject({ force: false });
+			throw new Error("HTTP 422");
+		}
+		return f.request(method, path, body);
+	});
+	await expect(journal.append(intent)).rejects.toThrow("422");
+	await expect(journal.append({ ...intent, attempt: "attempt-2" })).rejects.toThrow("422");
+});

--- a/apps/cli/src/lib/github-account-journal.ts
+++ b/apps/cli/src/lib/github-account-journal.ts
@@ -1,0 +1,123 @@
+import { type } from "arktype";
+import type { AccountJournal } from "./account-journal.ts";
+import { accountRecordSchema } from "./account-journal.ts";
+
+const reference = type({ object: { sha: /^[a-f0-9]{40}$/ } });
+const object = type({ sha: /^[a-f0-9]{40}$/ });
+const commit = type({ tree: { sha: /^[a-f0-9]{40}$/ } });
+const tree = type({
+	truncated: "boolean",
+	tree: type({ path: "string", type: "string", sha: /^[a-f0-9]{40}$/ }).array(),
+});
+const blob = type({ encoding: "'base64'", content: "string <= 16000000" });
+const journalSchema = type({
+	schemaVersion: "'1'",
+	account: "string",
+	records: accountRecordSchema.array(),
+}).onUndeclaredKey("reject");
+export type GitRequest = (
+	method: "GET" | "POST" | "PATCH",
+	path: string,
+	body?: unknown,
+) => Promise<unknown>;
+
+/** Durable evidence, not a distributed lock. Provision and protect the branch before account admission. */
+export function githubAccountJournal(
+	request: GitRequest,
+	branch = "benchmark-account-journal",
+): AccountJournal {
+	if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(branch))
+		throw new Error("invalid account journal branch");
+	let tail: Promise<unknown> = Promise.resolve();
+	const snapshot = async (account: string) => {
+		const head = reference.assert(await request("GET", `/git/ref/heads/${branch}-${account}`))
+			.object.sha;
+		const baseTree = commit.assert(await request("GET", `/git/commits/${head}`)).tree.sha;
+		const inventory = tree.assert(await request("GET", `/git/trees/${baseTree}?recursive=1`));
+		if (inventory.truncated) throw new Error("account journal tree is incomplete");
+		const entry = inventory.tree.find((entry) => entry.path === "journal.json");
+		if (entry?.type !== "blob") throw new Error("account journal has not been provisioned");
+		const data = blob.assert(await request("GET", `/git/blobs/${entry.sha}`));
+		const journal = journalSchema.assert(
+			JSON.parse(Buffer.from(data.content, "base64").toString("utf8")),
+		);
+		if (journal.account !== account || journal.records.some((record) => record.account !== account))
+			throw new Error("journal account provenance mismatch");
+		return { head, baseTree, journal };
+	};
+	return {
+		async read(account) {
+			if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(account))
+				throw new Error("invalid account identity");
+			await tail;
+			return (await snapshot(account)).journal.records;
+		},
+		append(raw) {
+			const record = accountRecordSchema.assert(raw);
+			const pending = tail.then(async () => {
+				const state = await snapshot(record.account);
+				const path = "journal.json";
+				if (
+					state.journal.records.some(
+						(entry) => entry.attempt === record.attempt && entry.kind === record.kind,
+					)
+				)
+					throw new Error("immutable journal record already exists");
+				const nextTree = object.assert(
+					await request("POST", "/git/trees", {
+						base_tree: state.baseTree,
+						tree: [
+							{
+								path,
+								mode: "100644",
+								type: "blob",
+								content: `${JSON.stringify({ ...state.journal, records: [...state.journal.records, record] })}\n`,
+							},
+						],
+					}),
+				);
+				const nextCommit = object.assert(
+					await request("POST", "/git/commits", {
+						message: `Record ${record.account} ${record.attempt} ${record.kind}`,
+						tree: nextTree.sha,
+						parents: [state.head],
+					}),
+				);
+				// Never force: another writer advancing the branch makes this append fail closed.
+				const updated = reference.assert(
+					await request("PATCH", `/git/refs/heads/${branch}-${record.account}`, {
+						sha: nextCommit.sha,
+						force: false,
+					}),
+				);
+				if (updated.object.sha !== nextCommit.sha)
+					throw new Error("journal append was not acknowledged");
+			});
+			tail = pending;
+			return pending;
+		},
+	};
+}
+
+export function githubGitRequest(env: NodeJS.ProcessEnv = process.env): GitRequest {
+	const repository = env.GITHUB_REPOSITORY;
+	const token = env.GH_TOKEN || env.GITHUB_TOKEN;
+	if (!repository || !/^[\w.-]+\/[\w.-]+$/.test(repository) || !token)
+		throw new Error("account journal requires GitHub repository and token");
+	return async (method, path, body) => {
+		const response = await fetch(`https://api.github.com/repos/${repository}${path}`, {
+			method,
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github+json",
+				"Content-Type": "application/json",
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+			...(body === undefined ? {} : { body: JSON.stringify(body) }),
+			signal: AbortSignal.timeout(20_000),
+		});
+		if (!response.ok)
+			throw new Error(`account journal ${method} HTTP ${response.status}; allocation blocked`);
+		return response.json();
+	};
+}

--- a/apps/cli/src/lib/github-account-journal.ts
+++ b/apps/cli/src/lib/github-account-journal.ts
@@ -93,7 +93,10 @@ export function githubAccountJournal(
 				if (updated.object.sha !== nextCommit.sha)
 					throw new Error("journal append was not acknowledged");
 			});
-			tail = pending;
+			// The chain only orders appends; it must not carry their outcomes. A rejected tail would skip
+			// every later append's callback and fail every read with the first (possibly transient)
+			// error for the rest of the process, silently dropping the batch's remaining records.
+			tail = pending.catch(() => undefined);
 			return pending;
 		},
 	};

--- a/apps/cli/src/lib/run-replicate.ts
+++ b/apps/cli/src/lib/run-replicate.ts
@@ -1,0 +1,213 @@
+import { join } from "node:path";
+import { describeDriverFailure as projectDriverFailure } from "@sandbox-benchmarks/driver";
+import { diagnosticSecretsFromEnv } from "@sandbox-benchmarks/driver/env";
+import {
+	CREATE_FAILURE_PREFIX,
+	runSuite,
+	SuiteUsageError,
+	unmetRequirements,
+} from "@sandbox-benchmarks/harness";
+import { writeNormalizedRun } from "@sandbox-benchmarks/results";
+import type { Run } from "@sandbox-benchmarks/schema";
+import { logInfo, logProviderStatuses, logWarning, withGroup } from "./actions-log.ts";
+import { runDriverSuite, usesDriverSuite } from "./driver-run.ts";
+
+const describeDriverFailure = (error: unknown): string =>
+	projectDriverFailure(error, diagnosticSecretsFromEnv(process.env));
+
+export interface ReplicateOutcome {
+	/** The replicate index, or undefined for the single un-indexed run (local/smoke). */
+	index?: number;
+	/** Where this replicate's shard Run belongs. Always set — including on a failure that never got as
+	 *  far as writing it — so the fleet table can name the missing shard rather than blanking the cell. */
+	outFile: string;
+	/** The normalized shard Run, absent when normalization itself failed. */
+	run?: Run;
+	failed: boolean;
+	/** Why it failed (or a note about a recorded gap) — the annotation/summary text. */
+	detail?: string;
+	/**
+	 * Wall-clock milliseconds this replicate took, end to end.
+	 *
+	 * Recorded because collapsing the runner axis DELETED it: when every replicate was its own job,
+	 * the Actions UI listed R durations for free, and a straggler was obvious. Driven from one runner
+	 * they share a single job duration, so without this a report cannot say which sandbox was slow —
+	 * and a straggler is precisely what puts the cell near its `timeout-minutes`, where the whole
+	 * fleet's shards are lost at once rather than one replicate's.
+	 */
+	durationMs: number;
+}
+
+export function replicateLabel(index: number | undefined): string {
+	return index === undefined ? "single" : `r${index}`;
+}
+
+/** Everything one replicate needs; `replicateIndex` undefined is the single un-indexed run. */
+interface ReplicateContext {
+	execute?: typeof runSuite;
+	provider: string;
+	suite: string;
+	runId: string;
+	sha: string;
+	rawRoot: string;
+	outFile: string;
+	indexFile?: string;
+	replicateIndex?: number;
+	/** Force the DriverModule path. Registered ids already take that path; waived ids error. */
+	driverPath?: boolean;
+	/** Providers that must reach "validated" for this replicate to count as a success. */
+	required: readonly string[];
+}
+
+/**
+ * Run ONE replicate end to end — suite → normalize → gap verification → require gate — and report
+ * what happened. Total by construction: it never throws and never exits, because a `--replicates`
+ * fan-out has R of these in flight and one replicate's failure must not abort its peers or skip
+ * their shard writes (the per-replicate matrix cells had `fail-fast: false` for the same reason).
+ */
+export async function runReplicate(ctx: ReplicateContext): Promise<ReplicateOutcome> {
+	const { provider, suite, runId, sha, rawRoot, outFile, indexFile, replicateIndex } = ctx;
+	// Annotations are emitted as `::warning::` workflow commands, which bypass the `[rN]` line tagging
+	// by necessity (a tagged command stops being an annotation). So the replicate has to ride in the
+	// TITLE instead — otherwise a 12-way fan-out puts up to 12 byte-identical warnings in the panel
+	// with nothing saying which sandbox each came from.
+	const cell =
+		`${suite} / ${provider}` +
+		(replicateIndex === undefined ? "" : ` ${replicateLabel(replicateIndex)}`);
+	const startedAt = Bun.nanoseconds();
+	// A getter, so every `...base` spread below stamps the elapsed time AT ITS OWN return rather than
+	// freezing it here, before the suite has even started.
+	const base = {
+		index: replicateIndex,
+		outFile,
+		get durationMs() {
+			return Math.round((Bun.nanoseconds() - startedAt) / 1e6);
+		},
+	};
+
+	// A suite that RAN AND BROKE is a result — the harness has already written its `--failed.json` marker
+	// into the raw tree — so the error is held, not thrown. Normalizing anyway is what turns that marker
+	// into a recorded `failed` gap on this shard's Run document; rethrowing here would skip the write, the
+	// shard would contribute nothing for the aggregate to merge, and the only trace of the failure would
+	// die inside the CI artifact. The replicate still reports failed at the bottom of this block.
+	let suiteError: unknown;
+	let usageError: string | undefined;
+	await withGroup(`Run suite ${suite} on ${provider}`, async () => {
+		try {
+			const executeSuite =
+				ctx.execute ??
+				(usesDriverSuite(provider, ctx.driverPath === true) ? runDriverSuite : runSuite);
+			await executeSuite({
+				runId,
+				replicateIndex,
+				providerName: provider,
+				suiteName: suite,
+				// Tag the raw tree by suite: `<rawRoot>/<provider>/<suite>/`. The normalizer reads each suite
+				// subdirectory independently and rejects any catalogued metric a suite emits off its declared
+				// Dimensions (the runtime half of the suite↔dimension↔metric contract).
+				resultsDir: join(rawRoot, provider, suite),
+			});
+			logInfo(`Suite "${suite}" completed on ${provider}`);
+		} catch (err) {
+			// A usage error (unknown provider/suite) produced no raw tree and no marker: there is nothing to
+			// normalize, and pretending otherwise would write an empty Run for a cell that never existed.
+			if (err instanceof SuiteUsageError) {
+				usageError = err.message;
+				return;
+			}
+			suiteError = err;
+			logWarning(
+				`Suite "${suite}" threw on ${provider} — will normalize any failed marker into a gap: ${describeDriverFailure(
+					err,
+				)}`,
+				{ title: cell },
+			);
+		}
+	});
+	if (usageError !== undefined) return { ...base, failed: true, detail: usageError };
+
+	let run: Run | undefined;
+	let normalizeError: unknown;
+	await withGroup("Normalize Run document", async () => {
+		try {
+			run = writeNormalizedRun({
+				rawRoot,
+				runId,
+				sha,
+				outFile,
+				updateIndexFile: indexFile,
+				...(replicateIndex !== undefined ? { replicateIndex } : {}),
+			});
+			logInfo(`Normalized Run ${runId} → ${outFile}`);
+			// Already inside withGroup — don't nest another ::group::.
+			await logProviderStatuses(run, { grouped: false });
+		} catch (err) {
+			// Prefer the suite failure that caused a bad tree; otherwise keep the normalize error.
+			normalizeError = suiteError ?? err;
+		}
+	});
+	if (!run) {
+		const detail =
+			normalizeError === undefined
+				? "normalize produced no Run document"
+				: describeDriverFailure(normalizeError);
+		return { ...base, failed: true, detail };
+	}
+	const normalized = run;
+
+	if (suiteError) {
+		const message = describeDriverFailure(suiteError);
+		// Verify before claiming: the harness writes the failed marker, but a throw can predate it (or
+		// the marker can be lost before normalize), leaving this shard's Run EMPTY for the cell. Saying
+		// "recorded as a failed gap" then would launder the loss — the aggregate would show a bare
+		// pending provider while every job log claims the gap exists — so check the normalized Run itself.
+		//
+		// Match the gap's REASON against THIS run's error, not just its (scope, id, outcome): the harness
+		// records the marker reason verbatim (`message`) for a post-run failure, or under the
+		// `Failed to create sandbox: ` prefix for a creation failure. A bare shape check would also accept
+		// a stale `--failed.json` from an earlier error, or an independently-derived suite gap (a disk
+		// shortfall, a dedup twin) — none of which prove the marker THIS run tried to write survived.
+		const gapRecorded = normalized.providers
+			.find((p) => p.providerId === provider)
+			?.gaps.some(
+				(g) =>
+					g.scope === "suite" &&
+					g.id === suite &&
+					g.outcome === "failed" &&
+					(g.reason === message || g.reason === `${CREATE_FAILURE_PREFIX}${message}`),
+			);
+		const detail = gapRecorded
+			? `Suite "${suite}" failed on ${provider} — recorded as a failed gap in ${outFile}: ${message}`
+			: `Suite "${suite}" failed on ${provider} but no gap could be recorded in ${outFile} ` +
+				`(no failed marker survived into the raw tree; this job log is the only trace): ${message}`;
+		return { ...base, run: normalized, failed: true, detail };
+	}
+
+	// Missing credentials (and an unusable sandbox) are recorded as a skip, not a throw — the lenient
+	// local-dev default. That would make a smoke run whose secret is missing/misnamed exit 0 having
+	// benchmarked nothing, so CI passes `--require <provider>` (or REQUIRE_PROVIDERS) to assert the
+	// provider actually reached `validated` — i.e. produced at least one catalogued metric.
+	if (ctx.required.length > 0) {
+		const reports = normalized.providers.map((p) => ({
+			provider: p.providerId,
+			status: p.validationStatus === "validated" ? "ok" : p.validationStatus,
+		}));
+		const unmet = unmetRequirements(reports, ctx.required);
+		if (unmet.length > 0) {
+			const details: string[] = [];
+			for (const providerId of unmet) {
+				// The gaps ARE the explanation for "no metrics", and their outcome is the important half of
+				// it: a required provider that skipped on a precondition is a configuration problem, one that
+				// failed is an outage, and the operator reading this line needs to know which they have.
+				const gaps = normalized.providers.find((p) => p.providerId === providerId)?.gaps ?? [];
+				const gapDetail = gaps.map((g) => `${g.id} ${g.outcome}: ${g.reason}`).join("; ");
+				const line = `Required provider "${providerId}" produced no metrics${gapDetail ? ` — ${gapDetail}` : " and was absent from the Run"}`;
+				details.push(line);
+			}
+			return { ...base, run: normalized, failed: true, detail: details.join("\n") };
+		}
+	}
+
+	logInfo(`Cell ${cell} succeeded → ${outFile}`);
+	return { ...base, run: normalized, failed: false };
+}

--- a/apps/cli/src/lib/workflow-experiment.test.ts
+++ b/apps/cli/src/lib/workflow-experiment.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test";
+import { workflowAxes, workflowExperiment } from "./workflow-experiment.ts";
+
+const env = {
+	GITHUB_RUN_ID: "123",
+	GITHUB_SHA: "a".repeat(40),
+	BENCH_PROVIDERS: "daytona-vm,daytona-container,tama",
+	BENCH_SUITES: "system,realworld-mastra",
+};
+test("workflow planning preserves samples and defaults shared accounts to one sandbox", () => {
+	const plan = workflowExperiment(env, "2026-09-10");
+	expect(plan.cells).toHaveLength(45);
+	expect(plan.batches).toHaveLength(45);
+	expect(workflowAxes(plan)).toEqual(["daytona", "tama"]);
+	expect(plan.accounts.every((account) => account.sandboxes === 1)).toBe(true);
+	const daytona = plan.rounds.find((round) => round.quotaDomain === "daytona");
+	expect(daytona).toBeDefined();
+	expect(workflowAxes(plan, "daytona", daytona?.id)).toHaveLength(30);
+	expect(
+		plan.cells.filter((cell) => cell.suite === "realworld-mastra").map((cell) => cell.replicate),
+	).toEqual([
+		...Array.from({ length: 12 }, (_, i) => i),
+		...Array.from({ length: 12 }, (_, i) => i),
+		...Array.from({ length: 12 }, (_, i) => i),
+	]);
+});
+test("convergence and implicit per-cell quota overrides fail admission", () => {
+	expect(() => workflowExperiment({ ...env, BENCH_SUITES: "memory" }, "2026-09-10")).toThrow(
+		"convergence",
+	);
+	expect(() => workflowExperiment({ ...env, BENCH_MAX_CONCURRENCY: "12" }, "2026-09-10")).toThrow(
+		"retired",
+	);
+});
+test("large account cohorts partition into bounded collection rounds", () => {
+	const plan = workflowExperiment(
+		{ ...env, BENCH_PROVIDERS: "tama", BENCH_SUITES: "system", BENCH_REPLICAS: "257" },
+		"2026-09-10",
+	);
+	expect(plan.rounds.map((round) => round.batches.length)).toEqual([256, 1]);
+	expect(plan.cells.at(-1)?.replicate).toBe(256);
+});

--- a/apps/cli/src/lib/workflow-experiment.ts
+++ b/apps/cli/src/lib/workflow-experiment.ts
@@ -1,6 +1,11 @@
 import { evidenceDigest } from "@sandbox-benchmarks/results";
-import type { ExperimentCell, ExperimentPlan, ProviderId } from "@sandbox-benchmarks/schema";
-import { accountCapacityPolicySchema, SUITES, TARGET_SPEC } from "@sandbox-benchmarks/schema";
+import type { ExperimentCell, ExperimentPlan } from "@sandbox-benchmarks/schema";
+import {
+	accountCapacityPolicySchema,
+	quotaDomain,
+	SUITES,
+	TARGET_SPEC,
+} from "@sandbox-benchmarks/schema";
 import {
 	VERCEL_PROJECT_NAME_DEFAULT,
 	VERCEL_TEAM_SLUG_DEFAULT,
@@ -9,12 +14,6 @@ import {
 import { resolveDriverArtifact } from "./driver-run.ts";
 import { planExperiment } from "./experiment-plan.ts";
 import { planReplicateMap, selectProviders, selectSuites } from "./matrix.ts";
-
-export function quotaDomain(provider: ProviderId): string {
-	if (provider === "daytona-vm" || provider === "daytona-container") return "daytona";
-	if (provider === "modal-gvisor" || provider === "modal-vm") return "modal";
-	return provider;
-}
 
 /** Resolve declarations without credentials. Workers must independently match these identities. */
 export function workflowExperiment(env: NodeJS.ProcessEnv, createdOn: string): ExperimentPlan {

--- a/apps/cli/src/lib/workflow-experiment.ts
+++ b/apps/cli/src/lib/workflow-experiment.ts
@@ -1,0 +1,111 @@
+import { evidenceDigest } from "@sandbox-benchmarks/results";
+import type { ExperimentCell, ExperimentPlan, ProviderId } from "@sandbox-benchmarks/schema";
+import { accountCapacityPolicySchema, SUITES, TARGET_SPEC } from "@sandbox-benchmarks/schema";
+import {
+	VERCEL_PROJECT_NAME_DEFAULT,
+	VERCEL_TEAM_SLUG_DEFAULT,
+	vercelVcrImageRefs,
+} from "@sandbox-benchmarks/schema/toolchain";
+import { resolveDriverArtifact } from "./driver-run.ts";
+import { planExperiment } from "./experiment-plan.ts";
+import { planReplicateMap, selectProviders, selectSuites } from "./matrix.ts";
+
+export function quotaDomain(provider: ProviderId): string {
+	if (provider === "daytona-vm" || provider === "daytona-container") return "daytona";
+	if (provider === "modal-gvisor" || provider === "modal-vm") return "modal";
+	return provider;
+}
+
+/** Resolve declarations without credentials. Workers must independently match these identities. */
+export function workflowExperiment(env: NodeJS.ProcessEnv, createdOn: string): ExperimentPlan {
+	const id = env.GITHUB_RUN_ID;
+	const sha = env.GITHUB_SHA;
+	if (!id || !sha) throw new Error("workflow identity is required");
+	const replicas = planReplicateMap(env.BENCH_SUITES, env.BENCH_REPLICAS);
+	const cells: ExperimentCell[] = [];
+	const passOverride = env.BENCH_PTS_PASSES?.trim();
+	const capacity = accountCapacityPolicySchema.assert(
+		JSON.parse(env.BENCH_ACCOUNT_CAPACITY || "{}"),
+	);
+	if (env.BENCH_MAX_CONCURRENCY?.trim())
+		throw new Error(
+			"per-cell concurrency is retired; use reviewed BENCH_ACCOUNT_CAPACITY account policy",
+		);
+	for (const provider of selectProviders(env.BENCH_PROVIDERS)) {
+		// Mirrored and custom artifact refs must be public planning inputs, never inferred from credentials.
+		const ref = env[`BENCH_ARTIFACT_${provider.toUpperCase().replaceAll("-", "_")}`]?.trim();
+		const artifact = resolveDriverArtifact(
+			provider,
+			ref
+				? { ref }
+				: provider === "vercel"
+					? {
+							ref: vercelVcrImageRefs(VERCEL_TEAM_SLUG_DEFAULT, VERCEL_PROJECT_NAME_DEFAULT)
+								.version,
+						}
+					: {},
+		);
+		for (const suiteName of selectSuites(env.BENCH_SUITES)) {
+			const suite = SUITES[suiteName];
+			if (
+				passOverride === "converge" ||
+				(!passOverride && "ptsConverge" in suite && suite.ptsConverge)
+			)
+				throw new Error(
+					`${suiteName}: convergence is not admitted for bounded publication; select an explicitly versioned fixed-pass experiment`,
+				);
+			const passes = passOverride ? Number(passOverride) : (suite.ptsTimesToRun ?? 2);
+			if (!Number.isSafeInteger(passes) || passes < 1)
+				throw new Error("fixed passes must be a positive integer");
+			for (const replicate of replicas[suiteName] ?? [])
+				cells.push({
+					id: `${provider}-${suiteName}-r${replicate}`,
+					provider,
+					quotaDomain: quotaDomain(provider),
+					suite: suiteName,
+					replicate,
+					workloadRevision: evidenceDigest({ sha, suite, passes }),
+					environmentRevision: sha,
+					artifactIdentity: evidenceDigest(artifact),
+					target: { ...TARGET_SPEC },
+					metrics: [...suite.metrics],
+					exclusions: [],
+					passes,
+					startupMinutes: 40,
+					workloadMinutes: suite.commandTimeoutMinutes * suite.commands.length,
+					finishMinutes: 15,
+				});
+		}
+	}
+	const plan = planExperiment({ id, sha, createdOn, cells }, capacity);
+	workflowAxes(plan);
+	for (const account of plan.accounts) workflowAxes(plan, account.quotaDomain);
+	return plan;
+}
+
+/** Every nesting level stays within the Actions matrix limit under one frozen plan. */
+export function workflowAxes(plan: ExperimentPlan, account?: string, round?: string): unknown[] {
+	if (account === undefined) {
+		const domains = [...new Set(plan.rounds.map((entry) => entry.quotaDomain))];
+		if (domains.length > 256)
+			throw new Error("experiment requires explicit account collection partitions");
+		return domains;
+	}
+	if (round === undefined) {
+		const rounds = plan.rounds
+			.filter((entry) => entry.quotaDomain === account)
+			.map((entry) => entry.id);
+		if (rounds.length === 0 || rounds.length > 256)
+			throw new Error("account requires explicit round collection partitions");
+		return rounds;
+	}
+	const selected = plan.rounds.find((entry) => entry.quotaDomain === account && entry.id === round);
+	if (!selected) throw new Error("unknown collection round");
+	return selected.batches.map((id) => {
+		const batch = plan.batches.find((entry) => entry.id === id);
+		const cell = plan.cells.find((entry) => entry.id === batch?.cells[0]);
+		if (!batch || !cell || batch.quotaDomain !== quotaDomain(cell.provider))
+			throw new Error("invalid workflow quota domain");
+		return { batch: id, provider: cell.provider, suite: cell.suite };
+	});
+}

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,9 @@
         "leaderboard": "./src/bin/leaderboard.ts",
         "reprice-dataset": "./src/bin/reprice-dataset.ts",
         "driver-check": "./src/bin/driver-check.ts",
+        "plan-experiment": "./src/bin/plan-experiment.ts",
+        "evaluate-experiment": "./src/bin/evaluate-experiment.ts",
+        "aggregate-experiment": "./src/bin/aggregate-experiment.ts",
       },
       "dependencies": {
         "@actions/core": "1.11.1",

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "aggregate-experiment": "./src/bin/aggregate-experiment.ts",
       },
       "dependencies": {
+        "@actions/artifact": "6.2.1",
         "@actions/core": "1.11.1",
         "@daytona/api-client": "catalog:computesdk",
         "@daytona/sdk": "catalog:computesdk",
@@ -265,11 +266,15 @@
     },
   },
   "packages": {
+    "@actions/artifact": ["@actions/artifact@6.2.1", "", { "dependencies": { "@actions/core": "^3.0.0", "@actions/github": "^9.0.0", "@actions/http-client": "^4.0.0", "@azure/storage-blob": "^12.30.0", "@octokit/core": "^7.0.6", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-retry": "^8.0.0", "@octokit/request": "^10.0.7", "@octokit/request-error": "^7.1.0", "@protobuf-ts/plugin": "^2.2.3-alpha.1", "@protobuf-ts/runtime": "^2.9.4", "archiver": "^7.0.1", "jwt-decode": "^4.0.0", "unzip-stream": "^0.3.1" } }, "sha512-sJGH0mhEbEjBCw7o6SaLhUU66u27aFW8HTfkIb5Tk2/Wy0caUDc+oYQEgnuFN7a0HCpAbQyK0U6U7XUJDgDWrw=="],
+
     "@actions/core": ["@actions/core@1.11.1", "", { "dependencies": { "@actions/exec": "^1.1.1", "@actions/http-client": "^2.0.1" } }, "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A=="],
 
     "@actions/exec": ["@actions/exec@1.1.1", "", { "dependencies": { "@actions/io": "^1.0.1" } }, "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w=="],
 
-    "@actions/http-client": ["@actions/http-client@2.2.3", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^5.25.4" } }, "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA=="],
+    "@actions/github": ["@actions/github@9.1.1", "", { "dependencies": { "@actions/http-client": "^3.0.2", "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0", "@octokit/request": "^10.0.7", "@octokit/request-error": "^7.1.0", "undici": "^6.23.0" } }, "sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA=="],
+
+    "@actions/http-client": ["@actions/http-client@4.0.1", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^6.23.0" } }, "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg=="],
 
     "@actions/io": ["@actions/io@1.1.3", "", {}, "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="],
 
@@ -315,6 +320,32 @@
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
+    "@azure/abort-controller": ["@azure/abort-controller@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg=="],
+
+    "@azure/core-auth": ["@azure/core-auth@1.11.0", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-util": "^1.13.0", "tslib": "^2.6.2" } }, "sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg=="],
+
+    "@azure/core-client": ["@azure/core-client@1.11.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.10.0", "@azure/core-rest-pipeline": "^1.22.0", "@azure/core-tracing": "^1.3.0", "@azure/core-util": "^1.13.0", "@azure/logger": "^1.3.0", "tslib": "^2.6.2" } }, "sha512-2QygG2F76ZpMP2eMztiJvAiFMu71M9rDeU7vO/QKg5Css7MgM4frUOslFjhVjRhbGaCNPtz/S8M6y46/fFKVuQ=="],
+
+    "@azure/core-http-compat": ["@azure/core-http-compat@2.5.0", "", { "dependencies": { "@azure/abort-controller": "^2.1.2" }, "peerDependencies": { "@azure/core-client": "^1.10.0", "@azure/core-rest-pipeline": "^1.22.0" } }, "sha512-BoSmXPx2er1Ai+wKlDvj29jIQespCNBwEmKyZVHO2kEFsWbGjAjwMCGzug3DJM5/QYIV3vej0S1zcU5bq9fa8w=="],
+
+    "@azure/core-lro": ["@azure/core-lro@2.7.2", "", { "dependencies": { "@azure/abort-controller": "^2.0.0", "@azure/core-util": "^1.2.0", "@azure/logger": "^1.0.0", "tslib": "^2.6.2" } }, "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw=="],
+
+    "@azure/core-paging": ["@azure/core-paging@1.7.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-7GEAoIsaoBr6KELNRb8nypowCqvk8dnCHFCYg4XD4lOQGY2GqjQg5IhkRjyBFRO18CGSMq05PaNqSOE9GQro3g=="],
+
+    "@azure/core-rest-pipeline": ["@azure/core-rest-pipeline@1.25.0", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.10.0", "@azure/core-tracing": "^1.3.0", "@azure/core-util": "^1.13.0", "@azure/logger": "^1.3.0", "@typespec/ts-http-runtime": "^0.3.4", "tslib": "^2.6.2" } }, "sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA=="],
+
+    "@azure/core-tracing": ["@azure/core-tracing@1.4.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ=="],
+
+    "@azure/core-util": ["@azure/core-util@1.14.0", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw=="],
+
+    "@azure/core-xml": ["@azure/core-xml@1.6.0", "", { "dependencies": { "fast-xml-parser": "^5.5.9", "tslib": "^2.8.1" } }, "sha512-e7lX/dk//F6Qf7BB6PTY4+p2yuOQtyOeHGyapYHNwqSp2OnYpwQt49A/Nin2XmKBQ69pwagR4k/lQBq8lbHQkA=="],
+
+    "@azure/logger": ["@azure/logger@1.4.0", "", { "dependencies": { "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA=="],
+
+    "@azure/storage-blob": ["@azure/storage-blob@12.33.0", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.9.0", "@azure/core-client": "^1.9.3", "@azure/core-http-compat": "^2.2.0", "@azure/core-lro": "^2.2.0", "@azure/core-paging": "^1.6.2", "@azure/core-rest-pipeline": "^1.19.1", "@azure/core-tracing": "^1.2.0", "@azure/core-util": "^1.11.0", "@azure/core-xml": "^1.4.5", "@azure/logger": "^1.1.4", "@azure/storage-common": "^12.4.1", "events": "^3.0.0", "tslib": "^2.8.1" } }, "sha512-2SX8oP8PyblUcAFZSg39c8Ls+tFjavM6sBeV+qpw33mRzRhI/5hrFJmJ/x0H9xx5l6ECPvgSP8uPxqTeVbHNIA=="],
+
+    "@azure/storage-common": ["@azure/storage-common@12.5.0", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.9.0", "@azure/core-http-compat": "^2.4.0", "@azure/core-rest-pipeline": "^1.24.0", "@azure/core-tracing": "^1.2.0", "@azure/core-util": "^1.11.0", "@azure/logger": "^1.1.4", "events": "^3.3.0", "tslib": "^2.8.1" } }, "sha512-bttzuhQiCIwrkzjPDA+AtAR7dg19L/CC6ztcqJ5LfvWpXuys9mHp0UQ0udYnoUvv9SCT9KTR5kqFvFr0e6k0lQ=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
@@ -336,6 +367,8 @@
     "@blaxel/core": ["@blaxel/core@0.3.5", "", { "dependencies": { "@hey-api/client-fetch": "^0.10.0", "@modelcontextprotocol/sdk": "^1.20.0", "archiver": "^7.0.1", "axios": "^1.9.0", "dockerfile-ast": "^0.7.1", "dotenv": "^16.5.0", "form-data": "^4.0.2", "jwt-decode": "^4.0.0", "toml": "^3.0.0", "uuid": "^11.1.0", "ws": "^8.18.2", "yaml": "^2.7.1", "zod": "^3.24.3" } }, "sha512-undBY+3HH8TWrBfYpd3OxshyEjulmPWi+Mrl0VQd2VopaRAkvYDLhwjJISOagZdhRGRUTskwjg2vGTPZQhfrnQ=="],
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
+
+    "@bufbuild/protoplugin": ["@bufbuild/protoplugin@2.14.1", "", { "dependencies": { "@bufbuild/protobuf": "2.14.1", "@typescript/vfs": "^1.6.2", "typescript": "5.4.5" } }, "sha512-oddqHkmUlBSo1TgswPW6hzrP/3nxMIdKUMcB6/NSY/oUkepDV7SealCZlE0ZxhLRIgmvDSuNWOb0HEKfsWPJww=="],
 
     "@bytecodealliance/preview2-shim": ["@bytecodealliance/preview2-shim@0.17.6", "", {}, "sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw=="],
 
@@ -555,6 +588,8 @@
 
     "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
 
+    "@octokit/plugin-retry": ["@octokit/plugin-retry@8.1.1", "", { "dependencies": { "@octokit/request-error": "^7.1.1", "@octokit/types": "^17.0.0", "bottleneck": "^2.15.3" }, "peerDependencies": { "@octokit/core": ">=7" } }, "sha512-VCVvZ/R1+u3WuiBWpNavZ0mY4aaJNAsENrpBP9aLSR2QyOpQgd7DhM5j4AW7z4MQpnJYgwBPf0XqPQoNBRdQwg=="],
+
     "@octokit/request": ["@octokit/request@10.0.10", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "content-type": "^2.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w=="],
 
     "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
@@ -668,6 +703,14 @@
     "@oxc-transform/binding-win32-x64-msvc": ["@oxc-transform/binding-win32-x64-msvc@0.111.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QddKW4kBH0Wof6Y65eYCNHM4iOGmCTWLLcNYY1FGswhzmTYOUVXajNROR+iCXAOFnOF0ldtsR79SyqgyHH1Bgg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@protobuf-ts/plugin": ["@protobuf-ts/plugin@2.11.1", "", { "dependencies": { "@bufbuild/protobuf": "^2.4.0", "@bufbuild/protoplugin": "^2.4.0", "@protobuf-ts/protoc": "^2.11.1", "@protobuf-ts/runtime": "^2.11.1", "@protobuf-ts/runtime-rpc": "^2.11.1", "typescript": "^3.9" }, "bin": { "protoc-gen-ts": "bin/protoc-gen-ts", "protoc-gen-dump": "bin/protoc-gen-dump" } }, "sha512-HyuprDcw0bEEJqkOWe1rnXUP0gwYLij8YhPuZyZk6cJbIgc/Q0IFgoHQxOXNIXAcXM4Sbehh6kjVnCzasElw1A=="],
+
+    "@protobuf-ts/protoc": ["@protobuf-ts/protoc@2.11.1", "", { "bin": { "protoc": "protoc.js" } }, "sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg=="],
+
+    "@protobuf-ts/runtime": ["@protobuf-ts/runtime@2.11.1", "", {}, "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ=="],
+
+    "@protobuf-ts/runtime-rpc": ["@protobuf-ts/runtime-rpc@2.11.1", "", { "dependencies": { "@protobuf-ts/runtime": "^2.11.1" } }, "sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -789,6 +832,10 @@
 
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
+    "@typescript/vfs": ["@typescript/vfs@1.6.4", "", { "dependencies": { "debug": "^4.4.3" }, "peerDependencies": { "typescript": "*" } }, "sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ=="],
+
+    "@typespec/ts-http-runtime": ["@typespec/ts-http-runtime@0.3.9", "", { "dependencies": { "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "tslib": "^2.6.2" } }, "sha512-edSdeAqkdxBVzA1yL1LrLCml1YjyCVvPMtMqJpbF+6K609tHe8V6sQUzFQSGcYNhcuhOceZtjvN32+mpIth30A=="],
+
     "@vercel/backends": ["@vercel/backends@0.8.30", "", { "dependencies": { "@vercel/build-utils": "13.36.3", "@vercel/nft": "1.10.0", "@vercel/static-config": "3.4.0", "execa": "3.2.0", "fs-extra": "11.1.0", "get-port": "5.1.1", "oxc-transform": "0.111.0", "path-to-regexp": "8.3.0", "resolve.exports": "2.0.3", "rolldown": "1.0.0-rc.1", "srvx": "0.11.16", "ts-morph": "12.0.0", "tsx": "4.21.0", "zod": "3.22.4" } }, "sha512-rCDufBDL3Y9eiKOKZLoiy350KMt/kP7YmcRgI1egfrUpaaGObDesxkK9IQdP7fnYrK+rc2+rK07qb21AdsoAHw=="],
 
     "@vercel/blob": ["@vercel/blob@2.4.0", "", { "dependencies": { "async-retry": "^1.3.3", "is-buffer": "^2.0.5", "is-node-process": "^1.2.0", "throttleit": "^2.1.0", "undici": "^6.23.0" } }, "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew=="],
@@ -889,6 +936,8 @@
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
+
     "archiver": ["archiver@7.0.1", "", { "dependencies": { "archiver-utils": "^5.0.2", "async": "^3.2.4", "buffer-crc32": "^1.0.0", "readable-stream": "^4.0.0", "readdir-glob": "^1.1.2", "tar-stream": "^3.0.0", "zip-stream": "^6.0.1" } }, "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ=="],
 
     "archiver-utils": ["archiver-utils@5.0.2", "", { "dependencies": { "glob": "^10.0.0", "graceful-fs": "^4.2.0", "is-stream": "^2.0.1", "lazystream": "^1.0.0", "lodash": "^4.17.15", "normalize-path": "^3.0.0", "readable-stream": "^4.0.0" } }, "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA=="],
@@ -933,9 +982,13 @@
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
+    "binary": ["binary@0.3.0", "", { "dependencies": { "buffers": "~0.1.1", "chainsaw": "~0.1.0" } }, "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg=="],
+
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
@@ -946,6 +999,8 @@
     "buffer": ["buffer@5.6.0", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4" } }, "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw=="],
 
     "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
+
+    "buffers": ["buffers@0.1.1", "", {}, "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="],
 
     "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
@@ -964,6 +1019,8 @@
     "cbor-extract": ["cbor-extract@2.2.2", "", { "dependencies": { "node-gyp-build-optional-packages": "5.1.1" }, "optionalDependencies": { "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2", "@cbor-extract/cbor-extract-darwin-x64": "2.2.2", "@cbor-extract/cbor-extract-linux-arm": "2.2.2", "@cbor-extract/cbor-extract-linux-arm64": "2.2.2", "@cbor-extract/cbor-extract-linux-x64": "2.2.2", "@cbor-extract/cbor-extract-win32-x64": "2.2.2" }, "bin": { "download-cbor-prebuilds": "bin/download-prebuilds.js" } }, "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng=="],
 
     "cbor-x": ["cbor-x@1.6.4", "", { "optionalDependencies": { "cbor-extract": "^2.2.2" } }, "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q=="],
+
+    "chainsaw": ["chainsaw@0.1.0", "", { "dependencies": { "traverse": ">=0.3.0 <0.4" } }, "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -1001,7 +1058,7 @@
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
-    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+    "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "convert-hrtime": ["convert-hrtime@3.0.0", "", {}, "sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA=="],
 
@@ -1113,6 +1170,10 @@
 
     "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.3.1", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.11.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.2", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw=="],
+
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
@@ -1181,6 +1242,8 @@
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
     "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "human-signals": ["human-signals@1.1.1", "", {}, "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="],
@@ -1220,6 +1283,8 @@
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "is-unsafe": ["is-unsafe@2.0.2", "", {}, "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ=="],
 
     "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
@@ -1311,11 +1376,13 @@
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
-    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+    "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
 
     "modal": ["modal@0.9.0", "", { "dependencies": { "cbor-x": "^1.6.0", "long": "^5.3.1", "nice-grpc": "^2.1.12", "protobufjs": "^7.5.0", "smol-toml": "^1.3.3", "uuid": "^11.1.0" } }, "sha512-kCXcdJkhbJorf/q/6T9Wdlg6in9JmRnCNQnV6rVBMyeqNV/iXI6BYk4IzY4cvZ6dbauNeDMjk/Q08cbxvoIaXg=="],
 
@@ -1557,6 +1624,8 @@
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
+    "traverse": ["traverse@0.3.9", "", {}, "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ=="],
+
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "ts-error": ["ts-error@1.0.6", "", {}, "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA=="],
@@ -1586,6 +1655,8 @@
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "unzip-stream": ["unzip-stream@0.3.4", "", { "dependencies": { "binary": "^0.3.0", "mkdirp": "^0.5.1" } }, "sha512-PyofABPVv+d7fL7GOpusx7eRT9YETY2X04PhwbSipdj6bMxVCFJrr+nm0Mxqbf9hUiTin/UsnuFWBXlDZFy0Cw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
@@ -1653,11 +1724,25 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "@actions/artifact/@actions/core": ["@actions/core@3.0.1", "", { "dependencies": { "@actions/exec": "^3.0.0", "@actions/http-client": "^4.0.0" } }, "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA=="],
+
+    "@actions/core/@actions/http-client": ["@actions/http-client@2.2.3", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^5.25.4" } }, "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA=="],
+
+    "@actions/github/@actions/http-client": ["@actions/http-client@3.0.2", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^6.23.0" } }, "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA=="],
+
+    "@actions/github/undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
+
+    "@actions/http-client/undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
+
     "@blaxel/core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "@blaxel/core/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "@blaxel/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@bufbuild/protoplugin/@bufbuild/protobuf": ["@bufbuild/protobuf@2.14.1", "", {}, "sha512-agRJn3+EJDUe8AvxTx/LnHA/GErvLE62pSaSk7+MwFOtOv8eWBu/qCq2qoZjBjVZ3C2aiFJCveuSs17KMkYGOw=="],
+
+    "@bufbuild/protoplugin/typescript": ["typescript@5.4.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="],
 
     "@computesdk/modal/modal": ["modal@0.7.6", "", { "dependencies": { "cbor-x": "^1.6.0", "long": "^5.3.1", "nice-grpc": "^2.1.12", "protobufjs": "^7.5.0", "smol-toml": "^1.3.3", "uuid": "^11.1.0" } }, "sha512-AOFRO/eGl4fcNKxHkNLx55+tL318IeAiTDJCMh/Q1ZXhoaZFnpmlirVV2J5BhO32XLA7AiH6KYGA7gRBGA09lQ=="],
 
@@ -1679,11 +1764,15 @@
 
     "@mapbox/node-pre-gyp/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
+    "@modelcontextprotocol/sdk/content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "@modelcontextprotocol/sdk/jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+    "@octokit/plugin-retry/@octokit/request-error": ["@octokit/request-error@7.1.2", "", { "dependencies": { "@octokit/types": "^18.0.0" } }, "sha512-XZRuT3xZ84D3gYErI1DZvhJ33dCWVV6uzBtWkaBB4TvA/L6eOeTZodxLFVB44bBEEo3vEx7y00UfX1tBLrtLRg=="],
+
+    "@octokit/plugin-retry/@octokit/types": ["@octokit/types@17.0.0", "", { "dependencies": { "@octokit/openapi-types": "^28.0.0" } }, "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/sdk-trace": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ=="],
 
@@ -1695,13 +1784,21 @@
 
     "@opentelemetry/sdk-trace-node/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/sdk-trace": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ=="],
 
+    "@protobuf-ts/plugin/typescript": ["typescript@3.9.10", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="],
+
     "@run-cloud/sdk/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "@runloop/api-client/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@ts-morph/common/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
+    "@ts-morph/common/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+
     "@types/node-fetch/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
+    "@typescript/vfs/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "@vercel/backends/zod": ["zod@3.22.4", "", {}, "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="],
 
@@ -1759,8 +1856,6 @@
 
     "archiver-utils/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
-    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
-
     "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "bun-types/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
@@ -1781,13 +1876,31 @@
 
     "engine.io-client/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "express/content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "express/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
+    "fast-xml-builder/path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
+
+    "fast-xml-builder/xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
+
+    "fast-xml-parser/@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
+
+    "fast-xml-parser/path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
+
+    "fast-xml-parser/strnum": ["strnum@2.4.2", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw=="],
+
+    "fast-xml-parser/xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
+
     "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "http-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "https-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -1839,13 +1952,13 @@
 
     "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
-
     "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "yauzl/buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "@actions/artifact/@actions/core/@actions/exec": ["@actions/exec@3.0.0", "", { "dependencies": { "@actions/io": "^3.0.2" } }, "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw=="],
 
     "@computesdk/modal/modal/smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
@@ -1855,9 +1968,17 @@
 
     "@mapbox/node-pre-gyp/https-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "@octokit/plugin-retry/@octokit/request-error/@octokit/types": ["@octokit/types@18.0.0", "", { "dependencies": { "@octokit/openapi-types": "^29.0.1" } }, "sha512-l6bAF43PNxkJp6g+W4PjoUSSkxHomXw2nOum5CTftJz1NlV3vu93NImgOYtLf6CbBUb5j+fiuzW0PPQ5JTSvZA=="],
+
+    "@octokit/plugin-retry/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@28.0.0", "", {}, "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ=="],
+
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
 
     "@types/node-fetch/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "@typespec/ts-http-runtime/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "@typespec/ts-http-runtime/https-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "@vercel/rust/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
@@ -1898,6 +2019,10 @@
     "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "@actions/artifact/@actions/core/@actions/exec/@actions/io": ["@actions/io@3.0.2", "", {}, "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="],
+
+    "@octokit/plugin-retry/@octokit/request-error/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@29.0.1", "", {}, "sha512-9qWOMFNxxLokERcms42rU0PTLqQmVs7g5E41TI4mCOxmpFayD1rfC7XxOL55cG9MBZLFlC31BrR37myMKardwg=="],
 
     "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/docs/adr/0004-consumption-layer-aggregation.md
+++ b/docs/adr/0004-consumption-layer-aggregation.md
@@ -4,6 +4,9 @@ status: accepted
 
 # Raw-first history, consumption-layer candidate→promote
 
+The publication threshold below is superseded by [ADR-0010](./0010-experiment-completeness.md).
+Its raw-first history and candidate→promote decisions remain in force.
+
 ## Context
 
 A benchmark run is produced by the CI matrix as one Run document per `(provider, suite)` shard. Those

--- a/docs/adr/0010-experiment-completeness.md
+++ b/docs/adr/0010-experiment-completeness.md
@@ -1,0 +1,39 @@
+---
+status: accepted
+---
+
+# Frozen experiments and evidence-based publication
+
+## Decision
+
+An experiment plan owns the expected provider, suite, replicate, metric, revision, artifact, resource,
+pass-policy and exclusion set. Account capacity and phase budgets determine bounded batches without
+reducing the replicate count. Unknown sandbox capacity defaults to one; GPU allocation requires an
+explicit GPU capacity. Provider variants using the same credentials share one quota domain.
+
+Plans and execution attempts have separate identities. Plan digests bind attempts to the original
+request. Raw-tree and Run digests bind a terminal receipt to its original observations. Interrupted
+launch intents cannot serve as terminal receipts. Whole-attempt selection is deterministic; conflicting
+duplicates, measured reruns, unresolved cleanup, unknown command completion and missing eligible metrics
+prevent publication. Premeasurement retries require an explicit finite allowance in the original plan.
+
+This supersedes **only the “at least one validated provider” publication rule** in ADR-0004. Raw-first
+history, re-normalization, and candidate→promote remain. Historical `validationStatus` keeps its meaning;
+experiment completeness is a separate evaluation. Run schema 7 links a complete experiment to its plan
+and selected attempts. Older Runs remain readable, with unverified experiment completeness.
+
+CLI composition owns planning, coordination and publication. Drivers own vendor inventory, allocation,
+authentication and recovery semantics. The harness owns command execution, completion observation and
+collection, preserving ADR-0007. GitHub account queues provide job exclusion; they do not establish
+cleanup or replace vendor reconciliation. No artifact is an allocation lock.
+
+Exclusions are revision-specific, metric-scoped, owned, linked to a tracking issue and time-limited.
+Their eligibility set must be uniform across a comparison cohort. Aggregation excludes quarantined
+metrics from scores while retaining the original attempt evidence. A new plan cannot retroactively
+change an old experiment's denominator.
+
+## Rollout
+
+See [implementation and rollout status](../benchmark-execution-rollout.md). The pure contracts are not
+proof of live provider conformance. Strict publication rejects legacy candidates without a manifest;
+production dispatch must be migrated to emit and execute the manifest before publication can resume.

--- a/docs/adr/0010-experiment-completeness.md
+++ b/docs/adr/0010-experiment-completeness.md
@@ -36,4 +36,24 @@ change an old experiment's denominator.
 
 See [implementation and rollout status](../benchmark-execution-rollout.md). The pure contracts are not
 proof of live provider conformance. Strict publication rejects legacy candidates without a manifest;
-production dispatch must be migrated to emit and execute the manifest before publication can resume.
+production dispatch now emits and executes manifests, with live publication requiring account admission
+and complete verified attempts.
+
+## Durable account journal integration
+
+Account queues alone cannot detect an interrupted create that has not yet appeared in inventory.
+Before create, CLI composition appends an intent to a protected, account-specific GitHub journal
+branch. After create returns it appends the sandbox reference; release requires observed absence.
+Unknown creates block admission. Updates are fast-forward only and existing records cannot be
+replaced. Independent accounts use different branches; concurrent cells serialize journal appends.
+
+This is an evidence log using GitHub's existing Git storage, not a distributed quota or lease service.
+Actions artifacts remain immutable attempt archives, but cannot serve as the only ownership journal:
+expiry or deletion could erase an unresolved intent. The operational cost is protected journal branch
+provisioning and narrowly scoped write permission on the privileged worker. A missing branch fails
+closed; it never authorizes an empty account. Legacy allocating paths must use separate accounts until
+they adopt the owner. Account-wide capacity is guaranteed only after that admission condition holds.
+
+See [GitHub's reference API](https://docs.github.com/en/rest/git/refs) for fast-forward ref updates and
+[tree API](https://docs.github.com/en/rest/git/trees) for complete tree enumeration. Truncated histories
+and competing ref updates fail admission rather than discarding ownership facts.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,4 @@ here changes, supersede the ADR (leave it in place, note what replaced it) rathe
 | [0007](./0007-sandbox-driver-port.md) | Sandbox driver kit: one port, one file per provider; ComputeSDK as one driver |
 | [0008](./0008-driver-conformance-gate.md) | Driver conformance: the behavioral drift gate |
 | [0009](./0009-harness-operations-and-gpu-allocation.md) | Separate harness operations and typed provider-specific GPU allocation |
+| [0010](./0010-experiment-completeness.md) | Frozen experiments, immutable attempts and strict completeness |

--- a/docs/benchmark-execution-rollout.md
+++ b/docs/benchmark-execution-rollout.md
@@ -12,7 +12,9 @@ This is an implementation status record, not a claim that the live fleet meets t
   conflicting attempts, unapproved retries, missing metrics and unknown cleanup block completeness.
 - File-boundary verification of normalized and raw digests; atomic, no-overwrite JSON publication.
 - Account concurrency groups shared by benchmark/smoke, toolchain validation, and Modal GPU jobs,
-  with `queue: max` and no cancellation of running work.
+  with `queue: max` and no cancellation of running work. The per-cell group expression is generated
+  from each provider's registry `quotaDomain` (`bun run generate-provider-wiring`), the same lookup
+  that names the plan's batches and the journal branch.
 - Required-provider admission in the shared benchmark workflow. A failed Namespace credential setup
   can still reach normalization, but cannot produce a green all-skipped provider job.
 - Separate workflow-attempt artifact names, unconditional diagnostic upload, and upload paths limited

--- a/docs/benchmark-execution-rollout.md
+++ b/docs/benchmark-execution-rollout.md
@@ -1,0 +1,104 @@
+# Benchmark execution rollout
+
+This is an implementation status record, not a claim that the live fleet meets the new contract.
+
+## Implemented
+
+- Schema 1 experiment plans and attempt receipts; schema 7 Run linkage with historical Run readers.
+- Pure `planExperiment`: unchanged logical replicate identities, default capacity one, CPU/RAM/GPU
+  limits, phase budgets plus one 15-minute host margin, 180-minute batch ceiling, collection rounds
+  of at most 256 batches, and uniform reviewed exclusions. Retries default to zero.
+- Pure coverage evaluation and deterministic whole-attempt aggregation. Missing work, bad provenance,
+  conflicting attempts, unapproved retries, missing metrics and unknown cleanup block completeness.
+- File-boundary verification of normalized and raw digests; atomic, no-overwrite JSON publication.
+- Account concurrency groups shared by benchmark/smoke, toolchain validation, and Modal GPU jobs,
+  with `queue: max` and no cancellation of running work.
+- Required-provider admission in the shared benchmark workflow. A failed Namespace credential setup
+  can still reach normalization, but cannot produce a green all-skipped provider job.
+- Separate workflow-attempt artifact names, unconditional diagnostic upload, and upload paths limited
+  to this run's raw data and shards. Existing attempts are never overwritten.
+- Atomic identity-bound detached command receipts in the shared step runner. Launch, polling and
+  readback are bounded; execution and cleanup evidence is retained in the raw directory.
+- Explicit bounded diagnostic projection with credential redaction and primary/cleanup failure
+  preservation. Tama authentication is serialized across driver contexts; a failed post-login list
+  retains its vendor diagnostic without triggering another login.
+- Native command projections retain their errors until the shared redaction boundary, instead of
+  replacing them with a generic callback failure. Regression tests cover both exec and launch.
+- A narrow complete-inventory driver capability and Tama ownership projection. Account reconciliation
+  validates all variant inventories before deletion, requires observed absence after deletion, and
+  checks every inventory again before admission. Unavailable inventory, foreign resources, cancellation,
+  timeout, or new allocations block admission. This module is not yet wired into fleet dispatch.
+- Strict `promote` requires the original plan and attempt directories and independently reconstructs
+  the candidate before writing the dataset. Legacy Runs remain available for validation and reading.
+- Publication verifies identity-bound execution and cleanup receipts, including observed absence,
+  benchmark and collection completion, and sandbox attribution. Matching byte digests alone do not
+  satisfy the gate. Unterminated allocation intents also block publication.
+- Aggregation selects only planned eligible measurements. Published Runs carry a comparison cohort
+  digest covering workload/environment revisions, passes, resources and eligible metrics; leaderboard
+  output displays it. Legacy aggregation refuses to merge completed experiment Runs and discard their
+  linkage.
+- Launch-settlement timeouts now collect diagnostic tails through the same recovery path as polling
+  timeouts. Unreadable output has an unknown cause, not an inferred memory or agent failure.
+- Raw exception formatting in the reviewed CLI and collection failure sinks uses diagnostic projection.
+  Failed teardown fails suite execution; driver-session execution observes absence after destruction.
+  Implicit create retries default to zero. Explicit retries cannot follow an owner timeout or unresolved
+  failed-create cleanup.
+
+## Important current limitation
+
+**The existing matrix dispatcher does not yet produce or execute the new experiment manifest. Its
+dataset publication therefore fails closed.** Account queues limit overlapping jobs, but the legacy
+per-job replicate fleet still requires migration to planned batches. Queueing alone does not enforce
+the new sandbox/resource budgets or establish cleanup after runner loss.
+
+Do not enable fleet publication by bypassing the manifest requirement or synthesizing receipts from
+green GitHub jobs. A launch receipt, valid XML, and “All tasks passed” are insufficient evidence.
+
+## Remaining rollout work
+
+1. Wire immutable plan creation, account-domain batch dispatch and incremental attempt uploads into
+   matrix/smoke and publication workflows. Bind each worker's actual resolved environment and artifact
+   to the plan before allocation. Keep batch matrices sequential within each quota domain.
+2. Add driver inventory/reconciliation and move remaining managed adapters onto the driver port.
+   Cancellation and ambiguous creates must retain ownership until observed removal or confirmed expiry.
+   Direct development credentials must stay separate from coordinated publication credentials.
+   The initial Tama inventory and reconciliation implementation still needs durable allocation intents,
+   cross-job recovery history, and the remaining vendor inventories. An empty scan by itself cannot
+   prove that an interrupted create request will not allocate later.
+3. Reproduce E2B launch/descendant/filesystem/exec behaviors and Daytona's nested launch failure through
+   the shared executor. The new receipt implementation is not yet a verified fix for the six live E2B
+   timeouts. Compare isolated and bounded concurrent Microsandbox startup before changing readiness.
+4. Restore the Namespace GitHub App association for `starslingdev`; this is external account setup.
+5. Reproduce and version workload repairs: OpenClaw shrinkwrap quarantine, descriptor exhaustion and
+   resource failures; Mastra HOME/path behavior; fixed two-pass CPU/memory publication; lossless PTS
+   fio serialization. Do not remove failing tests, fabricate missing values, or adjust values to evade
+   deduplication. Admit revised workloads only after baseline and two different provider environments.
+6. Run privileged provider conformance and canaries, then collect a fresh complete experiment. Preserve
+   run 34437329093 as diagnostic history.
+
+## Commands
+
+Local verification after the correctness follow-up: 2,047 repository tests pass. Typecheck, Biome, spelling, catalog/registry/wiring
+drift checks, ShellCheck, Hadolint, queue-compatible actionlint and the configured offline zizmor gate
+pass. Live provider conformance and workload admission have not been run for these changes.
+
+```sh
+bun apps/cli/src/bin/plan-experiment.ts request.json plan.json capacity-policy.json
+bun apps/cli/src/bin/evaluate-experiment.ts plan.json attempt-directory
+bun apps/cli/src/bin/aggregate-experiment.ts plan.json attempts-root candidate-directory
+bun apps/cli/src/bin/promote.ts candidate-directory/runs/experiment-id.json data/dataset plan.json attempts-root
+```
+
+The planner accepts explicit versioned requests. It does not infer credential ownership or turn
+arbitrary legacy artifacts into completion evidence. An attempt directory contains `attempt.json`,
+its optional `run.json`, and its original `raw/` tree. All failed attempts in a retry lineage must be
+present. Inspection does not allocate resources or contact providers.
+
+## Workflow linter compatibility
+
+GitHub documents `queue: max`, but actionlint 1.7.12 and upstream revision
+`011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7` do not parse that property. `bun run lint:workflows`
+first validates every queue configuration, then suppresses only actionlint's exact unsupported-queue
+diagnostic. Tests reject invalid values and cancellation and check shared account group identity.
+All other actionlint rules remain enabled. Replace this compatibility path with a mise-pinned upstream
+release when it supports queues; do not broadly ignore workflow syntax errors.

--- a/docs/benchmark-execution-rollout.md
+++ b/docs/benchmark-execution-rollout.md
@@ -27,7 +27,7 @@ This is an implementation status record, not a claim that the live fleet meets t
 - A narrow complete-inventory driver capability and Tama ownership projection. Account reconciliation
   validates all variant inventories before deletion, requires observed absence after deletion, and
   checks every inventory again before admission. Unavailable inventory, foreign resources, cancellation,
-  timeout, or new allocations block admission. This module is not yet wired into fleet dispatch.
+  timeout, or new allocations block admission. It is called once by each account-owned batch before allocation.
 - Strict `promote` requires the original plan and attempt directories and independently reconstructs
   the candidate before writing the dataset. Legacy Runs remain available for validation and reading.
 - Publication verifies identity-bound execution and cleanup receipts, including observed absence,
@@ -44,27 +44,58 @@ This is an implementation status record, not a claim that the live fleet meets t
   Implicit create retries default to zero. Explicit retries cannot follow an owner timeout or unresolved
   failed-create cleanup.
 
-## Important current limitation
+## Integrated execution
 
-**The existing matrix dispatcher does not yet produce or execute the new experiment manifest. Its
-dataset publication therefore fails closed.** Account queues limit overlapping jobs, but the legacy
-per-job replicate fleet still requires migration to planned batches. Queueing alone does not enforce
-the new sandbox/resource budgets or establish cleanup after runner loss.
+Matrix and smoke now freeze one immutable plan and dispatch account → collection round → batch.
+Every allocating worker verifies the plan and source revision, reconciles its account once, and runs
+one bounded wave through the existing harness and normalizer. The account and round matrices use
+`max-parallel: 1`; independent accounts can proceed together. Fixed suite defaults and replicate
+indices are preserved. Convergence is rejected by publication planning until its separately reviewed
+measurement revision is admitted; an explicit fixed-pass input is part of the workload identity.
 
-Do not enable fleet publication by bypassing the manifest requirement or synthesizing receipts from
-green GitHub jobs. A launch receipt, valid XML, and “All tasks passed” are insufficient evidence.
+Each attempt uploads independently. The dataset workflow downloads the original plan and complete
+attempt directories, checks durable allocation/release records, and invokes strict aggregate/promote.
+Lost terminal uploads leave durable intents that block publication. Workflow reruns reuse the frozen
+plan and refuse to measure an already attempted cell again; start a fresh experiment instead of
+selecting a favorable rerun. Automatic allocation retries remain disabled.
+
+## Account admission before live rollout
+
+The durable journal uses a separate Git branch per quota domain:
+`benchmark-account-journal-<domain>`. It records immutable intent, allocation and release records with
+fast-forward-only commits. It is evidence storage, not a lease or an artifact allocation claim;
+GitHub account concurrency remains the exclusive scheduling authority. Raw evidence stays in Actions
+artifacts. Missing/truncated journals, unresolved creates and unconfirmed removal block allocation.
+
+Each branch starts with `journal.json` containing `{"schemaVersion":"1","account":"<domain>","records":[]}`.
+The file is an append-only record sequence; immutable Git commits retain every prior snapshot. Reading
+one blob avoids a REST request per historical record on every new batch.
+
+An operator must provision these branches after quiescing existing account writers and confirming a
+clean vendor baseline. Protect them against deletion and force pushes, retain their history, and
+permit the privileged workflow token to append commits. Do not reset a journal to recover an account.
+For an unknown create, obtain the vendor's request outcome and resource identity before recording
+recovery; an empty inventory is insufficient. No branch is automatically created or reset by a worker.
+The allocating workflow needs `contents: write` for this narrow journal update; checkouts still do not
+persist credentials. Accounts without this setup fail admission before allocation.
+
+Managed admission currently requires a migrated driver with complete inventory, observation and
+recovery. Tama supplies that capability; other provider migrations remain separate rollout work.
+Selected unsupported providers produce failed attempt evidence, never green skips. Toolchain and GPU
+jobs share the account queues but still have legacy allocation paths: keep their credentials in
+separate development accounts until those paths adopt the same journal owner. Sharing a queue alone
+is not a guarantee against an interrupted legacy create. Do not admit a publication account with
+uncoordinated legacy writers or direct development credentials.
+
+Publication remains gated on complete evidence and live admission. No provider canary or workload
+baseline result has been inferred from offline tests.
 
 ## Remaining rollout work
 
-1. Wire immutable plan creation, account-domain batch dispatch and incremental attempt uploads into
-   matrix/smoke and publication workflows. Bind each worker's actual resolved environment and artifact
-   to the plan before allocation. Keep batch matrices sequential within each quota domain.
-2. Add driver inventory/reconciliation and move remaining managed adapters onto the driver port.
-   Cancellation and ambiguous creates must retain ownership until observed removal or confirmed expiry.
-   Direct development credentials must stay separate from coordinated publication credentials.
-   The initial Tama inventory and reconciliation implementation still needs durable allocation intents,
-   cross-job recovery history, and the remaining vendor inventories. An empty scan by itself cannot
-   prove that an interrupted create request will not allocate later.
+1. Provision protected account journals and run the integrated privileged canary. Confirm artifact
+   upload/download and Git journal permissions in the actual Actions environment.
+2. Add complete inventories to remaining provider drivers and migrate legacy allocating paths,
+   including GPU and toolchain validation, onto the account owner before sharing publication accounts.
 3. Reproduce E2B launch/descendant/filesystem/exec behaviors and Daytona's nested launch failure through
    the shared executor. The new receipt implementation is not yet a verified fix for the six live E2B
    timeouts. Compare isolated and bounded concurrent Microsandbox startup before changing readiness.
@@ -78,9 +109,12 @@ green GitHub jobs. A launch receipt, valid XML, and “All tasks passed” are i
 
 ## Commands
 
-Local verification after the correctness follow-up: 2,047 repository tests pass. Typecheck, Biome, spelling, catalog/registry/wiring
-drift checks, ShellCheck, Hadolint, queue-compatible actionlint and the configured offline zizmor gate
-pass. Live provider conformance and workload admission have not been run for these changes.
+Offline integration tests cross the real harness, raw collector, normalizer and completeness evaluator.
+They cover account caps, cleanup failure, rerun refusal, missing uploads, interrupted intents, journal
+conflicts and matrix partitioning. Live provider conformance and workload admission remain separate.
+
+Final local verification: 2,042 tests pass, with typecheck, Biome, spelling, generated catalog/registry/
+wiring checks, ShellCheck, Hadolint, queue-compatible actionlint and configured offline zizmor passing.
 
 ```sh
 bun apps/cli/src/bin/plan-experiment.ts request.json plan.json capacity-policy.json

--- a/docs/benchmark-execution-rollout.md
+++ b/docs/benchmark-execution-rollout.md
@@ -55,7 +55,10 @@ one bounded wave through the existing harness and normalizer. The account and ro
 indices are preserved. Convergence is rejected by publication planning until its separately reviewed
 measurement revision is admitted; an explicit fixed-pass input is part of the workload identity.
 
-Each attempt uploads independently. The dataset workflow downloads the original plan and complete
+Each attempt uploads independently. The CLI performs those uploads (and the plan's) through
+`@actions/artifact`, which needs the run-scoped artifact runtime GitHub injects only into action
+steps, so the plan and bench jobs first run `.github/actions/artifact-runtime`; a `run:` step without
+it fails at its first upload. Downloads need no runtime. The dataset workflow downloads the original plan and complete
 attempt directories, checks durable allocation/release records, and invokes strict aggregate/promote.
 Lost terminal uploads leave durable intents that block publication. Workflow reruns reuse the frozen
 plan and refuse to measure an already attempted cell again; start a fresh experiment instead of

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "smoke": "bun --filter @sandbox-benchmarks/cli smoke",
     "format": "biome format . --write",
     "lint": "biome check . --error-on-warnings",
+    "lint:workflows": "bun tooling/repo-checks/src/lint-workflows.ts",
     "lint:fix": "biome check . --write",
     "lint:fix:unsafe": "biome check . --fix --unsafe",
     "lint:shell": "find packages/templates/images packages/schema/src/pts-profiles lib .mise/tasks -type f \\( -name '*.sh' -o -path '*.mise/tasks/*' \\) -exec mise exec -- shellcheck {} + && scripts/lint-action-shell.sh $(find .github/actions -name 'action.y*ml')",

--- a/packages/driver/src/architecture.test.ts
+++ b/packages/driver/src/architecture.test.ts
@@ -34,6 +34,7 @@ describe("driver package boundaries", () => {
 			"index.ts",
 			"lib/accelerator.ts",
 			"lib/define.ts",
+			"lib/diagnostics.ts",
 			"lib/errors.ts",
 			"lib/output.ts",
 			"lib/policy.ts",

--- a/packages/driver/src/cli.ts
+++ b/packages/driver/src/cli.ts
@@ -41,6 +41,9 @@ export interface CliRunResult {
 	readonly code: number;
 }
 
+// CLI profile files are process-shared even when separate driver contexts are opened.
+const preparationLocks = new Map<string, Promise<void>>();
+
 export interface CliRunOptions {
 	/** Hard subprocess budget. Runners MUST terminate the child before rejecting on timeout. */
 	readonly timeoutMs: number;
@@ -274,10 +277,12 @@ function snapshotCliSpec<Row>(provider: ProviderId, spec: CliSpec<Row>): CliSpec
 			createCommandTimeoutMs: Reflect.get(spec, "createCommandTimeoutMs"),
 			requestCoverage: snapshotCliCoverage(Reflect.get(spec, "requestCoverage")),
 			create: Reflect.get(spec, "create"),
+			inventoryOwned: Reflect.get(spec, "inventoryOwned"),
 			...(prepared === undefined
 				? {}
 				: {
 						prepare: {
+							authenticateFirst: Reflect.get(prepared, "authenticateFirst"),
 							probe: Reflect.get(prepared, "probe"),
 							fallback: Reflect.get(prepared, "fallback"),
 						},
@@ -459,6 +464,8 @@ const CLI_REQUEST_COVERAGE_AXES = {
 } as const satisfies Record<keyof CliCreateRequestCoverage, true>;
 
 export interface CliSpec<Row> {
+	/** Opt-in ownership predicate for the complete readiness-list response. No pagination may be omitted. */
+	readonly inventoryOwned?: (row: Row) => boolean;
 	/** Resolved binary path or name (the caller applies any env override). */
 	readonly binary: string;
 	/** Flags whose FOLLOWING argv value is a secret: redacted from every diagnostic. */
@@ -473,6 +480,8 @@ export interface CliSpec<Row> {
 	readonly create: (request: CreateRequest, name: string) => CliArgv;
 	/** Optional pre-create probe with a fallback action (for profile-based CLI authentication). */
 	readonly prepare?: {
+		/** Authenticate once before probing; avoids mistaking every list failure for bad credentials. */
+		readonly authenticateFirst?: boolean;
 		/** Must exit zero and parse through the readiness-row schema to count as prepared. */
 		readonly probe: CliArgv;
 		/** Checked fallback command, commonly `login --token …`; secret flags still redact it. */
@@ -964,6 +973,11 @@ export function cliMethodTable<Row>(
 	const run = (normalizedOptions.run as CliRunner | undefined) ?? defaultRunner;
 	const createAttemptCeilingMs = normalizedOptions.createAttemptCeilingMs;
 	const compiled = snapshotCliSpec(provider, spec);
+	const inventoryOwned = compiled.inventoryOwned;
+	if (inventoryOwned !== undefined && typeof inventoryOwned !== "function")
+		throw new DriverError("vendor-contract-violation", "CLI inventoryOwned must be callable", {
+			provider,
+		});
 	validateCliCoverage(provider, compiled.requestCoverage);
 	if (typeof compiled.binary !== "string" || compiled.binary.trim() === "") {
 		throw new DriverError("vendor-contract-violation", `${provider} CLI binary must be nonempty`, {
@@ -983,10 +997,20 @@ export function cliMethodTable<Row>(
 	const isRetryableCreate = compiled.isRetryableCreate;
 	const secretFlags = normalizeCliStringList(provider, "secretFlags", compiled.secretFlags);
 	const readyPoll = normalizeCliArgv(provider, "ready.poll", ready.poll);
+	if (
+		compiled.prepare?.authenticateFirst !== undefined &&
+		typeof compiled.prepare.authenticateFirst !== "boolean"
+	)
+		throw new DriverError(
+			"vendor-contract-violation",
+			"prepare.authenticateFirst must be boolean",
+			{ provider },
+		);
 	const prepare =
 		compiled.prepare === undefined
 			? undefined
 			: {
+					authenticateFirst: compiled.prepare.authenticateFirst === true,
 					probe: normalizeCliArgv(provider, "prepare.probe", compiled.prepare.probe),
 					fallback: normalizeCliArgv(provider, "prepare.fallback", compiled.prepare.fallback),
 				};
@@ -1146,7 +1170,7 @@ export function cliMethodTable<Row>(
 			provider,
 		});
 
-	const ensurePrepared = async (
+	const performPreparation = async (
 		remaining: () => number,
 		deadlineMs: number,
 		signal?: AbortSignal,
@@ -1154,22 +1178,24 @@ export function cliMethodTable<Row>(
 		if (prepare === undefined) return;
 		const probeBudget = remaining();
 		if (probeBudget < 1) throw createDeadlineError(deadlineMs);
-		let probed: CliRunResult;
-		try {
-			probed = await call(prepare.probe, Math.min(probeBudget, commandTimeoutMs), signal);
-		} catch (caught) {
-			if (isCliRunTimeoutError(caught) && probeBudget <= commandTimeoutMs) {
-				throw createDeadlineError(deadlineMs);
+		if (!prepare.authenticateFirst) {
+			let probed: CliRunResult;
+			try {
+				probed = await call(prepare.probe, Math.min(probeBudget, commandTimeoutMs), signal);
+			} catch (caught) {
+				if (isCliRunTimeoutError(caught) && probeBudget <= commandTimeoutMs) {
+					throw createDeadlineError(deadlineMs);
+				}
+				// A transport, cancellation, timeout, or runner-contract failure says nothing about the
+				// profile. Only a completed nonzero probe may authorize the state-changing fallback.
+				throw runnerFailed("create-failed", prepare.probe, caught);
 			}
-			// A transport, cancellation, timeout, or runner-contract failure says nothing about the
-			// profile. Only a completed nonzero probe may authorize the state-changing fallback.
-			throw runnerFailed("create-failed", prepare.probe, caught);
-		}
-		if (probed.code === 0) {
-			// Exit zero already proves authentication. Schema drift is not repaired by overwriting a
-			// developer's working profile, so surface it through the normal trust-boundary error.
-			parseRows(probed, [prepare.probe]);
-			return;
+			if (probed.code === 0) {
+				// Exit zero already proves authentication. Schema drift is not repaired by overwriting a
+				// developer's working profile, so surface it through the normal trust-boundary error.
+				parseRows(probed, [prepare.probe]);
+				return;
+			}
 		}
 
 		const fallbackBudget = remaining();
@@ -1204,6 +1230,28 @@ export function cliMethodTable<Row>(
 			throw vendorFailed("create-failed", prepare.probe, verified);
 		}
 		parseRows(verified, [prepare.probe]);
+	};
+
+	const ensurePrepared = (
+		remaining: () => number,
+		deadlineMs: number,
+		signal?: AbortSignal,
+	): Promise<void> => {
+		if (!prepare?.authenticateFirst) return performPreparation(remaining, deadlineMs, signal);
+		const prior = preparationLocks.get(binary) ?? Promise.resolve();
+		const next = prior
+			.catch(() => undefined)
+			.then(() => {
+				if (signal?.aborted) throw signal.reason ?? new Error("CLI preparation cancelled");
+				return performPreparation(remaining, deadlineMs, signal);
+			});
+		preparationLocks.set(binary, next);
+		void next
+			.finally(() => {
+				if (preparationLocks.get(binary) === next) preparationLocks.delete(binary);
+			})
+			.catch(() => undefined);
+		return next;
 	};
 	const ensurePreparedOnce = (
 		context: CliDriverContext,
@@ -1817,6 +1865,45 @@ export function cliMethodTable<Row>(
 					: { state: "terminal" as const };
 			},
 		},
+		...(inventoryOwned
+			? {
+					inventory: {
+						list: async (context: CliDriverContext, operationOptions?: DriverOperationOptions) => {
+							const started = Date.now();
+							await ensurePreparedOnce(
+								context,
+								() => commandTimeoutMs - (Date.now() - started),
+								commandTimeoutMs,
+								operationOptions?.signal,
+							);
+							let result: CliRunResult;
+							try {
+								result = await call(readyPoll, commandTimeoutMs, operationOptions?.signal);
+							} catch (error) {
+								throw runnerFailed("probe-failed", readyPoll, error);
+							}
+							if (result.code !== 0) throw vendorFailed("probe-failed", readyPoll, result);
+							const rows = parseRows(result, [readyPoll]);
+							const owned: SandboxRef[] = [];
+							let foreignCount = 0;
+							for (const row of rows) {
+								const owns: unknown = providerCallback("inventory ownership", () =>
+									inventoryOwned(row),
+								);
+								if (typeof owns !== "boolean")
+									throw new DriverError(
+										"vendor-contract-violation",
+										"inventory ownership must be boolean",
+										{ provider },
+									);
+								if (owns) owned.push(sandboxRef(provider, sandboxIdOf(row, [readyPoll])));
+								else foreignCount++;
+							}
+							return { owned, foreignCount };
+						},
+					},
+				}
+			: {}),
 		// No files, no launch: absent, not stubbed — the harness fallbacks (shell.ts) cover both.
 	};
 }

--- a/packages/driver/src/env.ts
+++ b/packages/driver/src/env.ts
@@ -2,6 +2,7 @@
 // and arktype separate from the root driver-kit surface. Both the compile-time slice (define.ts)
 // and this parser derive from REGISTRY[id].inputs, so type and validator cannot drift.
 
+import { PROVIDER_IDS } from "@sandbox-benchmarks/schema/provider-ids";
 import { normalizeProviderInput } from "@sandbox-benchmarks/schema/provider-meta";
 import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
 import { REGISTRY } from "@sandbox-benchmarks/schema/providers";
@@ -99,7 +100,7 @@ export function missingDriverEnvNames<P extends ProviderId>(
  */
 export function sensitiveEnvValuesFor<P extends ProviderId>(
 	id: P,
-	env: EnvOf<P>,
+	env: Readonly<Record<string, string | undefined>>,
 ): readonly string[] {
 	const values: string[] = [];
 	const resolved = env as Readonly<Record<string, string | undefined>>;
@@ -110,4 +111,15 @@ export function sensitiveEnvValuesFor<P extends ProviderId>(
 		if (value !== undefined && value.length > 0) values.push(value);
 	}
 	return values;
+}
+
+/** Explicit credential registry plus the repository-clone credentials used by the harness. */
+export function diagnosticSecretsFromEnv(
+	env: Readonly<Record<string, string | undefined>>,
+): readonly string[] {
+	const values = [env.BENCH_REPO_TOKEN, env.GITHUB_TOKEN, env.GH_TOKEN].filter(
+		(value): value is string => Boolean(value),
+	);
+	for (const provider of PROVIDER_IDS) values.push(...sensitiveEnvValuesFor(provider, env));
+	return [...new Set(values)];
 }

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -23,6 +23,7 @@ export type {
 	ResolvedArtifactOf,
 } from "./lib/define.ts";
 export { defineDriver } from "./lib/define.ts";
+export { describeDriverFailure, redactDiagnosticText } from "./lib/diagnostics.ts";
 
 export type {
 	DriverErrorCode,
@@ -62,6 +63,8 @@ export type {
 	ExecResult,
 	Exit,
 	GpuSpec,
+	InventoryCapability,
+	InventorySnapshot,
 	ResolvedArtifact,
 	SandboxDriver,
 	SandboxFiles,

--- a/packages/driver/src/lib/define.ts
+++ b/packages/driver/src/lib/define.ts
@@ -118,7 +118,7 @@ export interface DriverModule<P extends ProviderId, Handle = unknown>
 function driverMember(
 	provider: ProviderId,
 	driver: object,
-	member: "create" | "destroyById" | "probes" | "snapshots",
+	member: "create" | "destroyById" | "probes" | "snapshots" | "inventory",
 ): unknown {
 	try {
 		return Reflect.get(driver, member);
@@ -199,6 +199,7 @@ function policyGuardedDriver<P extends ProviderId, Handle>(
 	}
 	const probes = driverMember(provider, raw, "probes") as SandboxDriver<Handle>["probes"];
 	const snapshots = driverMember(provider, raw, "snapshots") as SandboxDriver<Handle>["snapshots"];
+	const inventory = driverMember(provider, raw, "inventory") as SandboxDriver<Handle>["inventory"];
 	return Object.freeze({
 		async create(request: CreateRequest, options?: DriverOperationOptions) {
 			if (request.gpu !== undefined && policy.accelerator === undefined) {
@@ -231,6 +232,7 @@ function policyGuardedDriver<P extends ProviderId, Handle>(
 				}),
 		...(probes === undefined ? {} : { probes }),
 		...(snapshots === undefined ? {} : { snapshots }),
+		...(inventory === undefined ? {} : { inventory }),
 	});
 }
 

--- a/packages/driver/src/lib/diagnostics.test.ts
+++ b/packages/driver/src/lib/diagnostics.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import { describeDriverFailure, redactDiagnosticText } from "./diagnostics.ts";
+import { DriverError, FailedCreateCleanupError } from "./errors.ts";
+
+test("retains driver-projected vendor diagnostics and ignores arbitrary SDK fields", () => {
+	const failure = new DriverError("create-failed", "tama new: exit 1", {
+		vendorMessage: "capacity exhausted; token <REDACTED>",
+		vendorExitCode: 1,
+		vendorHttpStatus: 429,
+	});
+	Object.assign(failure, { headers: { authorization: "sentinel-secret" } });
+	const message = describeDriverFailure(failure);
+	expect(message).toContain("capacity exhausted");
+	expect(message).toContain("HTTP 429");
+	expect(message).not.toContain("sentinel-secret");
+});
+
+test("preserves primary and cleanup failures without traversing untrusted causes", () => {
+	const primary = new DriverError("create-failed", "create refused", {
+		vendorMessage: "no capacity",
+	});
+	const failure = new FailedCreateCleanupError(new Error("delete unavailable"), primary, {
+		provider: "tama",
+		locator: { kind: "name", value: "benchmark-test" },
+		cleanup: async () => {},
+	});
+	expect(describeDriverFailure(failure)).toBe(
+		"create refused; no capacity; cleanup failed: delete unavailable",
+	);
+	expect(describeDriverFailure(new Error("safe", { cause: { token: "secret" } }))).toBe("safe");
+});
+
+test("caps vendor diagnostics", () => {
+	expect(
+		describeDriverFailure(
+			new DriverError("create-failed", "failed", { vendorMessage: "x".repeat(20000) }),
+		).length,
+	).toBeLessThanOrEqual(8192);
+});
+
+test("redacts registered secrets before truncation in primary and cleanup projections", () => {
+	const secret = "sentinel/token+secret-value";
+	const primary = new DriverError("create-failed", `request ${secret}`, {
+		vendorMessage: `x${" ".repeat(8170)}${secret}`,
+	});
+	const failure = new FailedCreateCleanupError(
+		new Error(`cleanup ${encodeURIComponent(secret)}`),
+		primary,
+		{
+			provider: "tama",
+			locator: { kind: "name", value: "benchmark-test" },
+			cleanup: async () => {},
+		},
+	);
+	const message = describeDriverFailure(failure, [secret]);
+	expect(message).not.toContain("sentinel");
+	expect(message).not.toContain("secret-value");
+	expect(message).toContain("<REDACTED>");
+	expect(redactDiagnosticText(`Bearer unknown-token ${secret}`, [secret])).toBe(
+		"Bearer <REDACTED> <REDACTED>",
+	);
+	expect(describeDriverFailure({ toString: () => secret }, [secret])).toBe("Unknown failure");
+});

--- a/packages/driver/src/lib/diagnostics.ts
+++ b/packages/driver/src/lib/diagnostics.ts
@@ -1,0 +1,44 @@
+import { isDriverError, isFailedCreateCleanupError } from "./errors.ts";
+
+/** Render only the driver-owned diagnostic projection, never arbitrary SDK object fields. */
+export function describeDriverFailure(error: unknown, secrets: readonly string[] = []): string {
+	const seen = new Set<unknown>();
+	const describe = (value: unknown, depth: number): string => {
+		if (depth > 4 || seen.has(value)) return "diagnostic chain truncated";
+		seen.add(value);
+		if (isFailedCreateCleanupError(value)) {
+			return `${describe(value.suppressed, depth + 1)}; cleanup failed: ${describe(value.error, depth + 1)}`;
+		}
+		if (isDriverError(value)) {
+			const parts = [value.message];
+			if (value.vendorMessage && !value.message.includes(value.vendorMessage)) {
+				parts.push(value.vendorMessage);
+			}
+			if (value.vendorHttpStatus !== undefined) parts.push(`HTTP ${value.vendorHttpStatus}`);
+			if (value.vendorExitCode !== undefined) parts.push(`process exit ${value.vendorExitCode}`);
+			return redactDiagnosticText(parts.join("; "), secrets).slice(0, 8192);
+		}
+		return value instanceof Error
+			? value.message
+			: typeof value === "string"
+				? value
+				: "Unknown failure";
+	};
+	return redactDiagnosticText(describe(error, 0), secrets).slice(0, 16384);
+}
+
+/** Redact before truncation so a cutoff cannot expose the beginning of a credential. */
+export function redactDiagnosticText(text: string, secrets: readonly string[]): string {
+	let output = text;
+	for (const secret of [...new Set(secrets)]
+		.filter(Boolean)
+		.toSorted((a, b) => b.length - a.length)) {
+		for (const form of new Set([
+			secret,
+			encodeURIComponent(secret),
+			JSON.stringify(secret).slice(1, -1),
+		]))
+			output = output.replaceAll(form, "<REDACTED>");
+	}
+	return output.replace(/\b(Bearer|Basic)\s+[A-Za-z0-9+/_=.-]+/gi, "$1 <REDACTED>");
+}

--- a/packages/driver/src/lib/port.ts
+++ b/packages/driver/src/lib/port.ts
@@ -115,11 +115,23 @@ export interface SnapshotCapability<Handle = unknown> {
 	delete(snapshotId: string): Promise<void>;
 }
 
+/** Full account observation, not the opaque and possibly paginated diagnostic list probe. */
+export interface InventorySnapshot {
+	readonly owned: readonly SandboxRef[];
+	readonly foreignCount: number;
+}
+
+export interface InventoryCapability {
+	/** Drain all pages. An unavailable or partial inventory must reject, never return an empty list. */
+	list(options?: DriverOperationOptions): Promise<InventorySnapshot>;
+}
+
 export interface SandboxDriver<Handle = unknown> {
 	create(request: CreateRequest, options?: DriverOperationOptions): Promise<SandboxSession<Handle>>;
 	destroyById?(ref: SandboxRef, options?: DriverOperationOptions): Promise<void>;
 	readonly probes?: ControlPlaneProbes;
 	readonly snapshots?: SnapshotCapability<Handle>;
+	readonly inventory?: InventoryCapability;
 }
 
 export type CreateBudget =

--- a/packages/driver/src/lib/table.ts
+++ b/packages/driver/src/lib/table.ts
@@ -14,6 +14,7 @@ import type {
 	DriverOperationOptions,
 	ExecOptions,
 	ExecResult,
+	InventorySnapshot,
 	ResolvedArtifact,
 	SandboxDriver,
 	SandboxObservation,
@@ -69,6 +70,9 @@ export interface MethodTable<Handle, Ctx, Native = Handle> {
 	readonly snapshots?: {
 		create(ctx: Ctx, session: SandboxSession<Native>): Promise<{ readonly snapshotId: string }>;
 		delete(ctx: Ctx, snapshotId: string): Promise<void>;
+	};
+	readonly inventory?: {
+		list(ctx: Ctx, options?: DriverOperationOptions): Promise<InventorySnapshot>;
 	};
 }
 
@@ -183,7 +187,15 @@ export function driverFromTable<Handle, Ctx, Native = Handle>(
 	const probeList = tableProbes?.list;
 	const probeDescribe = tableProbes?.describe;
 	const tableSnapshots = table.snapshots;
+	const inventory = table.inventory;
 	return {
+		...(inventory
+			? {
+					inventory: {
+						list: async (options?: DriverOperationOptions) => inventory.list(await ctx(), options),
+					},
+				}
+			: {}),
 		async create(request, operationOptions) {
 			const resolved = await ctx();
 			const created = await table.create(resolved, request, operationOptions);

--- a/packages/drivers/src/_computesdk.test.ts
+++ b/packages/drivers/src/_computesdk.test.ts
@@ -1295,6 +1295,28 @@ describe("computeSdkDriver", () => {
 		expect(projected.every(([projectedSandbox]) => projectedSandbox === sandbox)).toBe(true);
 	});
 
+	test("native command failures retain useful diagnostics through the redaction boundary", async () => {
+		const { compute } = fakeCompute(baseSandbox);
+		const session = await bridge(compute, {
+			commands: {
+				exec: async () => {
+					throw new Error("native exec transport refused test-key");
+				},
+				launch: async () => {
+					throw new Error("native launch session unavailable test-key");
+				},
+			},
+		}).create(request);
+		const execError = await session.exec("true").catch((caught: unknown) => caught);
+		const launchError = await session.launch?.("task").catch((caught: unknown) => caught);
+		expectRedacted(execError, "exec-failed");
+		expectRedacted(launchError, "exec-failed");
+		expect(execError).toMatchObject({ vendorMessage: "native exec transport refused [REDACTED]" });
+		expect(launchError).toMatchObject({
+			vendorMessage: "native launch session unavailable [REDACTED]",
+		});
+	});
+
 	test("launch rejects a background command that the wrapper reports as failed", async () => {
 		const { compute } = fakeCompute({
 			...baseSandbox,

--- a/packages/drivers/src/_computesdk.ts
+++ b/packages/drivers/src/_computesdk.ts
@@ -1140,12 +1140,9 @@ function computeSdkMethodTable<TCompute extends ComputeSdkLike>(
 					});
 				} else {
 					if (ref === undefined) throw new Error("canonical sandbox identity is unavailable");
-					rawResult = await invokeComputeSdkProviderCallbackAsync(
-						provider,
-						"command exec",
-						() => commands.exec(sandbox, command, execOptions, ref),
-						{ code: "exec-failed", ref },
-					);
+					// The outer operation boundary projects and redacts the native failure. Wrapping here
+					// first erased its diagnostic before that boundary could preserve it.
+					rawResult = await commands.exec(sandbox, command, execOptions, ref);
 				}
 				result = normalizeCommandResult(
 					provider,
@@ -1204,15 +1201,7 @@ function computeSdkMethodTable<TCompute extends ComputeSdkLike>(
 				const ref = refFor(sandbox);
 				try {
 					if (ref === undefined) throw new Error("canonical sandbox identity is unavailable");
-					await invokeComputeSdkProviderCallbackAsync(
-						provider,
-						"command launch",
-						() => commands.launch(sandbox, command, execOptions, ref),
-						{
-							code: "exec-failed",
-							...(refFor(sandbox) === undefined ? {} : { ref: refFor(sandbox) }),
-						},
-					);
+					await commands.launch(sandbox, command, execOptions, ref);
 					return;
 				} catch (caught) {
 					throw wrapperFailure(

--- a/packages/drivers/src/tama.test.ts
+++ b/packages/drivers/src/tama.test.ts
@@ -50,6 +50,7 @@ describe("Tama proof driver", () => {
 		expect(spec.createCommandTimeoutMs).toBe(20 * 60_000);
 		expect(spec.requestCoverage).toEqual(TAMA_REQUEST_COVERAGE);
 		expect(spec.prepare).toEqual({
+			authenticateFirst: true,
 			probe: ["list", "--all", "--json"],
 			fallback: ["login", "--token", "tama_test-token"],
 		});
@@ -129,6 +130,7 @@ describe("Tama proof driver", () => {
 	test("rejects unsupported request axes before invoking the CLI", async () => {
 		const calls: string[][] = [];
 		const run: CliRunner = async (_binary, args) => {
+			if (args[0] === "login") return { stdout: "", stderr: "", code: 0 };
 			calls.push([...args]);
 			return { stdout: "", stderr: "", code: 0 };
 		};
@@ -156,6 +158,7 @@ describe("Tama proof driver", () => {
 		let name = "";
 		let destroyed = false;
 		const run: CliRunner = async (_binary, args) => {
+			if (args[0] === "login") return { stdout: "", stderr: "", code: 0 };
 			if (args[0] === "new") {
 				name = args[1] ?? "";
 				return { stdout: "{}", stderr: "", code: 0 };
@@ -186,6 +189,58 @@ describe("Tama proof driver", () => {
 		expect(await driver.probes?.observe(session.sandboxRef)).toEqual({ state: "absent" });
 	});
 
+	test("serializes profile authentication across contexts and preserves a failed list without relogin", async () => {
+		let active = 0;
+		let peak = 0;
+		const calls: string[] = [];
+		const run: CliRunner = async (_binary, args) => {
+			calls.push(args[0] ?? "");
+			if (args[0] === "login") {
+				peak = Math.max(peak, ++active);
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				active--;
+				return { stdout: "", stderr: "", code: 0 };
+			}
+			return { stdout: "", stderr: "control plane unavailable", code: 1 };
+		};
+		const create = () =>
+			driverFromTable(
+				cliMethodTable("tama", tamaSpec(context), {
+					run,
+					createAttemptCeilingMs: TAMA_CREATE_CEILING_MS,
+				}),
+				async () => ({}),
+			).create(request);
+		const results = await Promise.allSettled([create(), create()]);
+		expect(peak).toBe(1);
+		expect(calls).toEqual(["login", "list", "login", "list"]);
+		for (const result of results) {
+			expect(result.status).toBe("rejected");
+			if (result.status === "rejected")
+				expect(result.reason.vendorMessage).toContain("control plane unavailable");
+		}
+	});
+
+	test("inventory distinguishes exact benchmark names from foreign machines", async () => {
+		const rows = [
+			{ ...readyMachine, name: "bench-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" },
+			{ ...readyMachine, id: "machine-aaaaaaaaaaaa", name: "developer-machine" },
+		];
+		const run: CliRunner = async (_binary, args) => ({
+			stdout: args[0] === "login" ? "" : JSON.stringify(rows),
+			stderr: "",
+			code: 0,
+		});
+		const driver = driverFromTable(
+			cliMethodTable("tama", tamaSpec(context), { run }),
+			async () => ({}),
+		);
+		expect(await driver.inventory?.list()).toEqual({
+			owned: [{ provider: "tama", id: readyMachine.id }],
+			foreignCount: 1,
+		});
+	});
+
 	test("retains teardown ownership when an unrelated local dependency is not found", async () => {
 		let name = "";
 		let destroyAttempts = 0;
@@ -198,6 +253,7 @@ describe("Tama proof driver", () => {
 			`error: machine ${readyMachine.id} not found\nerror: connection reset`,
 		];
 		const run: CliRunner = async (_binary, args) => {
+			if (args[0] === "login") return { stdout: "", stderr: "", code: 0 };
 			if (args[0] === "new") {
 				name = args[1] ?? "";
 				return { stdout: "{}", stderr: "", code: 0 };

--- a/packages/drivers/src/tama.ts
+++ b/packages/drivers/src/tama.ts
@@ -56,10 +56,13 @@ export function tamaSpec({ env, resolvedArtifact }: DriverContext<"tama">) {
 	return defineCliSpec(TAMA_MACHINES, {
 		binary: env.TAMA_CLI ?? "tama",
 		secretFlags: ["--token"],
+		inventoryOwned: (row) =>
+			/^bench-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/.test(row.name),
 		commandTimeoutMs: 60_000,
 		createCommandTimeoutMs: 20 * 60_000,
 		requestCoverage: TAMA_REQUEST_COVERAGE,
 		prepare: {
+			authenticateFirst: true,
 			probe: ["list", "--all", "--json"],
 			fallback: ["login", "--token", env.TAMA_TOKEN],
 		},

--- a/packages/harness/CONTEXT.md
+++ b/packages/harness/CONTEXT.md
@@ -15,3 +15,11 @@ control-plane operation. Operational readiness alone does not define the measure
 **Result gap**:
 A recorded absence of a benchmark result, such as a skipped or failed workload. A gap is not a
 zero-valued measurement.
+
+**Execution receipt**:
+Evidence binding benchmark step outcomes to a particular sandbox and logical replicate. Launch
+acceptance and recognizable output are not successful completion outcomes.
+
+**Cleanup confirmation**:
+Observation that the allocated sandbox is absent after teardown. A successful request to destroy it
+is only an acknowledgement until removal is observed.

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -374,7 +374,7 @@ function makeSandbox(opts: {
 		return { exitCode: 0, stdout: "" };
 	};
 	const tagOf = (command: string, ext: string): string | undefined =>
-		command.match(new RegExp(`/tmp/(bench-[0-9a-f-]+)\\.${ext}`))?.[1];
+		command.match(new RegExp(`/tmp/(bench-[0-9a-f-]+)/(?:output|completion)\\.${ext}`))?.[1];
 	return {
 		sandboxId: "sb-test-1",
 		async runCommand(command) {
@@ -394,7 +394,7 @@ function makeSandbox(opts: {
 			const doneTag = tagOf(command, "done");
 			if (doneTag) {
 				const d = detached.get(doneTag);
-				return { exitCode: 0, stdout: d ? String(d.exit) : "__RUNNING__" };
+				return { exitCode: 0, stdout: d ? `v1 ${doneTag} ${d.exit}` : "__RUNNING__" };
 			}
 			// Cat-read of the log: the stashed output (stderr merged into stdout, mirroring live 2>&1).
 			const logTag = tagOf(command, "log");
@@ -486,6 +486,7 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 		suiteName: "cpu-node",
 		providerName: "daytona-container",
 		resultsDir,
+		retryBudgetMs: 60 * 60_000,
 		...overrides,
 	});
 	const MARKER = "sandbox-daytona-container-cpu-node--failed.json";
@@ -608,7 +609,10 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 		expect(existsSync(join(resultsDir, MARKER))).toBe(true);
 	});
 
-	it("writes a FAILED marker once the retry budget is spent", async () => {
+	it.each([
+		0,
+		undefined,
+	])("writes a FAILED marker without a positive retry budget (%s)", async (retryBudgetMs) => {
 		const resultsDir = freshDir();
 		let attempts = 0;
 		const compute = {
@@ -622,10 +626,7 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 		// A budget smaller than one delay leaves no room for another attempt, so the first failure is
 		// also the last: patience is bounded, and the cell still records why it produced nothing.
 		await expect(
-			createSuiteSandbox(
-				() => compute,
-				createCtx(resultsDir, { retryDelayMs: 50, retryBudgetMs: 0 }),
-			),
+			createSuiteSandbox(() => compute, createCtx(resultsDir, { retryDelayMs: 50, retryBudgetMs })),
 		).rejects.toThrow("no slot right now");
 		expect(attempts).toBe(1);
 		expect(JSON.parse(readFileSync(join(resultsDir, MARKER), "utf8")).outcome).toBe("failed");

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,5 +1,7 @@
 // Public surface of @sandbox-benchmarks/harness — drives a provider to produce raw benchmark output.
-import { readdirSync } from "node:fs";
+
+import { randomUUID } from "node:crypto";
+import { readdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type {
 	CreateRequest,
@@ -8,11 +10,20 @@ import type {
 	SandboxDriver,
 	SandboxSession,
 } from "@sandbox-benchmarks/driver";
-import { isRetryableDriverCreate } from "@sandbox-benchmarks/driver";
+import {
+	isFailedCreateCleanupError,
+	isRetryableDriverCreate,
+	describeDriverFailure as projectDriverFailure,
+} from "@sandbox-benchmarks/driver";
 import {
 	driverReadinessBudgetMs,
 	verifyDriverReadiness,
 } from "@sandbox-benchmarks/driver/conformance";
+import { diagnosticSecretsFromEnv } from "@sandbox-benchmarks/driver/env";
+
+const describeDriverFailure = (error: unknown): string =>
+	projectDriverFailure(error, diagnosticSecretsFromEnv(process.env));
+
 import type {
 	DirectProvider,
 	ProviderConfig,
@@ -235,7 +246,7 @@ async function benchmarkCycles(
 			// cold start shouldn't discard the cycles that already succeeded, so record it as a FAILED spawn
 			// gap and keep going; the dedup below collapses an identical failure repeated across cycles. It
 			// is a failure, not a skip: the provider was asked for a sandbox and did not produce one.
-			const reason = err instanceof Error ? err.message : String(err);
+			const reason = describeDriverFailure(err);
 			gaps.push({
 				scope: "operation",
 				id: HARNESS_METRIC_IDS.spawn,
@@ -323,15 +334,15 @@ export interface RunSuiteOptions {
 
 async function destroySandbox(
 	sandbox: Pick<SandboxHandle, "destroy"> | undefined,
-): Promise<SandboxTeardownResult> {
+): Promise<SandboxTeardownResult & { diagnostic?: string }> {
 	const attemptedAt = new Date().toISOString();
 	if (!sandbox) return { completed: false, attemptedAt };
 	try {
 		await withTimeout(Promise.resolve(sandbox.destroy()), 15_000, "Destroy timeout");
 		return { completed: true, attemptedAt, completedAt: new Date().toISOString() };
 	} catch (err) {
-		console.warn(`[cleanup] destroy failed: ${err instanceof Error ? err.message : String(err)}`);
-		return { completed: false, attemptedAt };
+		console.warn(`[cleanup] destroy failed: ${describeDriverFailure(err)}`);
+		return { completed: false, attemptedAt, diagnostic: describeDriverFailure(err) };
 	}
 }
 
@@ -413,9 +424,8 @@ export interface SuiteSandboxCompute {
 	};
 }
 
-// Concurrent jobs share one provider account; quota/capacity errors mean "no slot right now", not
-// "broken" — retry patiently so jobs self-serialize as earlier sandboxes are destroyed.
-const CREATE_RETRY_BUDGET_MS = 60 * MIN;
+// Allocation retries require explicit composition policy; never hide attempts inside a suite run.
+const CREATE_RETRY_BUDGET_MS = 0;
 const CREATE_RETRY_DELAY_MS = 2 * MIN;
 /** How long a single `sandbox.create` may run before the attempt is abandoned (and any late handle
  *  destroyed). Generous: a cold provider image can take minutes to provision. Adequate only for
@@ -550,6 +560,9 @@ export async function createSuiteSandboxFromPlan<Session extends Pick<SandboxHan
 		// was created, so there is nothing to clean up), while a create that outlives the timeout leaves it
 		// a pending promise whose late handle must still be destroyed (see the catch).
 		let createPromise: Promise<Session> | undefined;
+		const allocationTimeout = new Error(
+			"Sandbox creation timed out; allocation ownership unresolved",
+		);
 		try {
 			createPromise = createOwnedSandbox(
 				plan.create,
@@ -557,7 +570,7 @@ export async function createSuiteSandboxFromPlan<Session extends Pick<SandboxHan
 			);
 			return createTimeoutMs === null
 				? await createPromise
-				: await withTimeout(createPromise, createTimeoutMs, "Sandbox creation timed out");
+				: await withTimeout(createPromise, createTimeoutMs, () => allocationTimeout);
 		} catch (err) {
 			// `withTimeout` only RACES the create — it cannot cancel it. A create that resolves after the
 			// timeout (or after a capacity error on a later attempt) leaves a live sandbox no one awaits, and
@@ -570,11 +583,12 @@ export async function createSuiteSandboxFromPlan<Session extends Pick<SandboxHan
 					() => {},
 				);
 			}
-			const message = err instanceof Error ? err.message : String(err);
+			const message = describeDriverFailure(err);
 			// Classification belongs to the selected plan. The legacy wrapper below preserves its explicit
 			// marker plus narrow prose fallback; a DriverModule plan can instead require typed policy without
 			// inheriting any legacy vendor-message guesses.
-			const retryable = plan.isRetryable(err);
+			const retryable =
+				err !== allocationTimeout && !isFailedCreateCleanupError(err) && plan.isRetryable(err);
 			// The budget bounds the CELL, not just the sleeps: an attempt is only started when the backoff
 			// AND the attempt's own worst case still fit inside it. Checking the delay alone let a provider
 			// whose attempts run long (run.cloud's adapter-owned readiness wait) begin one final attempt at
@@ -611,7 +625,7 @@ export function createSuiteSandbox(
 				});
 			},
 			isRetryable: (error) => {
-				const message = error instanceof Error ? error.message : String(error);
+				const message = describeDriverFailure(error);
 				return (
 					isRetryableCreateError(error) || /quota|rate.?limit|too many|capacity|429/i.test(message)
 				);
@@ -654,6 +668,8 @@ export interface SuiteRunContext {
 	/** Readiness budget override. Defaults to {@link SUITE_READINESS}; tests inject a fast one so a
 	 *  never-ready case doesn't really sleep out the live budget. */
 	readiness?: WaitUntilReadyOptions;
+	/** Managed callers must observe removal after the destroy acknowledgement. */
+	confirmCleanup?: () => Promise<void>;
 }
 
 /** A selected DriverModule readiness strategy plus its policy-owned wall-clock budget. */
@@ -816,6 +832,23 @@ export async function executeSuite(options: ExecuteSuiteOptions): Promise<void> 
 			suite,
 			providerName: module.id,
 			artifact: request.artifact,
+			confirmCleanup: async () => {
+				const probes = driver.probes;
+				if (!probes) throw new Error("driver cannot confirm sandbox removal");
+				const deadline = Date.now() + 15_000;
+				while (Date.now() < deadline) {
+					const observation = await withTimeout(
+						probes.observe(session.sandboxRef),
+						Math.max(1, deadline - Date.now()),
+						"Cleanup observation timeout",
+					);
+					if (observation.state === "absent") return;
+					await new Promise((resolve) =>
+						setTimeout(resolve, Math.min(250, Math.max(1, deadline - Date.now()))),
+					);
+				}
+				throw new Error("sandbox removal remains unconfirmed");
+			},
 			...(module.costEvidence === undefined ? {} : { costEvidence: module.costEvidence }),
 		},
 		() => new SessionStepRunner(session, module.execution, undefined, resolvePtsPassPolicy(suite)),
@@ -834,7 +867,7 @@ export async function executeSuite(options: ExecuteSuiteOptions): Promise<void> 
 }
 
 type SuiteWorkContext = Omit<SuiteRunContext, "transport" | "driverReadiness" | "readiness">;
-type SuiteWorkRunner = Pick<StepRunner, "phase" | "stepLog"> & {
+type SuiteWorkRunner = Pick<StepRunner, "phase" | "stepLog" | "detachedEvidence"> & {
 	run: SessionStepRunner["run"] | StepRunner["run"];
 	step: SessionStepRunner["step"] | StepRunner["step"];
 };
@@ -850,6 +883,8 @@ async function runSuiteWork(
 	let suiteError: unknown;
 	let evidencePersistenceError: unknown;
 	let suiteSkipped = false;
+	let runner: SuiteWorkRunner | undefined;
+	const executionId = randomUUID();
 	try {
 		if (sandboxId === undefined) {
 			throw new Error("Sandbox id is unavailable; artifact attribution cannot be persisted");
@@ -873,7 +908,7 @@ async function runSuiteWork(
 		// count on every other suite) and the BENCH_PTS_PASSES override. Constructed inside the
 		// try so a bad policy (buildPreamble rejects a fixed k < 1) is still torn down by the finally below;
 		// a throw before the try would leak the already-created sandbox.
-		const runner = createRunner();
+		runner = createRunner();
 		runner.phase = "setup";
 		await verifyReadiness();
 		const expectedFingerprint = expectedToolchainFingerprint(providerName, ctx.artifact);
@@ -965,7 +1000,7 @@ async function runSuiteWork(
 				// the failure marker.
 				if (suiteError) {
 					console.warn(
-						`[collect] failed after benchmark error: ${collectErr instanceof Error ? collectErr.message : String(collectErr)}`,
+						`[collect] failed after benchmark error: ${describeDriverFailure(collectErr)}`,
 					);
 				} else {
 					suiteError = collectErr;
@@ -989,7 +1024,54 @@ async function runSuiteWork(
 		// gate's deliberate skip (already marked) is untouched.
 		suiteError = err;
 	} finally {
+		try {
+			writeFileSync(
+				resolve(resultsDir, `execution-${executionId}.json`),
+				JSON.stringify({
+					schemaVersion: "1",
+					executionId,
+					runId: ctx.runId,
+					replicateIndex: ctx.replicateIndex,
+					suite: suiteName,
+					provider: providerName,
+					sandboxId,
+					steps: runner?.stepLog ?? [],
+					detached: runner?.detachedEvidence ?? [],
+					primaryFailure: suiteError === undefined ? null : describeDriverFailure(suiteError),
+				}),
+				{ flag: "wx", mode: 0o600 },
+			);
+		} catch (error) {
+			evidencePersistenceError = error;
+		}
 		const teardown = await destroySandbox(sandbox);
+		let confirmedAbsent = false;
+		if (teardown.completed && ctx.confirmCleanup) {
+			try {
+				await ctx.confirmCleanup();
+				confirmedAbsent = true;
+			} catch (error) {
+				teardown.completed = false;
+				teardown.diagnostic = describeDriverFailure(error);
+			}
+		}
+		if (!teardown.completed) {
+			const cleanupFailure = `Cleanup unresolved: ${teardown.diagnostic ?? "no successful destroy acknowledgement"}`;
+			suiteError = new Error(
+				suiteError === undefined
+					? cleanupFailure
+					: `${describeDriverFailure(suiteError)}; ${cleanupFailure}`,
+			);
+		}
+		try {
+			writeFileSync(
+				resolve(resultsDir, `cleanup-${executionId}.json`),
+				JSON.stringify({ schemaVersion: "1", executionId, ...teardown, confirmedAbsent }),
+				{ flag: "wx", mode: 0o600 },
+			);
+		} catch (error) {
+			evidencePersistenceError ??= error;
+		}
 		if (ctx.costEvidence) {
 			const capability = ctx.costEvidence;
 			const cell: ProviderCostCell = {
@@ -1097,7 +1179,7 @@ async function runSuiteWork(
 		// Run cannot tell "this provider crashed on the workload" from "this cell was never scheduled".
 		// The leaderboard still derives a `missing` gap when even this marker is lost (the artifact upload
 		// is itself best-effort), but a marker that survives says WHY, and that is the whole difference.
-		const reason = suiteError instanceof Error ? suiteError.message : String(suiteError);
+		const reason = describeDriverFailure(suiteError);
 		// The thrower classified it (a step timeout knows its budget, a lost sandbox knows its step);
 		// this frame only knows a message. `gapCauseOf` returns undefined for anything unclassified,
 		// which records the gap exactly as before rather than inventing a kind from the prose.

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -651,6 +651,7 @@ const SUITE_READINESS = {
 
 /** The already-resolved context {@link runSuiteOnSandbox} runs against. */
 export interface SuiteRunContext {
+	readonly sourceRevision?: string;
 	runId: RunId;
 	replicateIndex?: number;
 	suite: Suite;
@@ -795,6 +796,13 @@ export interface ExecuteSuiteOptions {
 	readonly replicateIndex?: number;
 	readonly suiteName: SuiteName;
 	readonly resultsDir: string;
+	readonly managed?: {
+		sourceRevision: string;
+		passes: number;
+		startupDeadline: number;
+		workloadMs: number;
+		collectionMs: number;
+	};
 }
 
 /** Allocate, execute, collect evidence and tear down one suite through the driver session seam. */
@@ -803,11 +811,15 @@ export async function executeSuite(options: ExecuteSuiteOptions): Promise<void> 
 	const { module, driver, request } = allocation;
 	const suite = SUITES[suiteName];
 	const budget = module.createBudget;
-	const timeoutMs =
+	const configuredTimeoutMs =
 		budget?.owner === "driver" ? null : (budget?.timeoutMs ?? SUITE_CREATE_ATTEMPT_TIMEOUT_MS);
+	const timeoutMs = options.managed
+		? Math.min(configuredTimeoutMs ?? Infinity, options.managed.startupDeadline - Date.now())
+		: configuredTimeoutMs;
+	if (timeoutMs !== null && timeoutMs <= 0) throw new Error("startup phase deadline exceeded");
 	const deadlineMs =
 		budget?.owner === "driver"
-			? budget.attemptCeilingMs
+			? Math.min(budget.attemptCeilingMs, timeoutMs ?? Infinity)
 			: (timeoutMs ?? SUITE_CREATE_ATTEMPT_TIMEOUT_MS);
 	const session = await createSuiteSandboxFromPlan(
 		{
@@ -821,7 +833,13 @@ export async function executeSuite(options: ExecuteSuiteOptions): Promise<void> 
 			providerName: module.id,
 			resultsDir: options.resultsDir,
 			createTimeoutMs: timeoutMs,
-			...(budget?.owner === "driver" ? { createAttemptCeilingMs: budget.attemptCeilingMs } : {}),
+			...(budget?.owner === "driver"
+				? {
+						createAttemptCeilingMs: options.managed
+							? Math.min(budget.attemptCeilingMs, timeoutMs ?? Infinity)
+							: budget.attemptCeilingMs,
+					}
+				: {}),
 		},
 	);
 	await runSuiteWork(
@@ -829,6 +847,7 @@ export async function executeSuite(options: ExecuteSuiteOptions): Promise<void> 
 		session.sandboxRef.id,
 		{
 			...options,
+			sourceRevision: options.managed?.sourceRevision,
 			suite,
 			providerName: module.id,
 			artifact: request.artifact,
@@ -851,10 +870,36 @@ export async function executeSuite(options: ExecuteSuiteOptions): Promise<void> 
 			},
 			...(module.costEvidence === undefined ? {} : { costEvidence: module.costEvidence }),
 		},
-		() => new SessionStepRunner(session, module.execution, undefined, resolvePtsPassPolicy(suite)),
+		() => {
+			const managed = options.managed;
+			const deadlines = new Map<string, number>();
+			return new SessionStepRunner(
+				session,
+				module.execution,
+				undefined,
+				managed ? { mode: "fixed", times: managed.passes } : resolvePtsPassPolicy(suite),
+				managed
+					? (phase) => {
+							if (phase === "setup" || phase === "create") return managed.startupDeadline;
+							if (!deadlines.has(phase))
+								deadlines.set(
+									phase,
+									Date.now() + (phase === "benchmark" ? managed.workloadMs : managed.collectionMs),
+								);
+							return deadlines.get(phase) ?? managed.startupDeadline;
+						}
+					: undefined,
+			);
+		},
 		async () => {
 			const readiness = await verifySuiteDriverReadiness({
-				timeoutMs: driverReadinessBudgetMs(module),
+				timeoutMs: Math.max(
+					1,
+					Math.min(
+						driverReadinessBudgetMs(module),
+						options.managed ? options.managed.startupDeadline - Date.now() : Infinity,
+					),
+				),
 				verify: async ({ signal }) => {
 					const result = await verifyDriverReadiness(module, session, { signal });
 					return { ready: result.status === "pass", detail: result.detail };
@@ -960,7 +1005,7 @@ async function runSuiteWork(
 		}
 
 		if (!suiteSkipped) {
-			for (const step of setupSteps(suite)) {
+			for (const step of setupSteps(suite, ctx.sourceRevision)) {
 				const attempts = (step.retries ?? 0) + 1;
 				for (let attempt = 1; ; attempt++) {
 					try {

--- a/packages/harness/src/lib/collect.test.ts
+++ b/packages/harness/src/lib/collect.test.ts
@@ -114,6 +114,20 @@ describe("collectResults", () => {
 		expect(existsSync(join(resultsDir, "pts_node-web-tooling.xml"))).toBe(false);
 	});
 
+	for (const name of ["execution-forged.json", "cleanup-forged.json"]) {
+		it(`rejects sandbox-forged ${name}`, async () => {
+			const resultsDir = join(work, name);
+			const forged = payloadSandbox({
+				"pts_node-web-tooling.xml": "<xml/>",
+				[name]: '{"completed":true}',
+			});
+			await expect(collectResults(new StepRunner(forged, UNCAPPED), resultsDir)).rejects.toThrow(
+				"reserved host-owned file",
+			);
+			expect(existsSync(join(resultsDir, name))).toBe(false);
+		});
+	}
+
 	it("rejects forged sandbox artifact evidence before it can replace host attribution", async () => {
 		const resultsDir = join(work, "forged-artifact-evidence");
 		const forged = payloadSandbox({
@@ -234,7 +248,7 @@ describe("collectResults", () => {
 			filesystem: {
 				exists: async (path) => path.endsWith(".done"),
 				readFile: async (path) => {
-					if (path.endsWith(".done")) return "0";
+					if (path.endsWith(".done")) return `v1 ${path.split("/")[2]} 0`;
 					if (++logReads <= READBACK_ATTEMPTS) throw new Error("fs API down");
 					return payload;
 				},

--- a/packages/harness/src/lib/collect.ts
+++ b/packages/harness/src/lib/collect.ts
@@ -245,6 +245,7 @@ async function decodeAndExtract(base64: string, resultsDir: string): Promise<num
 function assertNoReservedEvidenceFile(directory: string): void {
 	for (const entry of readdirSync(directory, { withFileTypes: true })) {
 		if (
+			/^(execution|cleanup)-.*\.json$/.test(entry.name) ||
 			entry.name === providerCostEvidenceFile() ||
 			entry.name === providerArtifactEvidenceFile()
 		) {

--- a/packages/harness/src/lib/completion.test.ts
+++ b/packages/harness/src/lib/completion.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { readFile, rm } from "node:fs/promises";
+import { completionCode, detachedCommand } from "./completion.ts";
+
+test("receipt rejects foreign identity, partial status, and fabricated exits", () => {
+	expect(completionCode("v1 bench-abc 7", "bench-abc")).toBe(7);
+	for (const raw of ["0", "", "v1 bench-def 0", "v1 bench-abc 7garbage", "v1 bench-abc 256"]) {
+		expect(completionCode(raw, "bench-abc")).toBeNull();
+	}
+});
+
+test.each([
+	["echo passed", 0],
+	["set -e; false; echo should-not-run", 1],
+	["echo 'All tasks passed'; exit 7", 7],
+	["sleep 0.1 & echo parent-completed", 0],
+])("real shell publishes actual exit for %s", async (command, expected) => {
+	const identity = `bench-${randomUUID()}`;
+	try {
+		const process = Bun.spawn(["bash", "-c", detachedCommand(identity, String(command))], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		expect(await process.exited).toBe(0);
+		const receipt = await readFile(`/tmp/${identity}/completion.done`, "utf8");
+		expect(completionCode(receipt, identity)).toBe(expected);
+		const output = await readFile(`/tmp/${identity}/output.log`, "utf8");
+		expect(output).not.toContain("should-not-run");
+	} finally {
+		await rm(`/tmp/${identity}`, { recursive: true, force: true });
+	}
+});

--- a/packages/harness/src/lib/completion.ts
+++ b/packages/harness/src/lib/completion.ts
@@ -1,0 +1,20 @@
+import { shellQuote } from "@sandbox-benchmarks/driver";
+
+export function detachedCommand(identity: string, command: string): string {
+	if (!/^bench-[a-f0-9-]+$/.test(identity)) throw new Error("invalid detached command identity");
+	const directory = `/tmp/${identity}`;
+	const done = `${directory}/completion.done`;
+	return (
+		`umask 077; mkdir ${directory} || exit 1; ` +
+		`bash -c ${shellQuote(command)} > ${directory}/output.log 2>&1 ` +
+		`&& code=0 || code=$?; printf 'v1 ${identity} %s\\n' "$code" > ${done}.tmp && mv ${done}.tmp ${done}`
+	);
+}
+
+/** A versioned receipt binds completion to the exact detached command, not just a filename. */
+export function completionCode(raw: string, identity: string): number | null {
+	const match = /^v1 ([a-zA-Z0-9-]+) (0|[1-9][0-9]*)\n?$/.exec(raw);
+	if (!match || match[1] !== identity) return null;
+	const code = Number(match[2]);
+	return Number.isInteger(code) && code <= 255 ? code : null;
+}

--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -249,6 +249,22 @@ describe("StepRunner", () => {
 });
 
 describe("StepRunner.runDetached", () => {
+	it("captures diagnostic output when native launch never settles", async () => {
+		const commands: string[] = [];
+		const sandbox: SandboxHandle = {
+			runCommand: async (command, options) => {
+				commands.push(command);
+				if (options?.background) return new Promise(() => {});
+				return { exitCode: 0, stdout: "last output from native launch" };
+			},
+			destroy: async () => {},
+		};
+		const runner = new StepRunner(sandbox);
+		await expect(runner.runDetached("hung launch", "true", 10)).rejects.toThrow("timed out");
+		expect(runner.detachedEvidence[0]?.state).toBe("deadline-exceeded");
+		expect(runner.detachedEvidence[0]?.logTail).toContain("last output from native launch");
+		expect(commands.some((command) => command.includes("pkill"))).toBe(true);
+	});
 	// A fake sandbox whose filesystem reports the done-file present after `readyAfter` polls and
 	// serves canned log/exit-code contents — the detached transport's two reads.
 	function detachedSandbox(opts: { readyAfter?: number; exitCode?: string; log?: string }): {
@@ -266,7 +282,9 @@ describe("StepRunner.runDetached", () => {
 			filesystem: {
 				exists: async (path) => path.endsWith(".done") && polls++ >= (opts.readyAfter ?? 0),
 				readFile: async (path) =>
-					path.endsWith(".done") ? (opts.exitCode ?? "0") : (opts.log ?? "benchmark output"),
+					path.endsWith(".done")
+						? receipt(path, opts.exitCode ?? "0")
+						: (opts.log ?? "benchmark output"),
 			},
 		};
 		return { sandbox, commands };
@@ -372,7 +390,7 @@ describe("StepRunner.runDetached", () => {
 		} finally {
 			console.log = spy;
 		}
-		expect(logged.join("\n")).toContain("stopped responding");
+		expect(logged.join("\n")).toContain("cause is unknown");
 	});
 
 	// A sandbox with NO filesystem API: the detached transport must still detach (double-fork) and
@@ -391,7 +409,10 @@ describe("StepRunner.runDetached", () => {
 				if (command.includes("nohup")) return { exitCode: 0, stdout: "launched" };
 				if (command.includes(".done")) {
 					const ready = probes++ >= readyAfter;
-					return { exitCode: 0, stdout: ready ? (opts.exitCode ?? "0") : "__RUNNING__" };
+					return {
+						exitCode: 0,
+						stdout: ready ? receipt(command, opts.exitCode ?? "0") : "__RUNNING__",
+					};
 				}
 				return { exitCode: 0, stdout: opts.log ?? "cat output" }; // the `.log` read
 			},
@@ -533,7 +554,7 @@ describe("StepRunner.runDetached", () => {
 					if (polls === 1) throw new Error("transient fs blip");
 					return polls >= 3;
 				},
-				readFile: async (path) => (path.endsWith(".done") ? "0" : "recovered fine"),
+				readFile: async (path) => (path.endsWith(".done") ? receipt(path) : "recovered fine"),
 			},
 		};
 		const runner = new StepRunner(sandbox, CAPPED, async () => undefined);
@@ -553,7 +574,7 @@ describe("StepRunner.runDetached", () => {
 			filesystem: {
 				exists: async (path) => path.endsWith(".done"),
 				readFile: async (path) => {
-					if (path.endsWith(".done")) return "0";
+					if (path.endsWith(".done")) return receipt(path);
 					if (++logReads < 3) throw new Error("fs API slow");
 					return "read back on attempt 3";
 				},
@@ -580,7 +601,7 @@ describe("StepRunner.runDetached", () => {
 			filesystem: {
 				exists: async (path) => path.endsWith(".done"),
 				readFile: async (path) => {
-					if (path.endsWith(".done")) return "0";
+					if (path.endsWith(".done")) return receipt(path);
 					throw new Error("fs API down"); // every .log read
 				},
 			},
@@ -605,7 +626,7 @@ describe("StepRunner.runDetached", () => {
 			filesystem: {
 				exists: async (path) => path.endsWith(".done"),
 				readFile: async (path) => {
-					if (path.endsWith(".done")) return "0";
+					if (path.endsWith(".done")) return receipt(path);
 					throw new Error("fs API down");
 				},
 			},
@@ -638,7 +659,7 @@ describe("StepRunner.runDetached", () => {
 		} finally {
 			console.log = spy;
 		}
-		expect(logged.join("\n")).toContain("stopped responding");
+		expect(logged.join("\n")).toContain("cause is unknown");
 	});
 
 	it("backs off the poll interval geometrically up to the cap", async () => {
@@ -672,7 +693,7 @@ describe("StepRunner.step (capability-driven transport)", () => {
 			destroy: async () => undefined,
 			filesystem: {
 				exists: async (path) => path.endsWith(".done"),
-				readFile: async (path) => (path.endsWith(".done") ? "0" : "out"),
+				readFile: async (path) => (path.endsWith(".done") ? receipt(path) : "out"),
 			},
 		};
 		return { sandbox, commands };
@@ -727,3 +748,8 @@ describe("StepRunner.step (capability-driven transport)", () => {
 		expect(commands[0]?.background).toBe(true);
 	});
 });
+
+function receipt(location: string, code = "0"): string {
+	const identity = /bench-[a-f0-9-]+/.exec(location)?.[0];
+	return `v1 ${identity} ${code}`;
+}

--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -245,6 +245,11 @@ describe("StepRunner", () => {
 		await expect(runner.run("fail", "false", 5_000)).rejects.toThrow(/exit code 1/);
 		const tolerated = await runner.run("fail-ok", "false", 5_000, { allowFailure: true });
 		expect(tolerated.exitCode).toBe(1);
+		// The receipt must let a reader tell the tolerated exit from the real failure.
+		expect(runner.stepLog).toEqual([
+			{ phase: "setup", label: "fail", ms: expect.any(Number), exitCode: 1 },
+			{ phase: "setup", label: "fail-ok", ms: expect.any(Number), exitCode: 1, allowFailure: true },
+		]);
 	});
 });
 

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -24,9 +24,15 @@
 
 import { randomUUID } from "node:crypto";
 import type { ExecResult, ExecutionPolicy, SandboxSession } from "@sandbox-benchmarks/driver";
-import { launchDetached, selectExecutionRoute } from "@sandbox-benchmarks/driver";
+import {
+	launchDetached,
+	redactDiagnosticText,
+	selectExecutionRoute,
+} from "@sandbox-benchmarks/driver";
+import { diagnosticSecretsFromEnv } from "@sandbox-benchmarks/driver/env";
 import type { ProviderTransport } from "@sandbox-benchmarks/schema";
 import { PTS_STATE_SELECT_SH } from "@sandbox-benchmarks/schema";
+import { completionCode, detachedCommand } from "./completion.ts";
 import { GapError } from "./gap-cause.ts";
 
 export const MIN = 60_000;
@@ -57,6 +63,11 @@ const READBACK_ATTEMPTS = 5;
 const READBACK_DELAY_MS = 2_000;
 /** Done-file sentinel for the no-filesystem cat-poll fallback: printed while the file isn't there yet. */
 const RUNNING_SENTINEL = "__RUNNING__";
+function observationBudget(deadline: number): number {
+	const remaining = deadline - performance.now();
+	if (remaining <= 0) throw new Error("step observation deadline exceeded");
+	return Math.min(POLL_CAP_MS, remaining);
+}
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 export type Phase = "create" | "setup" | "benchmark" | "collect";
@@ -66,6 +77,23 @@ export interface StepLogEntry {
 	label: string;
 	ms: number;
 	exitCode: number | null;
+}
+
+export interface DetachedStepEvidence {
+	identity: string;
+	label: string;
+	phase: Phase;
+	state:
+		| "launch-pending"
+		| "launch-accepted"
+		| "running"
+		| "observation-unavailable"
+		| "completed"
+		| "deadline-exceeded"
+		| "collection-failed";
+	exitCode: number | null;
+	lastObservationMs?: number;
+	logTail?: string | null;
 }
 
 /** The result of one in-sandbox command. */
@@ -200,12 +228,6 @@ function stepTimeout(label: string, timeoutMs: number): GapError {
 /** Single-quote a script for safe embedding in `bash -c '<script>'`. */
 export function shellQuote(script: string): string {
 	return `'${script.replace(/'/g, `'\\''`)}'`;
-}
-
-/** Parse a done-file's exit-code contents, defaulting a malformed value to a failure (1). */
-function parseExitCode(raw: string): number {
-	const code = Number.parseInt(raw, 10);
-	return Number.isFinite(code) ? code : 1;
 }
 
 /**
@@ -400,6 +422,7 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 	phase: Phase = "setup";
 	/** Every executed step with its phase, elapsed ms, and exit code. */
 	readonly stepLog: StepLogEntry[] = [];
+	readonly detachedEvidence: DetachedStepEvidence[] = [];
 	/** The in-sandbox preamble prepended to every step, carrying this run's PTS pass policy. */
 	private readonly preamble: string;
 	/**
@@ -428,9 +451,6 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 	protected abstract detached(timeoutMs: number): boolean;
 	protected abstract exitCode(result: Result): number | null;
 	protected abstract describeExit(result: Result): string;
-	protected parseCompletion(raw: string): number | null {
-		return parseExitCode(raw);
-	}
 	protected abstract completed(code: number | null, stdout: string, durationMs: number): Result;
 
 	/**
@@ -443,10 +463,14 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 	 * real Blaxel incident, 2026-07-19), where permanent absence must abandon it, and only the stub's own
 	 * error distinguishes the two. A dead sandbox is still caught, because the cat poll will fail too.
 	 */
-	private async pollDoneOnce(donePath: string, label: string): Promise<number | null | undefined> {
-		if (!this.pollFs) return this.pollDoneViaCat(donePath);
+	private async pollDoneOnce(
+		donePath: string,
+		label: string,
+		deadline: number,
+	): Promise<number | null | undefined> {
+		if (!this.pollFs) return this.pollDoneViaCat(donePath, deadline);
 		try {
-			return await this.pollDoneViaFs(this.pollFs, donePath);
+			return await this.pollDoneViaFs(this.pollFs, donePath, deadline);
 		} catch (err) {
 			if (!isUnsupportedFilesystem(err)) throw err;
 			console.log(
@@ -454,7 +478,7 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 					`falling back to the exec done-file poll`,
 			);
 			this.pollFs = undefined;
-			return this.pollDoneViaCat(donePath);
+			return this.pollDoneViaCat(donePath, deadline);
 		}
 	}
 
@@ -530,8 +554,45 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 		const started = performance.now();
 		const stopHeartbeat = startHeartbeat(label, started, timeoutMs);
 		const tag = `bench-${randomUUID()}`;
-		const logPath = `/tmp/${tag}.log`;
-		const donePath = `/tmp/${tag}.done`;
+		const logPath = `/tmp/${tag}/output.log`;
+		const donePath = `/tmp/${tag}/completion.done`;
+		const deadline = started + timeoutMs;
+		const evidence: DetachedStepEvidence = {
+			identity: tag,
+			label,
+			phase: this.phase,
+			state: "launch-pending",
+			exitCode: null,
+		};
+		this.detachedEvidence.push(evidence);
+		const logCount = this.stepLog.length;
+		const remaining = () => Math.max(1, deadline - performance.now());
+		let timeoutEvidenceCaptured = false;
+		const recoverTimeoutEvidence = async () => {
+			if (timeoutEvidenceCaptured) return;
+			timeoutEvidenceCaptured = true;
+			evidence.state = "deadline-exceeded";
+			const rawTail = await this.readLogTail(this.pollFs, logPath);
+			const tail =
+				rawTail === null
+					? null
+					: redactDiagnosticText(rawTail, diagnosticSecretsFromEnv(process.env)).slice(-8192);
+			evidence.logTail = tail;
+			// Best-effort stop the detached job; don't let a failing kill mask the timeout.
+			await withTimeout(
+				this.execute(`pkill -f ${shellQuote(tag)} || true`),
+				POLL_CAP_MS,
+				"stop timed-out step",
+			).catch(() => undefined);
+			if (tail === null) {
+				console.log(
+					`--- "${label}" timed out and its log could not be read: output observation is unavailable ` +
+						`and the cause is unknown ---`,
+				);
+			} else if (tail) {
+				console.log(`--- last output from "${label}" before timeout ---\n${tail}`);
+			}
+		};
 		try {
 			// Start fully detached so the job outlives the (short-lived, 408-prone) exec round-trip.
 			// Run preamble+script in a nested `bash -c` so `set -eo pipefail` governs the inner shell:
@@ -539,13 +600,11 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 			// failure followed by a passing command would exit 0 and be recorded as success. The inner
 			// shell aborts on first failure and its real exit code flows through the `&&/||` capture —
 			// success writes 0, failure writes the real code.
-			const wrapped =
-				`bash -c ${shellQuote(`${this.preamble}; ${script}`)} > ${logPath} 2>&1 ` +
-				`&& echo 0 > ${donePath} || echo $? > ${donePath}`;
-			await this.launch(wrapped);
+			const wrapped = detachedCommand(tag, `${this.preamble}; ${script}`);
+			await withTimeout(this.launch(wrapped), remaining(), () => stepTimeout(label, timeoutMs));
+			evidence.state = "launch-accepted";
 
 			// Poll for the done-file, backing off adaptively so a quick step isn't over-charged for polls.
-			const deadline = started + timeoutMs;
 			let pollDelayMs = POLL_START_MS;
 			let consecutivePollFailures = 0;
 			for (;;) {
@@ -554,9 +613,22 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 				// for the rest of the command budget (see MAX_CONSECUTIVE_POLL_FAILURES).
 				let exitCode: number | null | undefined;
 				try {
-					exitCode = await this.pollDoneOnce(donePath, label);
+					exitCode = await withTimeout(
+						this.pollDoneOnce(donePath, label, deadline),
+						remaining(),
+						() => stepTimeout(label, timeoutMs),
+					);
+					evidence.lastObservationMs = Math.round(performance.now() - started);
+					evidence.state =
+						exitCode === undefined
+							? "running"
+							: exitCode === null
+								? "observation-unavailable"
+								: "completed";
+					evidence.exitCode = exitCode ?? null;
 					consecutivePollFailures = 0;
 				} catch (err) {
+					evidence.state = "observation-unavailable";
 					consecutivePollFailures++;
 					if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
 						const reason = err instanceof Error ? err.message : String(err);
@@ -571,7 +643,17 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 					try {
 						// this.pollFs, not the raw capability: once the poll has degraded, the read-back must not
 						// re-try the same broken API and burn its whole retry budget rediscovering that.
-						const stdout = await this.readCompletedLog(this.pollFs, logPath, label);
+						let stdout: string;
+						try {
+							stdout = await withTimeout(
+								this.readCompletedLog(this.pollFs, logPath, label, deadline),
+								remaining(),
+								() => stepTimeout(label, timeoutMs),
+							);
+						} catch (error) {
+							evidence.state = "collection-failed";
+							throw error;
+						}
 						return this.finishStep(
 							label,
 							started,
@@ -592,22 +674,28 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 					// A timed-out step is otherwise a black box: the log lives only inside the sandbox, and
 					// a step that hangs is exactly the one whose output we need. Best-effort — a failed read
 					// must not mask the timeout.
-					const tail = await this.readLogTail(this.pollFs, logPath);
-					// Best-effort stop the detached job; don't let a failing kill mask the timeout.
-					await this.execute(`pkill -f ${shellQuote(tag)} || true`).catch(() => undefined);
-					if (tail === null) {
-						console.log(
-							`--- "${label}" timed out and its log could not be read: the sandbox stopped ` +
-								`responding (memory exhaustion or a dead agent), rather than running quietly ---`,
-						);
-					} else if (tail) {
-						console.log(`--- last output from "${label}" before timeout ---\n${tail}`);
-					}
+					await recoverTimeoutEvidence();
 					throw stepTimeout(label, timeoutMs);
 				}
-				await this.sleep(pollDelayMs);
+				await this.sleep(Math.min(pollDelayMs, remaining()));
 				pollDelayMs = Math.min(pollDelayMs * POLL_BACKOFF, POLL_CAP_MS);
 			}
+		} catch (error) {
+			if (
+				performance.now() >= deadline &&
+				evidence.state !== "completed" &&
+				evidence.state !== "collection-failed"
+			) {
+				await recoverTimeoutEvidence();
+			}
+			if (this.stepLog.length === logCount)
+				this.stepLog.push({
+					phase: this.phase,
+					label,
+					ms: Math.round(performance.now() - started),
+					exitCode: evidence.exitCode,
+				});
+			throw error;
 		} finally {
 			stopHeartbeat();
 		}
@@ -618,32 +706,44 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 	private async pollDoneViaFs(
 		fs: SandboxFilesystem,
 		donePath: string,
+		deadline: number,
 	): Promise<number | null | undefined> {
 		// Bound both fs calls so a hung filesystem API (some adapters go over the network) can't
 		// stall the poll loop indefinitely — the outer deadline only advances between iterations.
 		// A timeout or fs error THROWS to the poll loop, which tolerates a transient blip but fails
 		// fast on a run of them (a dead sandbox); swallowing errors here once made a killed sandbox
 		// indistinguishable from a quietly-running step for the entire command budget.
-		if (!(await withTimeout(fs.exists(donePath), POLL_CAP_MS, "done-file fs exists"))) {
+		observationBudget(deadline);
+		if (
+			!(await withTimeout(fs.exists(donePath), observationBudget(deadline), "done-file fs exists"))
+		) {
 			return undefined;
 		}
-		// The background script writes the done-file non-atomically (truncate, then echo the code),
-		// so an empty read means "created but not yet written" — still running, not exit 0.
-		const raw = (await withTimeout(fs.readFile(donePath), POLL_CAP_MS, "done-file fs read")).trim();
-		return raw === "" ? undefined : this.parseCompletion(raw);
+		// Empty data cannot establish completion, even if the storage transport reports existence.
+		observationBudget(deadline);
+		const raw = await withTimeout(
+			fs.readFile(donePath),
+			observationBudget(deadline),
+			"done-file fs read",
+		);
+		return raw === "" ? undefined : completionCode(raw, donePath.split("/")[2] ?? "");
 	}
 
 	/** Poll fallback for providers whose adapter exposes no filesystem API: read the done-file with a
 	 *  `cat` exec, treating the {@link RUNNING_SENTINEL} (or empty output) as not-done-yet. */
-	private async pollDoneViaCat(donePath: string): Promise<number | null | undefined> {
+	private async pollDoneViaCat(
+		donePath: string,
+		deadline: number,
+	): Promise<number | null | undefined> {
 		// Bound the exec so a hung `cat` can't outlast the step budget. An exec failure or timeout
 		// THROWS to the poll loop (which tolerates transient blips but fails fast on a dead sandbox);
 		// an absent done-file is the RUNNING_SENTINEL, not an error.
+		observationBudget(deadline);
 		const probe = await withTimeout(
 			this.execute(
 				`bash -c ${shellQuote(`cat ${donePath} 2>/dev/null || echo ${RUNNING_SENTINEL}`)}`,
 			),
-			POLL_CAP_MS,
+			observationBudget(deadline),
 			"done-file cat poll",
 		);
 		// The `|| echo RUNNING_SENTINEL` guard makes bash exit 0 whether the done-file is present or
@@ -656,9 +756,9 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 				`done-file cat poll returned exit ${this.exitCode(probe)} — sandbox not responding`,
 			);
 		}
-		const out = (probe.stdout ?? "").trim();
-		if (out === "" || out === RUNNING_SENTINEL) return undefined;
-		return this.parseCompletion(out);
+		const out = probe.stdout ?? "";
+		if (out === "" || out.trim() === RUNNING_SENTINEL) return undefined;
+		return completionCode(out, donePath.split("/")[2] ?? "");
 	}
 
 	/** The last {@link TIMEOUT_LOG_TAIL_LINES} lines of a detached step's log, or `null` when the log
@@ -690,27 +790,34 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 		fs: SandboxFilesystem | undefined,
 		logPath: string,
 		label: string,
+		deadline: number,
 	): Promise<string> {
 		let lastFailure = "";
 		for (let attempt = 1; attempt <= READBACK_ATTEMPTS; attempt++) {
+			observationBudget(deadline);
 			if (fs) {
 				try {
-					return await withTimeout(fs.readFile(logPath), POLL_CAP_MS, "log fs read");
+					return await withTimeout(
+						fs.readFile(logPath),
+						observationBudget(deadline),
+						"log fs read",
+					);
 				} catch (err) {
 					lastFailure = err instanceof Error ? err.message : String(err);
 				}
 			} else {
-				const text = await this.catLogOrNull(logPath);
+				const text = await this.catLogOrNull(logPath, deadline);
 				if (text !== null) return text;
 				lastFailure = "log cat read failed";
 			}
-			if (attempt < READBACK_ATTEMPTS) await this.sleep(READBACK_DELAY_MS);
+			if (attempt < READBACK_ATTEMPTS)
+				await this.sleep(Math.min(READBACK_DELAY_MS, observationBudget(deadline)));
 		}
 		// Cross-transport fallback: the fs API can be freshly wedged while plain exec still answers —
 		// try the other transport before declaring the log unreachable. (No-fs sandboxes already spent
 		// every attempt on exec; there is no other transport to try.)
 		if (fs) {
-			const text = await this.catLogOrNull(logPath);
+			const text = await this.catLogOrNull(logPath, deadline);
 			if (text !== null) return text;
 			lastFailure = `${lastFailure}; exec fallback also failed`;
 		}
@@ -724,14 +831,15 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 	/** `cat` the log over exec for {@link readLogTail} and {@link readCompletedLog}, preserving a read
 	 *  failure as `null` rather than folding it into `""` — an unreadable log (wedged sandbox, dead
 	 *  transport) must stay distinguishable from a step that simply printed nothing. */
-	private async catLogOrNull(logPath: string): Promise<string | null> {
+	private async catLogOrNull(logPath: string, deadline = Infinity): Promise<string | null> {
 		// No `|| true`: a failing cat (unreadable/absent log) must surface as null, not as a
 		// successful empty read — `|| true` once collapsed exec-transport failure into stdout "",
 		// which readCompletedLog then accepted as the step's real (empty) output. Exit 0 with empty
 		// stdout remains a legitimate read of a genuinely empty log.
+		observationBudget(deadline);
 		return withTimeout(
 			this.execute(`bash -c ${shellQuote(`cat ${logPath} 2>/dev/null`)}`),
-			POLL_CAP_MS,
+			observationBudget(deadline),
 			"log cat read",
 		)
 			.then((res) => (this.exitCode(res) === 0 ? (res.stdout ?? "") : null))
@@ -744,7 +852,9 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 	 *  failed rm just leaves the same orphaned files the sandbox teardown reclaims anyway. */
 	private async removeDetachedFiles(logPath: string, donePath: string): Promise<void> {
 		await withTimeout(
-			this.execute(`bash -c ${shellQuote(`rm -f ${logPath} ${donePath}`)}`),
+			this.execute(
+				`bash -c ${shellQuote(`rm -f ${logPath} ${donePath}; rmdir ${donePath.slice(0, donePath.lastIndexOf("/"))}`)}`,
+			),
 			POLL_CAP_MS,
 			"detached file cleanup",
 		).catch(() => undefined);
@@ -762,10 +872,12 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 		});
 
 		if (result.stdout && !opts.silent) {
-			process.stdout.write(result.stdout.endsWith("\n") ? result.stdout : `${result.stdout}\n`);
+			const stdout = redactDiagnosticText(result.stdout, diagnosticSecretsFromEnv(process.env));
+			process.stdout.write(stdout.endsWith("\n") ? stdout : `${stdout}\n`);
 		}
 		if (result.stderr && !opts.silent) {
-			process.stderr.write(result.stderr.endsWith("\n") ? result.stderr : `${result.stderr}\n`);
+			const stderr = redactDiagnosticText(result.stderr, diagnosticSecretsFromEnv(process.env));
+			process.stderr.write(stderr.endsWith("\n") ? stderr : `${stderr}\n`);
 		}
 		console.log(`=== [${label}] exit ${this.describeExit(result)} in ${elapsedS}s ===`);
 
@@ -773,7 +885,10 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 			// A silent step withheld its output above; surface it now so the failure is debuggable. The
 			// detached transport merges stderr into stdout (2>&1), so fall back to stdout when no stderr.
 			if (opts.silent) {
-				const tail = result.stderr || result.stdout;
+				const tail = redactDiagnosticText(
+					result.stderr || result.stdout || "",
+					diagnosticSecretsFromEnv(process.env),
+				);
 				if (tail) process.stderr.write(tail.endsWith("\n") ? tail : `${tail}\n`);
 			}
 			const code = this.exitCode(result);
@@ -851,9 +966,6 @@ export class SessionStepRunner extends StepExecution<ExecResult> {
 			case "unknown":
 				return `unknown (${result.exit.detail})`;
 		}
-	}
-	protected override parseCompletion(raw: string): number | null {
-		return /^(?:0|[1-9][0-9]*)$/.test(raw) && Number(raw) <= 255 ? Number(raw) : null;
 	}
 	protected completed(code: number | null, stdout: string, durationMs: number): ExecResult {
 		return {

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -441,9 +441,16 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 		filesystem: SandboxFilesystem | undefined,
 		private readonly sleep: (ms: number) => Promise<void>,
 		passPolicy: PtsPassPolicy,
+		private readonly phaseDeadline?: (phase: Phase) => number,
 	) {
 		this.preamble = buildPreamble(passPolicy);
 		this.pollFs = filesystem;
+	}
+
+	private boundedTimeout(timeoutMs: number): number {
+		const remaining = this.phaseDeadline ? this.phaseDeadline(this.phase) - Date.now() : Infinity;
+		if (remaining <= 0) throw new Error(`${this.phase} phase deadline exceeded`);
+		return Math.min(timeoutMs, remaining);
 	}
 
 	protected abstract execute(command: string): Promise<Result>;
@@ -513,6 +520,7 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 		timeoutMs: number,
 		opts: StepOptions = {},
 	): Promise<Result> {
+		timeoutMs = this.boundedTimeout(timeoutMs);
 		console.log(`\n=== [${label}] ===`);
 		const started = performance.now();
 		const stopHeartbeat = startHeartbeat(label, started, timeoutMs);
@@ -523,6 +531,14 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 				timeoutMs,
 				() => stepTimeout(label, timeoutMs),
 			);
+		} catch (error) {
+			this.stepLog.push({
+				phase: this.phase,
+				label,
+				ms: performance.now() - started,
+				exitCode: null,
+			});
+			throw error;
 		} finally {
 			stopHeartbeat();
 		}
@@ -550,6 +566,7 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 		timeoutMs: number,
 		opts: StepOptions = {},
 	): Promise<Result> {
+		timeoutMs = this.boundedTimeout(timeoutMs);
 		console.log(`\n=== [${label}] (detached) ===`);
 		const started = performance.now();
 		const stopHeartbeat = startHeartbeat(label, started, timeoutMs);
@@ -628,6 +645,7 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 					evidence.exitCode = exitCode ?? null;
 					consecutivePollFailures = 0;
 				} catch (err) {
+					if (err instanceof GapError && err.gapCause.kind === "step-timeout") throw err;
 					evidence.state = "observation-unavailable";
 					consecutivePollFailures++;
 					if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
@@ -682,7 +700,8 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 			}
 		} catch (error) {
 			if (
-				performance.now() >= deadline &&
+				((error instanceof GapError && error.gapCause.kind === "step-timeout") ||
+					performance.now() >= deadline) &&
 				evidence.state !== "completed" &&
 				evidence.state !== "collection-failed"
 			) {
@@ -942,8 +961,9 @@ export class SessionStepRunner extends StepExecution<ExecResult> {
 		private readonly execution: ExecutionPolicy,
 		sleep: (ms: number) => Promise<void> = delay,
 		passPolicy: PtsPassPolicy = DEFAULT_PTS_PASS_POLICY,
+		phaseDeadline?: (phase: Phase) => number,
 	) {
-		super(session.files, sleep, passPolicy);
+		super(session.files, sleep, passPolicy, phaseDeadline);
 	}
 	protected execute(command: string): Promise<ExecResult> {
 		return this.session.exec(command);

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -72,17 +72,27 @@ const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 
 export type Phase = "create" | "setup" | "benchmark" | "collect";
 
+/**
+ * One executed ATTEMPT of a step. A retried step (setup steps declare `retries`; the collect loop
+ * re-runs its step through transient read-back failures) logs one entry per attempt, so a receipt
+ * reader must judge a step by its final entry, not by every entry. `allowFailure` records the
+ * declared policy so the reader can tell a tolerated non-zero exit from a real one.
+ */
 export interface StepLogEntry {
 	phase: Phase;
 	label: string;
 	ms: number;
 	exitCode: number | null;
+	/** Present (true) only when the step was declared `allowFailure`. */
+	allowFailure?: boolean;
 }
 
 export interface DetachedStepEvidence {
 	identity: string;
 	label: string;
 	phase: Phase;
+	/** Present (true) only when the step was declared `allowFailure`. */
+	allowFailure?: boolean;
 	state:
 		| "launch-pending"
 		| "launch-accepted"
@@ -426,6 +436,12 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 	/** The in-sandbox preamble prepended to every step, carrying this run's PTS pass policy. */
 	private readonly preamble: string;
 	/**
+	 * Credential values to scrub from echoed output, snapshotted once per runner. Deriving them walks
+	 * every registered provider's inputs, and a runner redacts on every stdout/stderr write of every
+	 * step — recomputing there made each output line pay the whole registry walk.
+	 */
+	private readonly secrets: readonly string[] = diagnosticSecretsFromEnv(process.env);
+	/**
 	 * The sandbox filesystem WHILE it is usable — cleared for good the first time it proves it isn't.
 	 *
 	 * "Exposes a filesystem" is not "has a working one": computesdk hands an adapter that declares no
@@ -532,17 +548,23 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 				() => stepTimeout(label, timeoutMs),
 			);
 		} catch (error) {
-			this.stepLog.push({
-				phase: this.phase,
-				label,
-				ms: performance.now() - started,
-				exitCode: null,
-			});
+			this.recordStep(label, performance.now() - started, null, opts);
 			throw error;
 		} finally {
 			stopHeartbeat();
 		}
 		return this.finishStep(label, started, result, opts);
+	}
+
+	/** Append one attempt to the step log, carrying the declared failure policy when it was set. */
+	private recordStep(label: string, ms: number, exitCode: number | null, opts: StepOptions): void {
+		this.stepLog.push({
+			phase: this.phase,
+			label,
+			ms,
+			exitCode,
+			...(opts.allowFailure ? { allowFailure: true } : {}),
+		});
 	}
 
 	/**
@@ -578,6 +600,7 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 			identity: tag,
 			label,
 			phase: this.phase,
+			...(opts.allowFailure ? { allowFailure: true } : {}),
 			state: "launch-pending",
 			exitCode: null,
 		};
@@ -591,9 +614,7 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 			evidence.state = "deadline-exceeded";
 			const rawTail = await this.readLogTail(this.pollFs, logPath);
 			const tail =
-				rawTail === null
-					? null
-					: redactDiagnosticText(rawTail, diagnosticSecretsFromEnv(process.env)).slice(-8192);
+				rawTail === null ? null : redactDiagnosticText(rawTail, this.secrets).slice(-8192);
 			evidence.logTail = tail;
 			// Best-effort stop the detached job; don't let a failing kill mask the timeout.
 			await withTimeout(
@@ -708,12 +729,7 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 				await recoverTimeoutEvidence();
 			}
 			if (this.stepLog.length === logCount)
-				this.stepLog.push({
-					phase: this.phase,
-					label,
-					ms: Math.round(performance.now() - started),
-					exitCode: evidence.exitCode,
-				});
+				this.recordStep(label, Math.round(performance.now() - started), evidence.exitCode, opts);
 			throw error;
 		} finally {
 			stopHeartbeat();
@@ -883,19 +899,14 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 	private finishStep(label: string, started: number, result: Result, opts: StepOptions): Result {
 		const elapsedMs = Math.round(performance.now() - started);
 		const elapsedS = (elapsedMs / 1000).toFixed(1);
-		this.stepLog.push({
-			phase: this.phase,
-			label,
-			ms: elapsedMs,
-			exitCode: this.exitCode(result),
-		});
+		this.recordStep(label, elapsedMs, this.exitCode(result), opts);
 
 		if (result.stdout && !opts.silent) {
-			const stdout = redactDiagnosticText(result.stdout, diagnosticSecretsFromEnv(process.env));
+			const stdout = redactDiagnosticText(result.stdout, this.secrets);
 			process.stdout.write(stdout.endsWith("\n") ? stdout : `${stdout}\n`);
 		}
 		if (result.stderr && !opts.silent) {
-			const stderr = redactDiagnosticText(result.stderr, diagnosticSecretsFromEnv(process.env));
+			const stderr = redactDiagnosticText(result.stderr, this.secrets);
 			process.stderr.write(stderr.endsWith("\n") ? stderr : `${stderr}\n`);
 		}
 		console.log(`=== [${label}] exit ${this.describeExit(result)} in ${elapsedS}s ===`);
@@ -904,10 +915,7 @@ abstract class StepExecution<Result extends { stdout?: string; stderr?: string }
 			// A silent step withheld its output above; surface it now so the failure is debuggable. The
 			// detached transport merges stderr into stdout (2>&1), so fall back to stdout when no stderr.
 			if (opts.silent) {
-				const tail = redactDiagnosticText(
-					result.stderr || result.stdout || "",
-					diagnosticSecretsFromEnv(process.env),
-				);
+				const tail = redactDiagnosticText(result.stderr || result.stdout || "", this.secrets);
 				if (tail) process.stderr.write(tail.endsWith("\n") ? tail : `${tail}\n`);
 			}
 			const code = this.exitCode(result);

--- a/packages/harness/src/lib/phase-budget.test.ts
+++ b/packages/harness/src/lib/phase-budget.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import type { SandboxSession } from "@sandbox-benchmarks/driver";
+import { SessionStepRunner } from "./execute.ts";
+
+test("an exhausted phase never launches a subsequent command", async () => {
+	let calls = 0;
+	let deadline = Date.now() + 60_000;
+	const session: SandboxSession = {
+		sandboxRef: { provider: "tama", id: "test" },
+		artifact: { kind: "none" },
+		native: undefined,
+		destroy: async () => {},
+		exec: async () => {
+			calls++;
+			return {
+				exit: { kind: "exited", code: 0 },
+				stdout: "",
+				stderr: "",
+				durationMs: 1,
+				truncated: false,
+			};
+		},
+	};
+	const runner = new SessionStepRunner(
+		session,
+		{ syncCapMs: null, durable: "none" },
+		undefined,
+		{ mode: "fixed", times: 2 },
+		() => deadline,
+	);
+	runner.phase = "benchmark";
+	await runner.step("first command", "true", 1000);
+	deadline = Date.now() - 1;
+	await expect(runner.step("second command", "true", 1000)).rejects.toThrow("phase deadline");
+	expect(calls).toBe(1);
+});
+
+test("foreground transport failure preserves attempted phase with unknown exit", async () => {
+	const session: SandboxSession = {
+		sandboxRef: { provider: "tama", id: "test" },
+		artifact: { kind: "none" },
+		native: undefined,
+		destroy: async () => {},
+		exec: async () => {
+			throw new Error("transport unavailable");
+		},
+	};
+	const runner = new SessionStepRunner(session, { syncCapMs: null, durable: "none" });
+	runner.phase = "benchmark";
+	await expect(runner.run("workload", "true", 1000)).rejects.toThrow("transport unavailable");
+	expect(runner.stepLog).toMatchObject([{ label: "workload", phase: "benchmark", exitCode: null }]);
+});
+
+test("managed setup pins and verifies the experiment commit, independent of ambient branch defaults", async () => {
+	const { setupSteps } = await import("./setup.ts");
+	const sha = "a".repeat(40);
+	const clone = setupSteps(
+		{ commands: [], commandTimeoutMinutes: 1, timeoutMinutes: 1, dimensions: [], metrics: [] },
+		sha,
+	).find((step) => step.label === "clone repo");
+	expect(clone?.script).toContain(`git checkout --detach "${sha}"`);
+	expect(clone?.script).toContain(`test "$(git rev-parse HEAD)" = "${sha}"`);
+});

--- a/packages/harness/src/lib/session-execute.test.ts
+++ b/packages/harness/src/lib/session-execute.test.ts
@@ -57,7 +57,7 @@ describe("session execution", () => {
 				files: {
 					exists: async () => true,
 					readFile: async (path) => {
-						if (path.endsWith(".done")) return "7";
+						if (path.endsWith(".done")) return receipt(path, "7");
 						if (++reads === 1) throw new Error("transient file read");
 						return "stdout and stderr\n";
 					},
@@ -86,7 +86,8 @@ describe("session execution", () => {
 			session({
 				exec: async (command) => {
 					commands.push(command);
-					if (command.includes("cat /tmp") && command.includes(".done")) return result("0");
+					if (command.includes("cat /tmp") && command.includes(".done"))
+						return result(receipt(command));
 					return result("output");
 				},
 			}),
@@ -114,3 +115,8 @@ describe("session execution", () => {
 		expect(runner.stepLog[0]?.exitCode).toBeNull();
 	});
 });
+
+function receipt(location: string, code = "0"): string {
+	const identity = /bench-[a-f0-9-]+/.exec(location)?.[0];
+	return `v1 ${identity} ${code}`;
+}

--- a/packages/harness/src/lib/setup.ts
+++ b/packages/harness/src/lib/setup.ts
@@ -48,7 +48,10 @@ export interface SetupStep {
 	retries?: number;
 }
 
-export function setupSteps(suite: Suite): SetupStep[] {
+export function setupSteps(suite: Suite, sourceRevision?: string): SetupStep[] {
+	if (sourceRevision !== undefined && !/^[a-f0-9]{40}$/.test(sourceRevision))
+		throw new Error("managed source revision must be a commit SHA");
+	const ref = sourceRevision ?? REPO_REF;
 	const steps: SetupStep[] = [
 		{
 			label: "install base packages",
@@ -63,7 +66,7 @@ export function setupSteps(suite: Suite): SetupStep[] {
 			label: "clone repo",
 			// Drop the token from the remote immediately so later steps can't leak it. Branch refs need
 			// the origin/ fallback: bare `checkout --detach <branch>` DWIMs a remote branch into -b mode.
-			script: `rm -rf ${DIR} && git clone "${CLONE_URL}" ${DIR} && cd ${DIR} && git remote set-url origin "${REPO_URL}" && (git checkout --detach "${REPO_REF}" 2>/dev/null || git checkout --detach "origin/${REPO_REF}") && git log -1 --oneline`,
+			script: `rm -rf ${DIR} && git clone "${CLONE_URL}" ${DIR} && cd ${DIR} && git remote set-url origin "${REPO_URL}" && (git checkout --detach "${ref}" 2>/dev/null || git checkout --detach "origin/${ref}") && git log -1 --oneline${sourceRevision ? ` && test "$(git rev-parse HEAD)" = "${sourceRevision}"` : ""}`,
 			timeoutMs: 5 * MIN,
 		},
 		{

--- a/packages/harness/src/session-operations.test.ts
+++ b/packages/harness/src/session-operations.test.ts
@@ -37,6 +37,7 @@ function fixture(exec: SandboxSession["exec"]) {
 		},
 	};
 	const driver: SandboxDriver = {
+		probes: { observe: async () => ({ state: calls.includes("destroy") ? "absent" : "running" }) },
 		async create(request, options) {
 			expect(request.artifact).toEqual(artifact);
 			expect(request.deadlineMs).toBe(1000);

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -6,7 +6,11 @@
 // are implementation detail. This surface exposes only the entry points consumers (the CLI) need:
 // normalize a raw tree, write the Run, and summarize it.
 export { aggregateRuns } from "./lib/aggregate.ts";
-export type { AttemptWithRun, CoverageReport } from "./lib/experiment.ts";
+export type {
+	AttemptWithRun,
+	CoverageReport,
+	ExperimentAggregation,
+} from "./lib/experiment.ts";
 export {
 	aggregateExperiment,
 	evaluateExperiment,

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -6,6 +6,13 @@
 // are implementation detail. This surface exposes only the entry points consumers (the CLI) need:
 // normalize a raw tree, write the Run, and summarize it.
 export { aggregateRuns } from "./lib/aggregate.ts";
+export type { AttemptWithRun, CoverageReport } from "./lib/experiment.ts";
+export {
+	aggregateExperiment,
+	evaluateExperiment,
+	evidenceDigest,
+	verifyExperimentPlan,
+} from "./lib/experiment.ts";
 // The dataset↔figures seam: the registries the figure model is built from, the figure list the
 // Markdown links, where the charts land, the caption under each one — and the chart HTML itself. All of it pure and browser-free: `renderLeaderboardFigureHtml` builds
 // strings, and rasterising them is the CLI's job (`@sandbox-benchmarks/figures/screenshot`).

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -369,6 +369,11 @@ function mergeProvider(
  * at the boundary.
  */
 export function aggregateRuns(runs: readonly Run[]): Run {
+	if (runs.some((run) => run.experiment !== undefined)) {
+		throw new Error(
+			"aggregateRuns cannot merge completed experiments; use original planned attempts to preserve eligibility and provenance",
+		);
+	}
 	if (runs.length === 0) {
 		throw new Error("aggregateRuns requires at least one shard Run");
 	}

--- a/packages/results/src/lib/experiment.ts
+++ b/packages/results/src/lib/experiment.ts
@@ -177,6 +177,22 @@ export interface CoverageReport {
 	conflicts: string[];
 }
 
+/**
+ * The harness logs one entry per ATTEMPT of a step (retried setup steps, re-collected results), so
+ * a step is judged by its final attempt: an earlier failure that a later attempt superseded is
+ * evidence of a retry, not of a failed run. Keyed by phase + label because the same label can name
+ * different work in different phases.
+ */
+function finalAttempts<T extends { phase: string; label: string }>(entries: readonly T[]): T[] {
+	return [...new Map(entries.map((entry) => [`${entry.phase}\0${entry.label}`, entry])).values()];
+}
+
+/** A step succeeded, or was declared tolerant of failure AND actually reported an exit code — the
+ *  tolerance covers a non-zero exit, never a step whose completion was not observed. */
+function stepAccepted(step: { exitCode: number | null; allowFailure?: boolean }): boolean {
+	return step.exitCode === 0 || (step.allowFailure === true && step.exitCode !== null);
+}
+
 /** Evaluate whole attempts against the frozen denominator. Artifact order never selects a sample. */
 export function evaluateExperiment(
 	input: unknown,
@@ -283,8 +299,10 @@ export function evaluateExperiment(
 			execution.primaryFailure === null &&
 			execution.steps.some((step) => step.phase === "benchmark") &&
 			execution.steps.some((step) => step.phase === "collect") &&
-			execution.steps.every((step) => step.exitCode === 0) &&
-			execution.detached.every((step) => step.state === "completed" && step.exitCode === 0) &&
+			finalAttempts(execution.steps).every(stepAccepted) &&
+			finalAttempts(execution.detached).every(
+				(step) => step.state === "completed" && stepAccepted(step),
+			) &&
 			artifact?.sandboxId === execution.sandboxId;
 		const completed =
 			receiptsConfirmSuccess &&
@@ -325,13 +343,23 @@ export function evaluateExperiment(
 	return report;
 }
 
-/** Only this path creates a Run with verified experiment linkage. */
+export interface ExperimentAggregation {
+	coverage: CoverageReport;
+	/** Present only when coverage is complete: the one Run carrying verified experiment linkage. */
+	run?: Run;
+}
+
+/**
+ * Only this path creates a Run with verified experiment linkage. It evaluates coverage itself (a
+ * caller-supplied report could not be trusted) and hands that report back, so a caller that must
+ * persist coverage whether or not publication proceeds evaluates exactly once.
+ */
 export function aggregateExperiment(
 	plan: ExperimentPlan,
 	attempts: readonly AttemptWithRun[],
-): Run {
+): ExperimentAggregation {
 	const coverage = evaluateExperiment(plan, attempts);
-	if (!coverage.complete) throw new Error(`experiment is incomplete: ${JSON.stringify(coverage)}`);
+	if (!coverage.complete) return { coverage };
 	const selected = new Set(coverage.selectedAttempts);
 	const runs = attempts
 		.filter(({ evidence }) => selected.has(evidence.id))
@@ -369,7 +397,7 @@ export function aggregateExperiment(
 			]),
 		).values(),
 	].toSorted((a, b) => a.suite.localeCompare(b.suite));
-	return parseRun({
+	const run = parseRun({
 		...merged,
 		schemaVersion: "7",
 		experiment: {
@@ -378,4 +406,5 @@ export function aggregateExperiment(
 			attemptIds: coverage.selectedAttempts,
 		},
 	});
+	return { coverage, run };
 }

--- a/packages/results/src/lib/experiment.ts
+++ b/packages/results/src/lib/experiment.ts
@@ -1,0 +1,381 @@
+import { createHash } from "node:crypto";
+import type {
+	CleanupReceipt,
+	ExecutionReceipt,
+	ExperimentAttempt,
+	ExperimentPlan,
+	Run,
+} from "@sandbox-benchmarks/schema";
+import {
+	artifactVerified,
+	canonicalJsonString,
+	cleanupReceiptSchema,
+	effectiveArtifact,
+	executionReceiptSchema,
+	experimentAttemptSchema,
+	experimentPlanSchema,
+	getProvider,
+	parseRun,
+	providerReportedNothing,
+} from "@sandbox-benchmarks/schema";
+import { aggregateRuns } from "./aggregate.ts";
+
+export function evidenceDigest(value: unknown): string {
+	// Full experiment/Run envelopes are larger than individual vendor response diagnostics.
+	return `sha256:${createHash("sha256")
+		.update(
+			canonicalJsonString(value, {
+				maxBytes: 32 * 1024 * 1024,
+				maxDepth: 64,
+				maxNodes: 1_000_000,
+				maxArrayLength: 100_000,
+				maxObjectKeys: 10_000,
+				maxStringLength: 1024 * 1024,
+				maxKeyLength: 1024,
+			}),
+		)
+		.digest("hex")}`;
+}
+
+export function verifyExperimentPlan(value: unknown): ExperimentPlan {
+	const plan = experimentPlanSchema.assert(value);
+	const { digest, ...body } = plan;
+	if (evidenceDigest(body) !== digest) throw new Error("experiment plan digest mismatch");
+	const validDate = (date: string) => {
+		const parsed = new Date(`${date}T00:00:00Z`);
+		return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === date;
+	};
+	if (!validDate(plan.createdOn)) throw new Error("invalid experiment creation date");
+	const cells = new Map(plan.cells.map((cell) => [cell.id, cell]));
+	const quotaDomains = new Map<string, string>();
+	for (const cell of plan.cells) {
+		if (evidenceDigest(cell.target) !== evidenceDigest(plan.cells[0]?.target))
+			throw new Error("a published experiment requires one target resource specification");
+		const vendor = getProvider(cell.provider).vendor;
+		if (quotaDomains.has(vendor) && quotaDomains.get(vendor) !== cell.quotaDomain)
+			throw new Error(`shared provider credentials require one quota domain: ${vendor}`);
+		quotaDomains.set(vendor, cell.quotaDomain);
+	}
+	if (cells.size !== plan.cells.length) throw new Error("duplicate experiment cell");
+	const logical = new Set(
+		plan.cells.map((cell) => `${cell.provider}/${cell.suite}/${cell.replicate}`),
+	);
+	if (logical.size !== cells.size) throw new Error("duplicate logical replicate");
+	const assigned = new Set<string>();
+	const eligibleCells = plan.cells.filter((cell) =>
+		cell.metrics.some((metric) => !cell.exclusions.some((entry) => entry.metricId === metric)),
+	);
+	if (eligibleCells.length === 0) throw new Error("experiment has no eligible work");
+	const accounts = new Map(plan.accounts.map((account) => [account.quotaDomain, account]));
+	if (accounts.size !== plan.accounts.length) throw new Error("duplicate quota domain");
+	const batchIds = new Set<string>();
+	for (const batch of plan.batches) {
+		const account = accounts.get(batch.quotaDomain);
+		if (
+			!account ||
+			batch.maxConcurrency > account.sandboxes ||
+			batch.cells.length > batch.maxConcurrency ||
+			batch.budgetMinutes > 180
+		) {
+			throw new Error(`invalid account batch capacity: ${batch.id}`);
+		}
+		if (batchIds.has(batch.id)) throw new Error("duplicate experiment batch");
+		batchIds.add(batch.id);
+		for (const id of batch.cells) {
+			const cell = cells.get(id);
+			if (
+				!cell ||
+				!eligibleCells.includes(cell) ||
+				assigned.has(id) ||
+				cell.quotaDomain !== batch.quotaDomain
+			) {
+				throw new Error(`invalid batch assignment: ${id}`);
+			}
+			assigned.add(id);
+		}
+		const members = batch.cells.map((id) => cells.get(id)).filter((cell) => cell !== undefined);
+		if (
+			members.reduce((sum, cell) => sum + (cell.gpu?.count ?? 0), 0) > (account.gpus ?? 0) ||
+			members.reduce((sum, cell) => sum + cell.target.vcpus, 0) > (account.vcpus ?? Infinity) ||
+			members.reduce((sum, cell) => sum + cell.target.memoryGb, 0) >
+				(account.memoryGb ?? Infinity) ||
+			members.some(
+				(cell) =>
+					cell.startupMinutes + cell.workloadMinutes + cell.finishMinutes + 15 >
+					batch.budgetMinutes,
+			)
+		) {
+			throw new Error(`batch exceeds resource or time budget: ${batch.id}`);
+		}
+	}
+	if (assigned.size !== eligibleCells.length)
+		throw new Error("experiment cells missing from batches");
+	const scheduled = new Set<string>();
+	const roundIds = new Set<string>();
+	for (const round of plan.rounds) {
+		if (roundIds.has(round.id) || round.batches.length > 256)
+			throw new Error(`invalid collection round: ${round.id}`);
+		roundIds.add(round.id);
+		for (const id of round.batches) {
+			const batch = plan.batches.find((entry) => entry.id === id);
+			if (!batch || batch.quotaDomain !== round.quotaDomain || scheduled.has(id))
+				throw new Error(`invalid round assignment: ${id}`);
+			scheduled.add(id);
+		}
+	}
+	if (scheduled.size !== plan.batches.length)
+		throw new Error("batches missing from collection rounds");
+	const cohorts = new Map<string, string>();
+	for (const cell of cells.values()) {
+		const cohort = cell.suite;
+		const eligibility = evidenceDigest({
+			workloadRevision: cell.workloadRevision,
+			metrics: cell.metrics.toSorted(),
+			exclusions: cell.exclusions.toSorted((a, b) => a.metricId.localeCompare(b.metricId)),
+			environmentRevision: cell.environmentRevision,
+			passes: cell.passes,
+		});
+		if (cohorts.has(cohort) && cohorts.get(cohort) !== eligibility)
+			throw new Error(`inconsistent comparison cohort: ${cohort}`);
+		cohorts.set(cohort, eligibility);
+		if (new Set(cell.metrics).size !== cell.metrics.length)
+			throw new Error("duplicate required metric");
+		const excluded = new Set<string>();
+		for (const exclusion of cell.exclusions) {
+			if (
+				!validDate(exclusion.expires) ||
+				exclusion.workloadRevision !== cell.workloadRevision ||
+				!cell.metrics.includes(exclusion.metricId) ||
+				exclusion.expires <= plan.createdOn ||
+				excluded.has(exclusion.metricId)
+			) {
+				throw new Error(`invalid or expired exclusion: ${cell.id}/${exclusion.metricId}`);
+			}
+			excluded.add(exclusion.metricId);
+		}
+	}
+	return plan;
+}
+
+export interface AttemptWithRun {
+	evidence: ExperimentAttempt;
+	run?: Run;
+	execution?: ExecutionReceipt;
+	cleanup?: CleanupReceipt;
+}
+
+export interface CoverageReport {
+	planDigest: string;
+	complete: boolean;
+	selectedAttempts: string[];
+	cells: Array<{
+		id: string;
+		status: "complete" | "missing" | "failed" | "cancelled" | "excluded";
+		missingMetrics: string[];
+		excludedMetrics: string[];
+	}>;
+	conflicts: string[];
+}
+
+/** Evaluate whole attempts against the frozen denominator. Artifact order never selects a sample. */
+export function evaluateExperiment(
+	input: unknown,
+	attempts: readonly AttemptWithRun[],
+): CoverageReport {
+	const plan = verifyExperimentPlan(input);
+	const report: CoverageReport = {
+		planDigest: plan.digest,
+		complete: false,
+		selectedAttempts: [],
+		cells: [],
+		conflicts: [],
+	};
+	const ids = new Set<string>();
+	const knownCells = new Set(plan.cells.map((cell) => cell.id));
+	for (const { evidence: raw, run } of attempts.toSorted((a, b) =>
+		a.evidence.id.localeCompare(b.evidence.id),
+	)) {
+		const evidence = experimentAttemptSchema.assert(raw);
+		if (run) parseRun(run);
+		if (ids.has(evidence.id)) report.conflicts.push(`duplicate attempt: ${evidence.id}`);
+		ids.add(evidence.id);
+		if (
+			!knownCells.has(evidence.cellId) ||
+			evidence.planDigest !== plan.digest ||
+			evidence.sha !== plan.sha
+		) {
+			report.conflicts.push(`attempt provenance mismatch: ${evidence.id}`);
+		}
+		const cell = plan.cells.find((entry) => entry.id === evidence.cellId);
+		if (
+			cell &&
+			(evidence.workloadRevision !== cell.workloadRevision ||
+				evidence.environmentRevision !== cell.environmentRevision ||
+				evidence.artifactIdentity !== cell.artifactIdentity ||
+				evidence.passes !== cell.passes)
+		) {
+			report.conflicts.push(`attempt execution policy mismatch: ${evidence.id}`);
+		}
+		if (
+			run &&
+			(!cell ||
+				run.sha !== plan.sha ||
+				run.runId !== plan.id ||
+				evidenceDigest(run.targetSpec) !== evidenceDigest(cell?.target) ||
+				evidenceDigest(run) !== evidence.runDigest)
+		) {
+			report.conflicts.push(`attempt shard mismatch: ${evidence.id}`);
+		}
+	}
+	for (const cell of plan.cells) {
+		const lineage = attempts
+			.filter(({ evidence }) => evidence.cellId === cell.id)
+			.toSorted(
+				(a, b) =>
+					a.evidence.sequence - b.evidence.sequence || a.evidence.id.localeCompare(b.evidence.id),
+			);
+		const excludedMetrics = cell.exclusions.map((exclusion) => exclusion.metricId);
+		const eligible = cell.metrics.filter((id) => !excludedMetrics.includes(id));
+		if (eligible.length === 0) {
+			if (lineage.length > 0)
+				report.conflicts.push(`unexpected execution of excluded cell: ${cell.id}`);
+			report.cells.push({ id: cell.id, status: "excluded", missingMetrics: [], excludedMetrics });
+			continue;
+		}
+		let validLineage = lineage.length <= plan.maxPremeasurementRetries + 1;
+		for (let index = 0; index < lineage.length; index++) {
+			const current = lineage[index]?.evidence;
+			const previous = lineage[index - 1]?.evidence;
+			if (
+				!current ||
+				current.sequence !== index ||
+				(previous
+					? current.previousAttempt !== previous.id ||
+						previous.outcome !== "failed" ||
+						previous.measurementStarted ||
+						!previous.retryable ||
+						previous.cleanup === "unresolved"
+					: current.previousAttempt !== undefined)
+			)
+				validLineage = false;
+		}
+		if (!validLineage) report.conflicts.push(`unauthorized retry lineage: ${cell.id}`);
+		const selected = lineage.at(-1);
+		const provider = selected?.run?.providers.find((entry) => entry.providerId === cell.provider);
+		const artifact = provider?.artifactEvidence?.find(
+			(entry) => entry.cell.suite === cell.suite && entry.cell.replicateIndex === cell.replicate,
+		);
+		const measured = new Set(provider?.metrics.map((metric) => metric.metricId) ?? []);
+		const missingMetrics = eligible.filter((id) => !measured.has(id));
+		const evidence = selected?.evidence;
+		const execution = selected?.execution && executionReceiptSchema.assert(selected.execution);
+		const cleanup = selected?.cleanup && cleanupReceiptSchema.assert(selected.cleanup);
+		const receiptsConfirmSuccess =
+			execution !== undefined &&
+			cleanup !== undefined &&
+			execution.runId === plan.id &&
+			execution.provider === cell.provider &&
+			execution.suite === cell.suite &&
+			execution.replicateIndex === cell.replicate &&
+			cleanup.executionId === execution.executionId &&
+			cleanup.completed &&
+			cleanup.confirmedAbsent &&
+			execution.primaryFailure === null &&
+			execution.steps.some((step) => step.phase === "benchmark") &&
+			execution.steps.some((step) => step.phase === "collect") &&
+			execution.steps.every((step) => step.exitCode === 0) &&
+			execution.detached.every((step) => step.state === "completed" && step.exitCode === 0) &&
+			artifact?.sandboxId === execution.sandboxId;
+		const completed =
+			receiptsConfirmSuccess &&
+			evidence?.outcome === "completed" &&
+			evidence.completion === "known-success" &&
+			evidence.measurementStarted &&
+			evidence.cleanup === "confirmed" &&
+			evidence.rawDigest !== undefined &&
+			selected?.run?.providers.every(
+				(entry) => entry.providerId === cell.provider || providerReportedNothing(entry),
+			) &&
+			artifact !== undefined &&
+			artifactVerified(artifact) &&
+			evidenceDigest(effectiveArtifact(artifact.provenance)) === cell.artifactIdentity &&
+			selected?.run?.replicateIndex === cell.replicate &&
+			provider?.suitesCovered.includes(cell.suite) &&
+			missingMetrics.length === 0 &&
+			!provider.gaps.some((gap) => {
+				if (gap.scope !== "suite" || gap.id !== cell.suite) return true;
+				return (
+					gap.cause?.kind !== "metrics-unrecorded" ||
+					gap.cause.metricIds.some((id) => !excludedMetrics.includes(id))
+				);
+			});
+		const status = !selected
+			? "missing"
+			: completed && validLineage
+				? "complete"
+				: evidence?.outcome === "cancelled"
+					? "cancelled"
+					: "failed";
+		report.cells.push({ id: cell.id, status, missingMetrics, excludedMetrics });
+		if (status === "complete" && evidence) report.selectedAttempts.push(evidence.id);
+	}
+	report.complete =
+		report.conflicts.length === 0 &&
+		report.cells.every((cell) => cell.status === "complete" || cell.status === "excluded");
+	return report;
+}
+
+/** Only this path creates a Run with verified experiment linkage. */
+export function aggregateExperiment(
+	plan: ExperimentPlan,
+	attempts: readonly AttemptWithRun[],
+): Run {
+	const coverage = evaluateExperiment(plan, attempts);
+	if (!coverage.complete) throw new Error(`experiment is incomplete: ${JSON.stringify(coverage)}`);
+	const selected = new Set(coverage.selectedAttempts);
+	const runs = attempts
+		.filter(({ evidence }) => selected.has(evidence.id))
+		.toSorted((a, b) => a.evidence.cellId.localeCompare(b.evidence.cellId))
+		.map(({ run, evidence }) => {
+			if (!run || Number(run.schemaVersion) < 6)
+				throw new Error("experiment publication requires artifact-attributed shards");
+			const cell = plan.cells.find((entry) => entry.id === evidence.cellId);
+			const eligible = new Set(
+				cell?.metrics.filter((id) => !cell.exclusions.some((entry) => entry.metricId === id)),
+			);
+			return {
+				...run,
+				providers: run.providers.map((provider) => ({
+					...provider,
+					metrics: provider.metrics.filter((metric) => eligible.has(metric.metricId)),
+				})),
+			};
+		});
+	const merged = aggregateRuns(runs);
+	const cohorts = [
+		...new Map(
+			plan.cells.map((cell) => [
+				cell.suite,
+				{
+					suite: cell.suite,
+					target: cell.target,
+					workloadRevision: cell.workloadRevision,
+					environmentRevision: cell.environmentRevision,
+					passes: cell.passes,
+					metrics: cell.metrics
+						.filter((id) => !cell.exclusions.some((entry) => entry.metricId === id))
+						.toSorted(),
+				},
+			]),
+		).values(),
+	].toSorted((a, b) => a.suite.localeCompare(b.suite));
+	return parseRun({
+		...merged,
+		schemaVersion: "7",
+		experiment: {
+			planDigest: plan.digest,
+			cohortDigest: evidenceDigest(cohorts),
+			attemptIds: coverage.selectedAttempts,
+		},
+	});
+}

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -310,6 +310,7 @@ export interface AbsentProvider {
 /** The full comparison surface derived from one Run. */
 export interface Leaderboard {
 	runId: string;
+	comparisonCohort?: string;
 	sha: string;
 	generatedAt: string;
 	/** The requested comparison target recorded on this Run — never substituted from global config. */
@@ -709,6 +710,7 @@ export function buildLeaderboard(run: Run): Leaderboard {
 
 	return {
 		runId: run.runId,
+		...(run.experiment?.cohortDigest ? { comparisonCohort: run.experiment.cohortDigest } : {}),
 		sha: run.sha,
 		generatedAt: run.generatedAt,
 		targetSpec: run.targetSpec,
@@ -1117,6 +1119,12 @@ export function renderLeaderboardMarkdown(
 		"",
 		`Run ${runSourceLinks(board.runId)} · commit ${commitSourceLink(board.sha)} ·`,
 		`dataset ${datasetSourceLink(board.runId)} · generated ${board.generatedAt}`,
+		...(board.comparisonCohort
+			? [
+					"",
+					`Comparison cohort: \`${board.comparisonCohort}\`. Compare scores only with the same workload and eligible metric cohort.`,
+				]
+			: []),
 		"",
 		`Requested target for every provider: **${spec}**. This run contains **${rows.length} metric records**`,
 		`backed by **${observationCount} retained trial observations**, across **${metricCount} ${metricNoun}** and`,

--- a/packages/schema/CONTEXT.md
+++ b/packages/schema/CONTEXT.md
@@ -1,0 +1,25 @@
+# Benchmark experiments
+
+This context names the planned work and evidence used to establish a benchmark comparison.
+
+## Language
+
+**Experiment plan**:
+The frozen selection of providers, workloads, logical replicates, eligible metrics, revisions and
+resource policy that defines a complete comparison.
+
+**Logical replicate**:
+One planned sandbox measurement identified independently of any attempt to execute it. Repeating an
+attempt does not add a new logical replicate.
+
+**Execution attempt**:
+One effort to perform a logical replicate, including its allocation, measurement and cleanup outcome.
+A failed or interrupted attempt remains part of the experiment's evidence.
+
+**Eligible metric**:
+A metric admitted by the experiment plan and not covered by its reviewed exclusions. Other collected
+measurements may remain diagnostic evidence without contributing to that comparison.
+
+**Comparison cohort**:
+The workload revisions, execution environment, pass policy, requested resources and eligible metrics
+that must agree for scores to be compared.

--- a/packages/schema/scripts/generate-provider-wiring.test.ts
+++ b/packages/schema/scripts/generate-provider-wiring.test.ts
@@ -17,7 +17,9 @@ import {
 	parseDriverMigrationWaivers,
 	preAuthBindings,
 	providerInputBindings,
+	quotaDomainBindings,
 	REPO_ROOT,
+	renderAccountConcurrencyGroup,
 	renderCiSecretTable,
 	renderCiVariableTable,
 	renderDotenvValue,
@@ -92,6 +94,23 @@ describe("provider wiring projections", () => {
 		expect(renderRunnerSelection()).toBe(`    runs-on: \${{ 'ubuntu-24.04' }}`);
 		expect(renderRunnerNoCache("")).toBe(`no-cache: \${{ false && 'true' || 'false' }}`);
 		expect(renderRunnerLifetime("")).toBe(`BENCH_RUNNER_LIFETIME_MINUTES: \${{ '' }}`);
+	});
+
+	test("queues every provider behind its registry quota domain", () => {
+		const bindings = quotaDomainBindings();
+		// Every provider is charged to exactly one domain; only shared-credential variants share one.
+		expect(bindings.flatMap(({ owners }) => owners)).toEqual([...PROVIDER_IDS]);
+		expect(bindings.filter(({ owners }) => owners.length > 1)).toEqual([
+			{ domain: "daytona", owners: ["daytona-vm", "daytona-container"] },
+			{ domain: "modal", owners: ["modal-gvisor", "modal-vm"] },
+		]);
+		// A provider that shares no credential is its own domain — never a stray custom name.
+		expect(
+			bindings.filter(({ domain, owners }) => owners.length === 1 && owners[0] !== domain),
+		).toEqual([]);
+		expect(renderAccountConcurrencyGroup("")).toBe(
+			`group: benchmark-account-\${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && 'daytona' || (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && 'modal' || matrix.provider }}`,
+		);
 	});
 
 	test("scopes secrets, shared inputs, capability literals, and pre-auth values safely", () => {

--- a/packages/schema/scripts/generate-provider-wiring.ts
+++ b/packages/schema/scripts/generate-provider-wiring.ts
@@ -35,6 +35,11 @@ export interface RunnerBinding {
 	readonly owners: readonly ProviderId[];
 }
 
+export interface QuotaDomainBinding {
+	readonly domain: string;
+	readonly owners: readonly ProviderId[];
+}
+
 export type WiringLane = "matrix" | "release-scope";
 
 export interface DriverMigrationWaiver {
@@ -138,6 +143,16 @@ export function runnerBindings(): RunnerBinding[] {
 	return [...bindings.values()];
 }
 
+/** Every quota domain with the providers charged to it, in registry order. */
+export function quotaDomainBindings(): QuotaDomainBinding[] {
+	const bindings = new Map<string, ProviderId[]>();
+	for (const id of PROVIDER_IDS) {
+		const domain = providerMeta(id).quotaDomain ?? id;
+		bindings.set(domain, [...(bindings.get(domain) ?? []), id]);
+	}
+	return [...bindings].map(([domain, owners]) => ({ domain, owners }));
+}
+
 function ghaString(value: string): string {
 	return `'${value.replaceAll("'", "''")}'`;
 }
@@ -223,6 +238,20 @@ export function renderRunnerNoCache(indent = "          "): string {
 		.flatMap(({ owners: policyOwners }) => policyOwners);
 	const condition = owners.length === 0 ? "false" : ownerCondition(owners, "matrix");
 	return `${indent}no-cache: \${{ ${condition} && 'true' || 'false' }}`;
+}
+
+/**
+ * The per-cell Actions concurrency group that serialises every job charged to one vendor account.
+ * Providers whose domain is their own id fall through to `matrix.provider`; only shared domains
+ * need a clause, so the expression stays readable in the workflow.
+ */
+export function renderAccountConcurrencyGroup(indent = "      "): string {
+	const clauses = quotaDomainBindings().flatMap(({ domain, owners }) =>
+		owners.length === 1 && owners[0] === domain
+			? []
+			: [`${ownerCondition(owners, "matrix")} && ${ghaString(domain)}`],
+	);
+	return `${indent}group: benchmark-account-\${{ ${[...clauses, "matrix.provider"].join(" || ")} }}`;
 }
 
 export function renderRunnerLifetime(indent = "          "): string {
@@ -338,6 +367,16 @@ export function generatedProviderRegions(): GeneratedRegion[] {
 			file: ".github/workflows/bench-smoke.yml",
 			label: "provider-options",
 			body: renderSmokeProviderOptions(),
+		},
+		{
+			file: ".github/workflows/bench-suite.yml",
+			label: "provider-account-group-bench",
+			body: renderAccountConcurrencyGroup(),
+		},
+		{
+			file: ".github/workflows/toolchain-image.yml",
+			label: "provider-account-group-bake",
+			body: renderAccountConcurrencyGroup(),
 		},
 		{
 			file: ".github/workflows/bench-suite.yml",

--- a/packages/schema/scripts/provider-meta-schema.test.ts
+++ b/packages/schema/scripts/provider-meta-schema.test.ts
@@ -95,6 +95,16 @@ describe("Tier-3 provider metadata schema", () => {
 		).toThrow(/daytona-vm\/daytona-container.*derive the same release name/);
 	});
 
+	test("rejects a quota domain that splits providers sharing one credential", () => {
+		expect(() =>
+			validateProviderModules(meta("daytona-vm", { quotaDomain: "daytona-vm" })),
+		).toThrow(/sharing secret DAYTONA_API_KEY must declare one quotaDomain/);
+		expect(() => validateProviderModules(meta("modal-vm", { quotaDomain: "modal vm" }))).toThrow(
+			/quota domain identifier/,
+		);
+		expect(validateProviderModules(meta("e2b", { quotaDomain: "e2b-benchmark" }))).toBeDefined();
+	});
+
 	test("rejects duplicate, secret-defaulted, and required-defaulted inputs", () => {
 		expect(() =>
 			validateProviderModules(meta("e2b", { inputs: ["E2B_API_KEY", "E2B_API_KEY"] })),

--- a/packages/schema/scripts/provider-meta-schema.ts
+++ b/packages/schema/scripts/provider-meta-schema.ts
@@ -26,6 +26,13 @@ const stepPropertySchema = nonemptyStringSchema.narrow((value, ctx) =>
 		? true
 		: ctx.mustBe("a GitHub Actions step/output property name"),
 );
+// Names an Actions concurrency group and a journal branch, so it carries the identifier grammar the
+// experiment plan already enforces on its quota domains.
+const quotaDomainSchema = nonemptyStringSchema.narrow((value, ctx) =>
+	/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(value)
+		? true
+		: ctx.mustBe("a quota domain identifier (letters, digits, '.', '_', '-')"),
+);
 const finitePositiveNumberSchema = type("number > 0").narrow(Number.isFinite);
 const httpUrlSchema = type("string.url").narrow((value) => {
 	const protocol = new URL(value).protocol;
@@ -88,6 +95,7 @@ const providerArtifactSchema = noArtifactSchema
 export const providerMetaSourceSchema = type({
 	displayName: nonemptyStringSchema,
 	vendor: nonemptyStringSchema,
+	"quotaDomain?": quotaDomainSchema,
 	website: httpUrlSchema,
 	sdkPackage: nonemptyStringSchema,
 	artifact: providerArtifactSchema,
@@ -249,13 +257,27 @@ export function validateProviderModules(
 	// One input name is one cross-consumer contract. Shared credentials across isolation variants
 	// must normalize identically or generated CI would have to pick one owner's source/default policy.
 	const inputsByName = new Map<string, { owner: ProviderId; signature: string }>();
+	// One credential is one vendor account (ADR-0010): providers that share a secret draw on the same
+	// quota, so they must queue behind the same domain or the account concurrency group lets them
+	// race each other's allocations.
+	const secretDomains = new Map<string, { owner: ProviderId; domain: string }>();
 	for (const id of PROVIDER_IDS) {
 		const { preAuth } = parsed[id].meta;
+		const domain = parsed[id].meta.quotaDomain ?? id;
 		const stepInputs: StepProvidedInput[] = [];
 		for (const raw of parsed[id].meta.inputs) {
 			const input = normalizeProviderInput(raw);
 			if (input.source.kind === "step-env" || input.source.kind === "step-output") {
 				stepInputs.push({ ...input, source: input.source });
+			}
+			if (input.source.kind === "secret") {
+				const shared = secretDomains.get(input.name);
+				if (shared !== undefined && shared.domain !== domain) {
+					throw new Error(
+						`${shared.owner}/${id}: providers sharing secret ${input.name} must declare one quotaDomain (${shared.domain} vs ${domain})`,
+					);
+				}
+				secretDomains.set(input.name, shared ?? { owner: id, domain });
 			}
 			const signature = JSON.stringify({
 				source: input.source,

--- a/packages/schema/src/experiment.ts
+++ b/packages/schema/src/experiment.ts
@@ -1,0 +1,156 @@
+import { type } from "arktype";
+import { gpuSpecSchema } from "./driver-schemas.ts";
+import { providerIdSchema } from "./provider-parsers.ts";
+import { targetSpecSchema } from "./target-spec-schema.ts";
+
+const digest = type(/^sha256:[a-f0-9]{64}$/);
+const identifier = type(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/);
+
+const phase = type("'create' | 'setup' | 'benchmark' | 'collect'");
+export const executionReceiptSchema = type({
+	schemaVersion: "'1'",
+	executionId: identifier,
+	runId: identifier,
+	"replicateIndex?": "number.integer >= 0",
+	provider: providerIdSchema,
+	suite: "string >= 1",
+	sandboxId: "string >= 1",
+	steps: type({
+		phase,
+		label: "string",
+		ms: "number >= 0",
+		exitCode: "number.integer | null",
+	}).array(),
+	detached: type({
+		identity: identifier,
+		label: "string",
+		phase,
+		state:
+			"'launch-pending' | 'launch-accepted' | 'running' | 'observation-unavailable' | 'completed' | 'deadline-exceeded' | 'collection-failed'",
+		exitCode: "number.integer | null",
+		"lastObservationMs?": "number >= 0",
+		"logTail?": "string | null",
+	}).array(),
+	primaryFailure: "string | null",
+}).onUndeclaredKey("reject");
+
+export const cleanupReceiptSchema = type({
+	schemaVersion: "'1'",
+	executionId: identifier,
+	completed: "boolean",
+	attemptedAt: "string.date.iso",
+	"completedAt?": "string.date.iso",
+	"diagnostic?": "string",
+	confirmedAbsent: "boolean",
+}).onUndeclaredKey("reject");
+export type ExecutionReceipt = typeof executionReceiptSchema.infer;
+export type CleanupReceipt = typeof cleanupReceiptSchema.infer;
+
+export const experimentExclusionSchema = type({
+	metricId: "string >= 1",
+	workloadRevision: "string >= 1",
+	reason: "string >= 1",
+	owner: "string >= 1",
+	issue: /^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/,
+	expires: /^\d{4}-\d{2}-\d{2}$/,
+}).onUndeclaredKey("reject");
+
+export const experimentCellSchema = type({
+	id: identifier,
+	provider: providerIdSchema,
+	quotaDomain: identifier,
+	suite: "string >= 1",
+	replicate: "number.integer >= 0",
+	workloadRevision: "string >= 1",
+	artifactIdentity: "string >= 1",
+	environmentRevision: "string >= 1",
+	target: targetSpecSchema,
+	"gpu?": gpuSpecSchema,
+	metrics: "string[] >= 1",
+	exclusions: experimentExclusionSchema.array(),
+	passes: "number.integer >= 1",
+	startupMinutes: "number.safe > 0",
+	workloadMinutes: "number.safe > 0",
+	finishMinutes: "number.safe > 0",
+}).onUndeclaredKey("reject");
+
+export const experimentBatchSchema = type({
+	id: identifier,
+	quotaDomain: identifier,
+	cells: "string[] >= 1",
+	maxConcurrency: "number.integer >= 1",
+	budgetMinutes: "number.safe > 0",
+}).onUndeclaredKey("reject");
+
+export const experimentPlanSchema = type({
+	schemaVersion: "'1'",
+	id: identifier,
+	sha: /^[a-f0-9]{40}$/,
+	createdOn: /^\d{4}-\d{2}-\d{2}$/,
+	digest,
+	retryPolicy: "'premeasurement-only'",
+	maxPremeasurementRetries: "number.integer >= 0",
+	accounts: type({
+		quotaDomain: identifier,
+		sandboxes: "number.integer >= 1",
+		"vcpus?": "number.safe > 0",
+		"memoryGb?": "number.safe > 0",
+		"gpus?": "number.integer >= 0",
+	})
+		.onUndeclaredKey("reject")
+		.array()
+		.atLeastLength(1),
+	cells: experimentCellSchema.array().atLeastLength(1),
+	batches: experimentBatchSchema.array().atLeastLength(1),
+	rounds: type({ id: identifier, quotaDomain: identifier, batches: "string[] >= 1" })
+		.onUndeclaredKey("reject")
+		.array()
+		.atLeastLength(1),
+}).onUndeclaredKey("reject");
+
+/** Evidence is a receipt, not a second metric store. runDigest binds its observations to one shard. */
+export const experimentAttemptSchema = type({
+	schemaVersion: "'1'",
+	id: identifier,
+	cellId: identifier,
+	planDigest: digest,
+	sha: /^[a-f0-9]{40}$/,
+	workloadRevision: "string >= 1",
+	environmentRevision: "string >= 1",
+	artifactIdentity: "string >= 1",
+	passes: "number.integer >= 1",
+	workflowRun: identifier,
+	workflowAttempt: "number.integer >= 1",
+	job: "string >= 1",
+	sequence: "number.integer >= 0",
+	"previousAttempt?": identifier,
+	outcome: "'completed' | 'failed' | 'cancelled'",
+	measurementStarted: "boolean",
+	retryable: "boolean",
+	cleanup: "'confirmed' | 'unresolved' | 'not-allocated'",
+	completion: "'known-success' | 'known-failure' | 'unknown'",
+	"runDigest?": digest,
+	"rawDigest?": digest,
+	"diagnostic?": "string <= 16384",
+}).onUndeclaredKey("reject");
+
+export type ExperimentPlan = typeof experimentPlanSchema.infer;
+export type ExperimentCell = typeof experimentCellSchema.infer;
+export type ExperimentAttempt = typeof experimentAttemptSchema.infer;
+export type ExperimentBatch = typeof experimentBatchSchema.infer;
+
+export const experimentRequestSchema = type({
+	id: "string >= 1",
+	sha: "string >= 1",
+	createdOn: "string >= 1",
+	cells: experimentCellSchema.array(),
+	"maxPremeasurementRetries?": "number.integer >= 0",
+}).onUndeclaredKey("reject");
+export const accountCapacityPolicySchema = type({
+	"[string]": {
+		sandboxes: "number.integer >= 1",
+		"vcpus?": "number.safe > 0",
+		"memoryGb?": "number.safe > 0",
+		"gpus?": "number.integer >= 0",
+	},
+});

--- a/packages/schema/src/experiment.ts
+++ b/packages/schema/src/experiment.ts
@@ -15,16 +15,20 @@ export const executionReceiptSchema = type({
 	provider: providerIdSchema,
 	suite: "string >= 1",
 	sandboxId: "string >= 1",
+	// One entry per ATTEMPT: a retried step keeps its failed attempts, and a step declared
+	// `allowFailure` records that policy so a tolerated non-zero exit is distinguishable from a failure.
 	steps: type({
 		phase,
 		label: "string",
 		ms: "number >= 0",
 		exitCode: "number.integer | null",
+		"allowFailure?": "boolean",
 	}).array(),
 	detached: type({
 		identity: identifier,
 		label: "string",
 		phase,
+		"allowFailure?": "boolean",
 		state:
 			"'launch-pending' | 'launch-accepted' | 'running' | 'observation-unavailable' | 'completed' | 'deadline-exceeded' | 'collection-failed'",
 		exitCode: "number.integer | null",

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -16,6 +16,7 @@ export * from "./cost-evidence.ts";
 // The derived economics Dimension ($/run): its MetricDefs, the pricing-driven derivation, and the
 // pure cost models (burst vs fixed-infra amortization) they build on.
 export * from "./economics.ts";
+export * from "./experiment.ts";
 // The non-PTS, harness-measured Metric slice (lifecycle + control-plane) and its operation→id contract.
 export * from "./harness-metrics.ts";
 // Canonical persisted identifiers shared by Run and evidence schemas.

--- a/packages/schema/src/provider-meta.ts
+++ b/packages/schema/src/provider-meta.ts
@@ -82,6 +82,13 @@ export interface ProviderRunnerPolicy {
 export interface ProviderMetaSource {
 	readonly displayName: string;
 	readonly vendor: string;
+	/**
+	 * The vendor account whose quota and credentials this provider consumes. Isolation variants that
+	 * share credentials share one domain (ADR-0010) — it names the Actions concurrency group, the
+	 * account journal branch and the plan's batches, so it must stay stable once provisioned.
+	 * Omitted means the provider id is its own domain.
+	 */
+	readonly quotaDomain?: string;
 	readonly website: string;
 	readonly sdkPackage: string;
 	readonly artifact: ProviderArtifact;

--- a/packages/schema/src/provider-meta/daytona-container.ts
+++ b/packages/schema/src/provider-meta/daytona-container.ts
@@ -4,6 +4,7 @@ import { daytonaPricing, daytonaTransport } from "./_daytona.ts";
 export default defineProviderMeta("daytona-container", {
 	displayName: "Daytona (container)",
 	vendor: "Daytona",
+	quotaDomain: "daytona",
 	website: "https://daytona.io",
 	sdkPackage: "@daytona/sdk",
 	artifact: { kind: "baked", nameSuffix: "-container" },

--- a/packages/schema/src/provider-meta/daytona-vm.ts
+++ b/packages/schema/src/provider-meta/daytona-vm.ts
@@ -4,6 +4,7 @@ import { daytonaPricing, daytonaTransport } from "./_daytona.ts";
 export default defineProviderMeta("daytona-vm", {
 	displayName: "Daytona (VM)",
 	vendor: "Daytona",
+	quotaDomain: "daytona",
 	website: "https://daytona.io",
 	sdkPackage: "@daytona/sdk",
 	artifact: { kind: "baked" },

--- a/packages/schema/src/provider-meta/modal-gvisor.ts
+++ b/packages/schema/src/provider-meta/modal-gvisor.ts
@@ -4,6 +4,7 @@ import { modalPricing, modalTransport } from "./_modal.ts";
 export default defineProviderMeta("modal-gvisor", {
 	displayName: "Modal (gVisor)",
 	vendor: "Modal",
+	quotaDomain: "modal",
 	website: "https://modal.com",
 	sdkPackage: "modal",
 	artifact: { kind: "image" },

--- a/packages/schema/src/provider-meta/modal-vm.ts
+++ b/packages/schema/src/provider-meta/modal-vm.ts
@@ -4,6 +4,7 @@ import { modalPricing, modalTransport } from "./_modal.ts";
 export default defineProviderMeta("modal-vm", {
 	displayName: "Modal (VM)",
 	vendor: "Modal",
+	quotaDomain: "modal",
 	website: "https://modal.com",
 	sdkPackage: "modal",
 	artifact: { kind: "image" },

--- a/packages/schema/src/provider-meta/tama.ts
+++ b/packages/schema/src/provider-meta/tama.ts
@@ -12,9 +12,9 @@ export default defineProviderMeta("tama", {
 	// requiredEnvVars is the credential gate, and the gate is what turns an unwired provider into a
 	// recorded SKIP instead of a failed cell: a CLI profile is invisible to it, so treating "no token"
 	// as "maybe the profile works" would mean a matrix cell with no credential at all discovers that
-	// by failing to create a sandbox. The profile preference governs whether `tama login --token`
-	// RUNS (it replaces the stored credential, so a developer must not be signed out by a benchmark),
-	// not whether the provider is credentialed. Local devs export a token from `tama tokens create`
+	// by failing to create a sandbox. Preparation authenticates with the explicit token once per driver
+	// context, serialized across contexts so profile writes do not race. Local devs use separate
+	// benchmark credentials and export a token from `tama tokens create`
 	// — see .env.example.
 	inputs: ["TAMA_TOKEN", { name: "TAMA_CLI", source: { kind: "variable" }, required: false }],
 	isolation: {

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -13,6 +13,7 @@ import { REGISTRY } from "./provider-meta/index.ts";
 import type {
 	NormalizedProviderInput,
 	ProviderArtifact,
+	ProviderMetaSource,
 	ProviderPreAuth,
 	ProviderRunnerPolicy,
 } from "./provider-meta.ts";
@@ -138,6 +139,8 @@ export interface ProviderMeta {
 	displayName: string;
 	/** Stable vendor label shared by isolation variants. */
 	vendor: string;
+	/** The account whose quota this provider consumes; see {@link quotaDomain}. */
+	quotaDomain: string;
 	website: string;
 	/** The npm package the harness adapter wraps, e.g. "@computesdk/e2b". */
 	sdkPackage: string;
@@ -221,11 +224,25 @@ export const PROVIDERS: readonly ProviderMeta[] = deepFreeze(
 		return {
 			id,
 			...source,
+			quotaDomain: quotaDomain(id),
 			inputs,
 			requiredEnvVars: inputs.filter((input) => input.required).map((input) => input.name),
 		};
 	}),
 );
+
+/**
+ * The vendor account a provider's sandboxes are charged to and queued behind. Isolation variants
+ * that share credentials share one domain (daytona-vm and daytona-container → `daytona`); every
+ * other provider is its own. This one lookup names the Actions concurrency group (generated wiring),
+ * the account journal branch and the experiment plan's batches, so they cannot disagree.
+ */
+export function quotaDomain(id: ProviderId): string {
+	// Widen from the descriptor's literal type: most descriptors omit the field, so it is not on the
+	// registry's union type, only on the declared source shape.
+	const meta: ProviderMetaSource = REGISTRY[id];
+	return meta.quotaDomain ?? id;
+}
 
 /**
  * Retired provider ids that committed run documents still carry, each mapped to the current variant

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -820,7 +820,8 @@ export function providerStatusText(p: ProviderRun): string {
 /**
  * A full benchmark Run: every provider measured against one pinned target spec at one SHA.
  *
- * `schemaVersion` accepts `"2"` through `"6"`. v1's `skips: { suite, reason }[]` could not say
+ * `schemaVersion` accepts `"2"` through `"7"`. Version 7 adds experiment plan/attempt linkage;
+ * older documents do not establish experiment completeness. v1's `skips: { suite, reason }[]` could not say
  * whether a benchmark was deliberately not run or had crashed, and carried no positive record of what
  * DID run — so a suite that vanished (job died, artifact never uploaded) left no trace anywhere in the
  * document. v2 replaced it with {@link resultGapSchema} + {@link ProviderRun.suitesCovered}. v3 adds
@@ -856,7 +857,7 @@ export function providerStatusText(p: ProviderRun): string {
  * migrates them in place.
  */
 export const runSchema = type({
-	schemaVersion: "'2' | '3' | '4' | '5' | '6'",
+	schemaVersion: "'2' | '3' | '4' | '5' | '6' | '7'",
 	runId: runIdSchema,
 	sha: "string",
 	// ISO-8601 timestamp the Run was generated at — validated so the RunIndex sort key can't be a
@@ -867,6 +868,11 @@ export const runSchema = type({
 	// a per-replicate shard; the aggregate reads it to key {@link MetricResult.replicates} and drops it
 	// from the merged Run (which spans every replicate). Absent on legacy shards and aggregated Runs.
 	"replicateIndex?": "number.integer >= 0",
+	"experiment?": {
+		planDigest: /^sha256:[a-f0-9]{64}$/,
+		"cohortDigest?": /^sha256:[a-f0-9]{64}$/,
+		attemptIds: "string[] >= 1",
+	},
 	targetSpec: targetSpecSchema,
 	providers: providerRunSchema.array(),
 }).narrow((run, ctx) => {
@@ -874,6 +880,9 @@ export const runSchema = type({
 	// v4 and beyond, so "=== '3'" would have made every version bump retroactively reject the previous
 	// version's own fields (the v4 aggregate below carries folded `replicates`).
 	const version = Number(run.schemaVersion);
+	if (version >= 7 !== (run.experiment !== undefined)) {
+		return ctx.mustBe("experiment linkage exactly on Run v7 or newer");
+	}
 	// The replicate fields (`replicateIndex`, `MetricResult.replicates`) are v3-or-later, so "v2 == the
 	// pre-replicate schema" stays a real guarantee: a producer that writes a replicate field but forgets
 	// to bump schemaVersion is rejected here rather than silently read by a v3-gated consumer that then

--- a/tooling/repo-checks/src/assert-paths-allowlisted.test.ts
+++ b/tooling/repo-checks/src/assert-paths-allowlisted.test.ts
@@ -26,6 +26,8 @@ function tempGitRepo(): string {
 	expect(git(["init", "-q"]).exitCode).toBe(0);
 	expect(git(["config", "user.email", "test@example.com"]).exitCode).toBe(0);
 	expect(git(["config", "user.name", "test"]).exitCode).toBe(0);
+	// Fixture commits must not invoke a developer's interactive signing agent.
+	expect(git(["config", "commit.gpgsign", "false"]).exitCode).toBe(0);
 	return dir;
 }
 

--- a/tooling/repo-checks/src/lib/workflow-concurrency.ts
+++ b/tooling/repo-checks/src/lib/workflow-concurrency.ts
@@ -1,0 +1,19 @@
+import { type } from "arktype";
+
+const scope = type({ "concurrency?": "unknown" });
+const workflow = type({ "concurrency?": "unknown", jobs: { "[string]": scope } });
+const queue = type({ group: "string >= 1", "cancel-in-progress": "false", queue: "'max'" });
+
+/** Compatibility validation until actionlint understands GitHub's queue property. */
+export function checkConcurrencyQueues(source: string): void {
+	const parsed = workflow.assert(Bun.YAML.parse(source));
+	for (const item of [parsed, ...Object.values(parsed.jobs)]) {
+		const concurrency = item.concurrency;
+		if (concurrency !== null && typeof concurrency === "object" && "queue" in concurrency)
+			queue.assert(concurrency);
+	}
+}
+
+// Match only the parser's unsupported-field diagnostic; every other actionlint check remains active.
+export const ACTIONLINT_QUEUE_COMPATIBILITY =
+	'^unexpected key "queue" for "concurrency" section\\. expected one of "cancel-in-progress", "group"$';

--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -202,7 +202,11 @@ export function checkCiLintGate(doc: unknown, label: string = CI_LINT_WORKFLOW):
 		}
 		// Job existence isn't enough: it must actually invoke the tool, or the gate false-passes if
 		// the real invocation is renamed/removed while an empty job shell survives.
-		if (!jobRun(tool).includes(tool)) {
+		const run = jobRun(tool);
+		const queueCompatibleActionlint =
+			tool === "actionlint" &&
+			run.split("\n").some((line) => line.trim() === "bun run lint:workflows");
+		if (!run.includes(tool) && !queueCompatibleActionlint) {
 			errors.push(
 				`${label}: the "${tool}" job must actually run \`${tool}\` — the gate must not pass on a job that no longer invokes it`,
 			);

--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -332,16 +332,37 @@ function privilegeReasons(f: {
 
 /** True if any job in a parsed workflow declares `environment: <privileged>`. Used to confirm a local
  *  reusable workflow carries its own approval gate (the caller can't declare one for it). */
-function hasPrivilegedJob(doc: unknown, privileged: string): boolean {
-	const root = asRecord(doc, "reusable workflow: not a YAML mapping");
-	const jobs = asRecord(root.jobs, "reusable workflow: no jobs mapping");
-	return Object.values(jobs).some(
-		(j) =>
-			j !== null &&
-			typeof j === "object" &&
-			!Array.isArray(j) &&
-			jobEnvironmentName(j as Record<string, unknown>) === privileged,
+function hasPrivilegedJob(
+	doc: unknown,
+	privileged: string,
+	resolveLocal: (path: string) => unknown,
+	visited = new Set<string>(),
+): boolean {
+	const root = asRecord(doc, "reusable workflow");
+	const jobs = Object.values(asRecord(root.jobs, "reusable jobs")).map((job) =>
+		asRecord(job, "reusable job"),
 	);
+	const nested = jobs.filter((job) => typeof job.uses === "string");
+	const directGate = jobs.some((job) => jobEnvironmentName(job) === privileged);
+	if (nested.length === 0) return directGate;
+	return nested.every((job) => {
+		if (
+			typeof job.uses !== "string" ||
+			!job.uses.startsWith("./.github/workflows/") ||
+			visited.has(job.uses)
+		)
+			return false;
+		try {
+			return hasPrivilegedJob(
+				resolveLocal(job.uses.slice(2)),
+				privileged,
+				resolveLocal,
+				new Set([...visited, job.uses]),
+			);
+		} catch {
+			return false;
+		}
+	});
 }
 
 /**
@@ -415,7 +436,10 @@ export function checkPrivilegedEnvironment(
 			} catch {
 				calledDoc = undefined;
 			}
-			if (calledDoc !== undefined && !hasPrivilegedJob(calledDoc, privileged)) {
+			if (
+				calledDoc !== undefined &&
+				!hasPrivilegedJob(calledDoc, privileged, resolveLocalWorkflow)
+			) {
 				errors.push(
 					`${key}: calls local reusable workflow ${job.uses} with ${reasons.join(" and ")} but no ` +
 						`job in it sets \`environment: ${privileged}\` — a \`uses:\` caller can't gate itself, so ` +

--- a/tooling/repo-checks/src/lib/workflow-nesting.ts
+++ b/tooling/repo-checks/src/lib/workflow-nesting.ts
@@ -1,302 +1,8 @@
-// Invariant 6: GitHub-native suite→provider nesting wiring for the two dispatch lanes
-// (bench-matrix.yml, bench-smoke.yml) + the reusable bench-suite.yml they share. Kept out of
-// workflow-sync.ts so credential/timeout gates and nesting gates don't grow as one file.
-import { asRecord, RUN_STEP, SUITE_JOB, SUITE_WORKFLOW, stepByName } from "./workflow-yaml.ts";
+/* biome-ignore-all lint/suspicious/noTemplateCurlyInString: GitHub expression contract literals */
+// Check the production account → round → bounded batch dispatch graph.
+import { asRecord, RUN_STEP, SUITE_WORKFLOW, stepByName } from "./workflow-yaml.ts";
 
-/** A suite-matrix job is one that `uses` this reusable workflow (matched by path suffix). */
-const SUITE_WORKFLOW_USES_SUFFIX = "/bench-suite.yml";
-
-/**
- * The single suite-matrix caller of a dispatch lane: the job that `uses` the reusable bench-suite.yml
- * and expands `strategy.matrix.suite` from the plan's suite axis. Native nesting depends on
- * `name` / `with.suite` both resolving to `matrix.suite`. Both lanes have exactly one — bench-matrix
- * over every planned suite, bench-smoke over the single dispatched one — and they are held to the same
- * wiring so the smoke lane cannot quietly become a different pipeline.
- */
-export interface SuiteMatrixCaller {
-	jobId: string;
-	name: string;
-	suiteInput: string;
-	/** The `with.replicates` expression — this suite's slice of the plan's per-suite map. */
-	replicatesInput: string;
-	/** The `with.require_providers` expression, or undefined when the caller omits it (the matrix
-	 *  lane's graceful default: a provider with no credential skips rather than sinking the run). */
-	requireProvidersInput?: string;
-	matrixSuiteExpr: string;
-	/** Job ids listed in `publish.needs` (empty when publish is missing or has no needs list). */
-	publishNeeds: string[];
-}
-
-/** The expression the suite-matrix job must use for its suite axis (plan output → fromJSON). */
-// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-export const EXPECTED_SUITE_MATRIX_EXPR = "${{ fromJSON(needs.plan.outputs.suites) }}";
-/** The expression that makes each caller cell's display name the suite id (native nesting parent). */
-// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-export const EXPECTED_SUITE_NAME_EXPR = "${{ matrix.suite }}";
-/** The expression that makes each reusable fan-out cell's display name the provider id (the nesting
- *  child): "<suite> / <provider>". There is no replicate suffix — one cell owns all R replicate
- *  sandboxes of its (suite, provider), driven concurrently from the single runner. */
-// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-export const EXPECTED_PROVIDER_NAME_EXPR = "${{ matrix.provider }}";
-
-/** The run-step env key that hands the cell its replicate index array. */
-export const REPLICATES_ENV_KEY = "BENCH_REPLICATES";
-/** The expression that key must carry: the reusable's own `replicates` input, verbatim. */
-// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-export const EXPECTED_REPLICATES_ENV_EXPR = "${{ inputs.replicates }}";
-/** The argument the run step must pass, so the env value is actually CONSUMED. Setting the env
- *  without passing the flag leaves bench-suite on its single-sandbox default — a green matrix run
- *  publishing R=1 — which is precisely what this invariant exists to prevent. */
-export const EXPECTED_REPLICATES_ARG = `--replicates "$${REPLICATES_ENV_KEY}"`;
-/** The expression the suite-matrix caller must hand down as `with.replicates`: this suite's slice of
- *  the plan's per-suite map. Pinned because a hardcoded array here (`'[0]'`) would pass every other
- *  nesting check while quietly running one sandbox per cell — the same R=1 outcome the callee-side
- *  checks guard, entered from the caller instead. */
-export const EXPECTED_REPLICATES_INPUT_EXPR =
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-	"${{ toJSON(fromJSON(needs.plan.outputs.replicates)[matrix.suite]) }}";
-/** The expression bench-smoke's caller must hand down as `with.require_providers`: the dispatched
- *  provider. Pinned because the whole point of a smoke run is to prove ONE lane end to end — without
- *  it a missing or misnamed credential is recorded as a skip and the job still exits 0 having
- *  benchmarked nothing, which is a green run that hides the provider never being smoked. Everything
- *  else about the two lanes is now literally the same file, so this is the one behavioural difference
- *  a gate still has to hold in place. */
-// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-export const EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR = "${{ inputs.provider }}";
-
-/**
- * A dispatch lane's suite-matrix caller — exactly one job whose `uses` targets the reusable
- * bench-suite.yml, with its nesting wiring extracted. Zero or multiple callers throw (Invariant 6
- * must fail loudly, not pick one). Jobs that don't call the reusable (plan, publish) are ignored
- * except that `publish.needs` is captured for the dependency check. Used for both bench-matrix.yml
- * and bench-smoke.yml; `label` names the lane in error messages.
- */
-export function matrixSuiteCaller(doc: unknown, label: string): SuiteMatrixCaller {
-	const root = asRecord(doc, `${label}: not a YAML mapping`);
-	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
-	const callers: Array<Omit<SuiteMatrixCaller, "publishNeeds">> = [];
-	for (const [jobId, rawJob] of Object.entries(jobs)) {
-		const job = asRecord(rawJob, `${label}: job "${jobId}" is not a mapping`);
-		const uses = job.uses;
-		if (typeof uses !== "string" || !uses.endsWith(SUITE_WORKFLOW_USES_SUFFIX)) continue;
-		const withMap = asRecord(
-			job.with,
-			`${label}: job "${jobId}" calls ${uses} without a "with" mapping`,
-		);
-		const suiteInput = withMap.suite;
-		if (typeof suiteInput !== "string") {
-			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "suite" input`);
-		}
-		const replicatesInput = withMap.replicates;
-		if (typeof replicatesInput !== "string") {
-			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "replicates" input`);
-		}
-		// Optional by design: absent IS the matrix lane's posture (no provider is required, so a
-		// credential-less cell skips). A present non-string value is malformed YAML and must not read
-		// as absent: GitHub coerces it into a real workflow input, bypassing the matrix lane's absence
-		// assertion below.
-		if ("require_providers" in withMap && typeof withMap.require_providers !== "string") {
-			throw new Error(
-				`${label}: job "${jobId}" calls ${uses} with a non-string "require_providers" input`,
-			);
-		}
-		const requireProvidersInput =
-			typeof withMap.require_providers === "string" ? withMap.require_providers : undefined;
-		const name = typeof job.name === "string" ? job.name : "";
-		const strategy = asRecord(
-			job.strategy,
-			`${label}: job "${jobId}" calls ${uses} without a "strategy" mapping`,
-		);
-		const matrix = asRecord(
-			strategy.matrix,
-			`${label}: job "${jobId}" calls ${uses} without a "strategy.matrix" mapping`,
-		);
-		const matrixSuiteExpr = matrix.suite;
-		if (typeof matrixSuiteExpr !== "string") {
-			throw new Error(
-				`${label}: job "${jobId}" calls ${uses} without a string "strategy.matrix.suite" axis`,
-			);
-		}
-		callers.push({
-			jobId,
-			name,
-			suiteInput,
-			replicatesInput,
-			...(requireProvidersInput !== undefined ? { requireProvidersInput } : {}),
-			matrixSuiteExpr,
-		});
-	}
-	if (callers.length === 0) {
-		throw new Error(
-			`${label}: no job calls the reusable bench-suite.yml — the suite-matrix caller is missing`,
-		);
-	}
-	if (callers.length > 1) {
-		throw new Error(
-			`${label}: expected exactly one suite-matrix caller of bench-suite.yml, found ` +
-				`${callers.length} (${callers.map((c) => c.jobId).join(", ")})`,
-		);
-	}
-	// biome-ignore lint/style/noNonNullAssertion: length checked above.
-	const caller = callers[0]!;
-	const publish = jobs.publish;
-	let publishNeeds: string[] = [];
-	if (publish !== undefined) {
-		const publishJob = asRecord(publish, `${label}: job "publish" is not a mapping`);
-		const needs = publishJob.needs;
-		if (Array.isArray(needs)) {
-			publishNeeds = needs.map((n) => String(n));
-		} else if (typeof needs === "string") {
-			publishNeeds = [needs];
-		}
-	}
-	return { ...caller, publishNeeds };
-}
-
-/**
- * The two ways the dispatch lanes are ALLOWED to differ, declared per lane. Both fields are required
- * on purpose: a partial object would replace a defaulted one wholesale, so `{ requireProviderAssertion:
- * true }` would silently read as `requirePublishNeeds: undefined` and switch off an assertion the
- * caller never meant to waive. Making every call site state both flags means the complete list of
- * permitted differences is written out at each lane, which is the point of the invariant.
- */
-export interface SuiteMatrixCallerOptions {
-	/**
-	 * Require a `publish` job that needs the caller. True for bench-matrix.yml, where aggregation must
-	 * wait for every suite matrix cell. FALSE for bench-smoke.yml, which deliberately has no publish
-	 * phase at all — that missing third phase is the entire difference between the lanes, so demanding
-	 * it there would be demanding the smoke commit a dataset.
-	 */
-	requirePublishNeeds: boolean;
-	/**
-	 * Require `with.require_providers` to be {@link EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR}. True for
-	 * bench-smoke.yml (a smoke must fail when its dispatched provider never ran). When false the input
-	 * must be ABSENT, not merely different: the matrix's lenient posture is a property worth pinning,
-	 * since a stray value there would fail every cell whose provider it names.
-	 */
-	requireProviderAssertion: boolean;
-}
-
-/**
- * Invariant 6: a dispatch lane's suite-matrix caller is wired for GitHub-native nesting and depends on
- * the plan's suite axis — display name and `with.suite` are `${{ matrix.suite }}`, `with.replicates` is
- * the plan's per-suite slice, and the matrix axis is `fromJSON(needs.plan.outputs.suites)`. The two
- * per-lane differences are declared explicitly via {@link SuiteMatrixCallerOptions}. `label` names the
- * workflow in error messages and is required — with two lanes sharing this check, a defaulted label
- * would misattribute the smoke lane's drift to bench-matrix.yml.
- */
-export function checkSuiteMatrixCaller(
-	caller: SuiteMatrixCaller,
-	label: string,
-	options: SuiteMatrixCallerOptions,
-): string[] {
-	const errors: string[] = [];
-	if (caller.name !== EXPECTED_SUITE_NAME_EXPR) {
-		errors.push(
-			`${label}: job "${caller.jobId}" name must be "${EXPECTED_SUITE_NAME_EXPR}" for native ` +
-				`suite nesting in the Actions UI (got ${caller.name ? `"${caller.name}"` : "no name"})`,
-		);
-	}
-	if (caller.suiteInput !== EXPECTED_SUITE_NAME_EXPR) {
-		errors.push(
-			`${label}: job "${caller.jobId}" with.suite must be "${EXPECTED_SUITE_NAME_EXPR}" so each ` +
-				`matrix cell dispatches its own suite (got "${caller.suiteInput}")`,
-		);
-	}
-	if (caller.replicatesInput !== EXPECTED_REPLICATES_INPUT_EXPR) {
-		errors.push(
-			`${label}: job "${caller.jobId}" with.replicates must be "${EXPECTED_REPLICATES_INPUT_EXPR}" ` +
-				`so each cell receives its own suite's replicate axis from the plan — a literal or a ` +
-				`different suite's slice silently changes how many sandboxes the run measures ` +
-				`(got "${caller.replicatesInput}")`,
-		);
-	}
-	if (caller.matrixSuiteExpr !== EXPECTED_SUITE_MATRIX_EXPR) {
-		errors.push(
-			`${label}: job "${caller.jobId}" strategy.matrix.suite must be "${EXPECTED_SUITE_MATRIX_EXPR}" ` +
-				`so the suite axis stays registry-driven via plan.outputs.suites (got "${caller.matrixSuiteExpr}")`,
-		);
-	}
-	if (options.requirePublishNeeds && !caller.publishNeeds.includes(caller.jobId)) {
-		errors.push(
-			`${label}: job "publish" must need "${caller.jobId}" so aggregation waits for every suite ` +
-				`matrix cell (publish.needs=${JSON.stringify(caller.publishNeeds)})`,
-		);
-	}
-	if (options.requireProviderAssertion) {
-		if (caller.requireProvidersInput !== EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR) {
-			errors.push(
-				`${label}: job "${caller.jobId}" with.require_providers must be ` +
-					`"${EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR}" so a missing or misnamed credential fails the ` +
-					`run instead of being recorded as a skip on a job that still exits 0 (got ` +
-					`${caller.requireProvidersInput === undefined ? "no such input" : `"${caller.requireProvidersInput}"`})`,
-			);
-		}
-	} else if (caller.requireProvidersInput !== undefined) {
-		// The lenient posture is a property too. A value here fails every cell whose provider it names —
-		// loudly, but across a whole matrix run's worth of provider quota before anyone reads the error.
-		errors.push(
-			`${label}: job "${caller.jobId}" must not pass with.require_providers (got ` +
-				`"${caller.requireProvidersInput}") — this lane's posture is that a provider with no ` +
-				`credential SKIPS, so one unauthenticated cell cannot sink the run`,
-		);
-	}
-	return errors;
-}
-
-/** The bin a benchmark cell runs. A lane job whose `run:` mentions it is driving sandboxes itself,
- *  whatever the step is called. */
 const CELL_DRIVER_BIN = "bench-suite.ts";
-
-/** The step in a lane's `plan` job that resolves the axes (the shared plan-bench-axes action). */
-export const PLAN_STEP = "Plan";
-/** The expression bench-smoke's plan step must pass as `with.replicas`.
- *
- *  A smoke is one sandbox, and `default: '1'` alone does NOT guarantee that: a dispatch `default:`
- *  applies only when the field is ABSENT, while both the Actions UI (clear the box) and an API
- *  dispatch can send an empty string. Blank reaches plan-replicates as an unset BENCH_REPLICAS, which
- *  means "each suite's Suite.defaultReplicas" — R=12 on every realworld suite. So the fallback is what
- *  actually holds the property, and it is pinned here rather than left to a comment: losing it turns a
- *  cleared text field into twelve real sandboxes with no error anywhere. */
-export const EXPECTED_SMOKE_REPLICAS_INPUT_EXPR =
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-	"${{ inputs.replicas || '1' }}";
-
-/**
- * Invariant 7: a smoke dispatch measures ONE sandbox unless an operator explicitly asks for more —
- * both halves of it, the dispatch `default:` and the blank-value fallback (see
- * {@link EXPECTED_SMOKE_REPLICAS_INPUT_EXPR} for why the default alone is not enough).
- */
-export function checkSmokeSingleSandboxDefault(doc: unknown, label: string): string[] {
-	const root = asRecord(doc, `${label}: not a YAML mapping`);
-	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
-	const plan = jobs.plan;
-	if (plan === undefined) {
-		return [`${label}: job "plan" is missing — the smoke lane resolves its axes there`];
-	}
-	const step = stepByName(
-		asRecord(plan, `${label}: job "plan" is not a mapping`),
-		PLAN_STEP,
-		label,
-	);
-	if (step === undefined) {
-		return [`${label}: job "plan" has no step named "${PLAN_STEP}"`];
-	}
-	const withMap = asRecord(step.with ?? {}, `${label}: step "${PLAN_STEP}" with is not a mapping`);
-	const replicas = withMap.replicas;
-	if (replicas === EXPECTED_SMOKE_REPLICAS_INPUT_EXPR) return [];
-	return [
-		`${label}: job "plan" step "${PLAN_STEP}" must pass replicas: ` +
-			`"${EXPECTED_SMOKE_REPLICAS_INPUT_EXPR}" so a CLEARED replicas field still means one sandbox ` +
-			`(blank falls through to each suite's Suite.defaultReplicas — R=12 on every realworld suite — ` +
-			`with no error raised anywhere) (got ` +
-			`${replicas === undefined ? "no replicas input" : `"${String(replicas)}"`})`,
-	];
-}
-
-/** Every `env:` key a job could carry, step-level or job-level, as one flat list. Job-level `env` is
- *  included deliberately: it is inherited by every step, so hanging provider credentials there is a way
- *  to build a cell that no per-step scan would ever see. */
 function jobEnvKeys(job: Record<string, unknown>, label: string): string[] {
 	const keys: string[] = [];
 	const collect = (value: unknown): void => {
@@ -350,7 +56,10 @@ export function checkLaneDelegates(
 		const steps = Array.isArray(job.steps) ? job.steps : [];
 		for (const rawStep of steps) {
 			const step = asRecord(rawStep, `${label}: malformed step`);
-			if (typeof step.run === "string" && step.run.includes(CELL_DRIVER_BIN)) {
+			if (
+				typeof step.run === "string" &&
+				(step.run.includes(CELL_DRIVER_BIN) || step.run.includes("workflow-experiment.ts execute"))
+			) {
 				errors.push(
 					`${label}: job "${jobId}" has a step whose run: invokes ${CELL_DRIVER_BIN} — ${cell}`,
 				);
@@ -368,89 +77,92 @@ export function checkLaneDelegates(
 	return errors;
 }
 
-/**
- * Invariant 6 (callee half): the reusable bench-suite fan-out job display name is the provider id so
- * nested Actions UI cells read as "<suite> / <provider>", AND the replicate axis reaches the cell as
- * data rather than as a matrix axis.
- *
- * The replicate check is the load-bearing half. The `replicates` input used to be consumed by
- * `strategy.matrix.replicate`, so forgetting to wire it was impossible — the fan-out simply had no
- * cells. Now the array is handed to one cell through the run step's environment, and a dropped or
- * misspelled `BENCH_REPLICATES` would leave `bench-suite` on its single-sandbox default: a green
- * matrix run that quietly published R=1 for every provider, with the dataset's between-machine
- * intervals silently collapsing to within-machine ones. Assert both that the axis is gone from the
- * matrix (so R runners are not re-introduced by accident) and that the input reaches the cell.
- */
-export function checkSuiteWorkflowNesting(doc: unknown, label: string = SUITE_WORKFLOW): string[] {
-	const root = asRecord(doc, `${label}: not a YAML mapping`);
-	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
-	const job = jobs[SUITE_JOB];
-	if (job === undefined) {
-		return [`${label}: job "${SUITE_JOB}" is missing — the provider fan-out job is required`];
-	}
-	const bench = asRecord(job, `${label}: job "${SUITE_JOB}" is not a mapping`);
+export function checkExperimentNesting(docs: Record<string, unknown>): string[] {
 	const errors: string[] = [];
-
-	const name = typeof bench.name === "string" ? bench.name : "";
-	if (name !== EXPECTED_PROVIDER_NAME_EXPR) {
-		errors.push(
-			`${label}: job "${SUITE_JOB}" name must be "${EXPECTED_PROVIDER_NAME_EXPR}" for native ` +
-				`provider nesting under each suite (got ${name ? `"${name}"` : "no name"})`,
+	const job = (file: string, name: string) =>
+		asRecord(asRecord(asRecord(docs[file], file).jobs, file)[name], `${file}:${name}`);
+	const expect = (condition: boolean, detail: string) => {
+		if (!condition) errors.push(detail);
+	};
+	for (const file of ["bench-matrix.yml", "bench-smoke.yml"]) {
+		const caller = job(file, "suite");
+		expect(
+			caller.uses === "./.github/workflows/bench-account.yml",
+			`${file}: must dispatch account workflow`,
+		);
+		const strategy = asRecord(caller.strategy, file);
+		expect(
+			asRecord(strategy.matrix, file).account === "${{ fromJSON(needs.plan.outputs.accounts) }}",
+			`${file}: account axis must come from frozen plan`,
+		);
+		const step = stepByName(job(file, "plan"), "Plan", file);
+		expect(
+			step?.run === "bun apps/cli/src/bin/workflow-experiment.ts plan",
+			`${file}: must freeze experiment before dispatch`,
+		);
+		const env = asRecord(step?.env, file);
+		expect(
+			env.BENCH_PROVIDERS ===
+				(file === "bench-matrix.yml" ? "${{ inputs.providers }}" : "${{ inputs.provider }}"),
+			`${file}: selected providers must enter plan`,
+		);
+		expect(
+			env.BENCH_SUITES ===
+				(file === "bench-matrix.yml" ? "${{ inputs.suites }}" : "${{ inputs.suite }}"),
+			`${file}: selected suites must enter plan`,
+		);
+		expect(
+			env.BENCH_REPLICAS ===
+				(file === "bench-matrix.yml" ? "${{ inputs.replicas }}" : "${{ inputs.replicas || '1' }}"),
+			`${file}: preserve replicate defaults`,
 		);
 	}
-
-	// A `replicate` matrix axis would restore one idle runner per replicate — the cost this fan-out
-	// was moved in-process to remove. `?? {}` reads an absent strategy/matrix as "no axis"; a present
-	// but malformed one still throws, matching how the rest of this module navigates.
-	const strategy = asRecord(
-		bench.strategy ?? {},
-		`${label}: job "${SUITE_JOB}" strategy is not a mapping`,
+	for (const [file, callee, axis] of [
+		["bench-account.yml", "bench-round.yml", "round"],
+		["bench-round.yml", "bench-suite.yml", "include"],
+	]) {
+		if (!file || !callee || !axis) continue;
+		const caller = job(file, "execute");
+		const strategy = asRecord(caller.strategy, file);
+		expect(
+			strategy["max-parallel"] === 1 && strategy["fail-fast"] === false,
+			`${file}: account work must be sequential without cancelling peers`,
+		);
+		expect(caller.uses === `./.github/workflows/${callee}`, `${file}: wrong execution delegate`);
+		expect(
+			asRecord(strategy.matrix, file)[axis] === "${{ fromJSON(needs.plan.outputs.axis) }}",
+			`${file}: axis must come from frozen plan`,
+		);
+	}
+	const worker = job("bench-suite.yml", "bench");
+	const step = stepByName(worker, RUN_STEP, "bench-suite.yml");
+	expect(
+		step?.run === "bun apps/cli/src/bin/workflow-experiment.ts execute",
+		"worker must use managed batch executor",
 	);
-	const matrix = asRecord(
-		strategy.matrix ?? {},
-		`${label}: job "${SUITE_JOB}" strategy.matrix is not a mapping`,
+	expect(
+		asRecord(step?.env, "worker").BENCH_BATCH_ID === "${{ inputs.batch_id }}",
+		"worker must bind batch identity",
 	);
-	if (matrix.replicate !== undefined) {
-		errors.push(
-			`${label}: job "${SUITE_JOB}" must not have a "replicate" matrix axis — the cell drives ` +
-				`every replicate itself (bench-suite --replicates), so an axis here bills one idle ` +
-				`runner per replicate for no extra throughput`,
-		);
-	}
-
-	// Both remaining checks read the SAME step, so locate it once. `?? {}` again: a missing step or
-	// env block is drift this gate reports, not a parse error — the two checks below name it.
-	const step = stepByName(bench, RUN_STEP, label);
-	const env = asRecord(
-		step?.env ?? {},
-		`${label}: job "${SUITE_JOB}" step "${RUN_STEP}" env is not a mapping`,
+	const publish = job("bench-matrix.yml", "publish");
+	expect(
+		Array.isArray(publish.needs) &&
+			publish.needs.includes("suite") &&
+			publish.needs.includes("plan"),
+		"publication must wait for plan and all account batches",
 	);
-
-	// ...the array must actually reach it, or the cell silently falls back to a single sandbox...
-	const rawEnv = env[REPLICATES_ENV_KEY];
-	const replicatesEnv = typeof rawEnv === "string" ? rawEnv : undefined;
-	if (replicatesEnv !== EXPECTED_REPLICATES_ENV_EXPR) {
-		errors.push(
-			`${label}: job "${SUITE_JOB}" step "${RUN_STEP}" must set ${REPLICATES_ENV_KEY}: ` +
-				`"${EXPECTED_REPLICATES_ENV_EXPR}" so the cell fans out over the plan's replicate axis ` +
-				`(got ${replicatesEnv === undefined ? "no such env key" : `"${replicatesEnv}"`})`,
-		);
-	}
-
-	// ...AND the command must consume it. Checking only the env block left the invariant bypassable by
-	// its own stated failure mode: dropping the flag from the `run:` line keeps the env key present, so
-	// the gate stayed green while bench-suite took its single-sandbox default and the legacy
-	// `<runId>.json` glob in commit-dataset.yml collected the lone shard without complaint — a matrix
-	// run that publishes R=1 with the dataset's between-machine intervals collapsed to within-machine
-	// ones. A substring match is enough and matches how the rest of this module pins expressions.
-	const runCommand = typeof step?.run === "string" ? step.run : undefined;
-	if (runCommand === undefined || !runCommand.includes(EXPECTED_REPLICATES_ARG)) {
-		errors.push(
-			`${label}: job "${SUITE_JOB}" step "${RUN_STEP}" must pass ${EXPECTED_REPLICATES_ARG} to ` +
-				`bench-suite — setting ${REPLICATES_ENV_KEY} without consuming it silently runs ONE sandbox ` +
-				`per cell (got ${runCommand === undefined ? "no run: command" : `"${runCommand.trim()}"`})`,
-		);
-	}
-
+	const promotion = stepByName(
+		job("commit-dataset.yml", "commit"),
+		"Aggregate + promote",
+		"commit-dataset.yml",
+	);
+	expect(
+		typeof promotion?.run === "string" &&
+			promotion.run.includes(
+				"aggregate-experiment.ts experiment/manifest/plan.json experiment/attempts",
+			) &&
+			promotion.run.includes("data/dataset experiment/manifest/plan.json experiment/attempts"),
+		"publication must verify original plan and whole attempts",
+	);
 	return errors;
 }

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -32,13 +32,7 @@
 // timeout/delegation invariants plus runCheck orchestration, and re-exports the public surface the
 // gate's tests import.
 import { PROVIDERS, SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
-import {
-	checkLaneDelegates,
-	checkSmokeSingleSandboxDefault,
-	checkSuiteMatrixCaller,
-	checkSuiteWorkflowNesting,
-	matrixSuiteCaller,
-} from "./workflow-nesting.ts";
+import { checkExperimentNesting, checkLaneDelegates } from "./workflow-nesting.ts";
 import type { DispatchInput } from "./workflow-yaml.ts";
 import {
 	dispatchInput,
@@ -54,24 +48,7 @@ import {
 } from "./workflow-yaml.ts";
 import { findRepoRoot } from "./workspace.ts";
 
-export type { SuiteMatrixCaller, SuiteMatrixCallerOptions } from "./workflow-nesting.ts";
-export {
-	checkLaneDelegates,
-	checkSmokeSingleSandboxDefault,
-	checkSuiteMatrixCaller,
-	checkSuiteWorkflowNesting,
-	EXPECTED_PROVIDER_NAME_EXPR,
-	EXPECTED_REPLICATES_ARG,
-	EXPECTED_REPLICATES_ENV_EXPR,
-	EXPECTED_REPLICATES_INPUT_EXPR,
-	EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR,
-	EXPECTED_SMOKE_REPLICAS_INPUT_EXPR,
-	EXPECTED_SUITE_MATRIX_EXPR,
-	EXPECTED_SUITE_NAME_EXPR,
-	matrixSuiteCaller,
-	PLAN_STEP,
-	REPLICATES_ENV_KEY,
-} from "./workflow-nesting.ts";
+export { checkExperimentNesting, checkLaneDelegates } from "./workflow-nesting.ts";
 export type { DispatchInput } from "./workflow-yaml.ts";
 export {
 	dispatchInput,
@@ -234,19 +211,17 @@ export function runCheck(root: string = findRepoRoot()): string[] {
 		...checkLaneDelegates(matrix, MATRIX_WORKFLOW, credentialKeys),
 		...checkWorkflowTimeouts({ [SUITE_WORKFLOW]: suiteTimeout }),
 		...checkCellBudgetEnv(suiteEnv, suiteTimeout, SUITE_WORKFLOW),
-		// Both lanes are held to one caller shape, and each states BOTH flags: the matrix owns the
-		// publish dependency and must not require a provider; the smoke is the mirror image. Spelling
-		// out both at each lane is what makes this the complete, declared list of permitted differences
-		// rather than a default someone can drift past.
-		...checkSuiteMatrixCaller(matrixSuiteCaller(matrix, MATRIX_WORKFLOW), MATRIX_WORKFLOW, {
-			requirePublishNeeds: true,
-			requireProviderAssertion: false,
-		}),
-		...checkSuiteMatrixCaller(matrixSuiteCaller(smoke, SMOKE_WORKFLOW), SMOKE_WORKFLOW, {
-			requirePublishNeeds: false,
-			requireProviderAssertion: true,
-		}),
-		...checkSmokeSingleSandboxDefault(smoke, SMOKE_WORKFLOW),
-		...checkSuiteWorkflowNesting(suiteWf, SUITE_WORKFLOW),
+		...checkExperimentNesting(
+			Object.fromEntries(
+				[
+					"bench-matrix.yml",
+					"bench-smoke.yml",
+					"bench-account.yml",
+					"bench-round.yml",
+					"bench-suite.yml",
+					"commit-dataset.yml",
+				].map((file) => [file, readWorkflow(`.github/workflows/${file}`, root)]),
+			),
+		),
 	];
 }

--- a/tooling/repo-checks/src/lint-workflows.ts
+++ b/tooling/repo-checks/src/lint-workflows.ts
@@ -1,0 +1,21 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	ACTIONLINT_QUEUE_COMPATIBILITY,
+	checkConcurrencyQueues,
+} from "./lib/workflow-concurrency.ts";
+
+if (import.meta.main) {
+	for (const file of readdirSync(".github/workflows").filter((file) => /\.ya?ml$/.test(file))) {
+		try {
+			checkConcurrencyQueues(readFileSync(join(".github/workflows", file), "utf8"));
+		} catch (error) {
+			throw new Error(`Invalid concurrency queue in ${file}`, { cause: error });
+		}
+	}
+	const result = Bun.spawnSync(
+		["mise", "exec", "--", "actionlint", "-no-color", "-ignore", ACTIONLINT_QUEUE_COMPATIBILITY],
+		{ stdout: "inherit", stderr: "inherit" },
+	);
+	process.exitCode = result.exitCode;
+}

--- a/tooling/repo-checks/src/workflow-concurrency.test.ts
+++ b/tooling/repo-checks/src/workflow-concurrency.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { type } from "arktype";
+import { checkConcurrencyQueues } from "./lib/workflow-concurrency.ts";
+import { findRepoRoot } from "./lib/workspace.ts";
+
+test("queue compatibility rejects invalid values and pending-work cancellation", () => {
+	for (const value of ["one", "true", "100", `'\${{ inputs.queue }}'`]) {
+		expect(() =>
+			checkConcurrencyQueues(
+				`jobs: {}\nconcurrency:\n  group: account\n  cancel-in-progress: false\n  queue: ${value}`,
+			),
+		).toThrow();
+	}
+	expect(() =>
+		checkConcurrencyQueues(
+			"jobs: {}\nconcurrency:\n  group: account\n  queue: max\n  cancel-in-progress: true",
+		),
+	).toThrow();
+	expect(() =>
+		checkConcurrencyQueues(
+			"jobs: {}\nconcurrency:\n  group: account\n  queue: max\n  cancel-in-progress: false",
+		),
+	).not.toThrow();
+});
+
+test("all current allocating workflows share account queues across variants and lanes", () => {
+	const matrixGroup = `benchmark-account-\${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && 'daytona' || (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && 'modal' || matrix.provider }}`;
+	const schema = type({ jobs: { "[string]": { "concurrency?": "unknown" } } });
+	for (const [file, jobIds, group] of [
+		["bench-suite.yml", ["bench"], matrixGroup],
+		["toolchain-image.yml", ["bake"], matrixGroup],
+		[
+			"bench-gpu.yml",
+			["prepare-assets", "prepare-kernels", "benchmark"],
+			"benchmark-account-modal",
+		],
+	] as const) {
+		const source = readFileSync(join(findRepoRoot(), ".github/workflows", file), "utf8");
+		checkConcurrencyQueues(source);
+		const parsed = schema.assert(Bun.YAML.parse(source));
+		for (const job of jobIds)
+			expect(parsed.jobs[job]?.concurrency).toEqual({
+				group,
+				queue: "max",
+				"cancel-in-progress": false,
+			});
+	}
+});

--- a/tooling/repo-checks/src/workflow-concurrency.test.ts
+++ b/tooling/repo-checks/src/workflow-concurrency.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { quotaDomain } from "@sandbox-benchmarks/schema";
 import { type } from "arktype";
 import { checkConcurrencyQueues } from "./lib/workflow-concurrency.ts";
 import { findRepoRoot } from "./lib/workspace.ts";
@@ -26,25 +27,24 @@ test("queue compatibility rejects invalid values and pending-work cancellation",
 });
 
 test("all current allocating workflows share account queues across variants and lanes", () => {
-	const matrixGroup = `benchmark-account-\${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && 'daytona' || (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && 'modal' || matrix.provider }}`;
 	const schema = type({ jobs: { "[string]": { "concurrency?": "unknown" } } });
-	for (const [file, jobIds, group] of [
-		["bench-suite.yml", ["bench"], matrixGroup],
-		["toolchain-image.yml", ["bake"], matrixGroup],
-		[
-			"bench-gpu.yml",
-			["prepare-assets", "prepare-kernels", "benchmark"],
-			"benchmark-account-modal",
-		],
-	] as const) {
+	const queueSchema = type({ group: "string", queue: "'max'", "cancel-in-progress": "false" });
+	const jobQueue = (file: string, job: string) => {
 		const source = readFileSync(join(findRepoRoot(), ".github/workflows", file), "utf8");
 		checkConcurrencyQueues(source);
-		const parsed = schema.assert(Bun.YAML.parse(source));
-		for (const job of jobIds)
-			expect(parsed.jobs[job]?.concurrency).toEqual({
-				group,
-				queue: "max",
-				"cancel-in-progress": false,
-			});
-	}
+		return queueSchema.assert(schema.assert(Bun.YAML.parse(source)).jobs[job]?.concurrency);
+	};
+	// The per-cell group is a generated region rendered from the provider registry's quota domains
+	// (its content is pinned by the provider-wiring drift gate), so what this check owns is that
+	// every matrix lane queues on that ONE expression rather than a hand-maintained copy.
+	const bench = jobQueue("bench-suite.yml", "bench").group;
+	expect(bench).toStartWith("benchmark-account-${{ ");
+	expect(bench).toEndWith(" || matrix.provider }}");
+	expect(jobQueue("toolchain-image.yml", "bake").group).toBe(bench);
+	// The GPU lane is Modal-only and names the account directly: the registry's domain, not a literal
+	// that could survive a rename.
+	for (const job of ["prepare-assets", "prepare-kernels", "benchmark"])
+		expect(jobQueue("bench-gpu.yml", job).group).toBe(
+			`benchmark-account-${quotaDomain("modal-gvisor")}`,
+		);
 });

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -17,30 +17,15 @@
 // failure messages on synthetic drift, so a future regression names the offending file + key.
 import { describe, expect, test } from "bun:test";
 import { SUITE_NAMES } from "@sandbox-benchmarks/schema";
-import type { SuiteMatrixCaller } from "./lib/workflow-sync.ts";
 import {
 	CELL_BUDGET_ENV_KEY,
 	checkCellBudgetEnv,
 	checkLaneDelegates,
-	checkSmokeSingleSandboxDefault,
 	checkSuiteInput,
-	checkSuiteMatrixCaller,
-	checkSuiteWorkflowNesting,
 	checkWorkflowTimeouts,
 	dispatchInput,
-	EXPECTED_PROVIDER_NAME_EXPR,
-	EXPECTED_REPLICATES_ARG,
-	EXPECTED_REPLICATES_ENV_EXPR,
-	EXPECTED_REPLICATES_INPUT_EXPR,
-	EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR,
-	EXPECTED_SMOKE_REPLICAS_INPUT_EXPR,
-	EXPECTED_SUITE_MATRIX_EXPR,
-	EXPECTED_SUITE_NAME_EXPR,
 	jobTimeoutMinutes,
 	MATRIX_WORKFLOW,
-	matrixSuiteCaller,
-	PLAN_STEP,
-	REPLICATES_ENV_KEY,
 	RUN_STEP,
 	readWorkflow,
 	requiredCredentialKeys,
@@ -52,8 +37,8 @@ import {
 	WORKFLOW_TIMEOUT_MARGIN_MINUTES,
 } from "./lib/workflow-sync.ts";
 
-const smoke = readWorkflow(SMOKE_WORKFLOW);
 const matrix = readWorkflow(MATRIX_WORKFLOW);
+const smoke = readWorkflow(SMOKE_WORKFLOW);
 const suiteWf = readWorkflow(SUITE_WORKFLOW);
 const suiteInput = dispatchInput(smoke, "suite", SMOKE_WORKFLOW);
 const suiteEnv = stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW);
@@ -269,336 +254,32 @@ describe("checkLaneDelegates", () => {
 	});
 });
 
-describe("checkSmokeSingleSandboxDefault", () => {
-	// Invariant 7. `default: '1'` does NOT hold this on its own — a cleared dispatch field sends "",
-	// which means "each suite's Suite.defaultReplicas" (R=12 on realworld). The fallback is the guard.
-	test("the real smoke lane pins one sandbox against a cleared field", () => {
-		expect(checkSmokeSingleSandboxDefault(smoke, SMOKE_WORKFLOW)).toEqual([]);
-		expect(dispatchInput(smoke, "replicas", SMOKE_WORKFLOW).default).toBe("1");
-	});
-
-	test("flags a plan step that forwards replicas without the blank fallback", () => {
-		const yaml = Bun.YAML.stringify({
-			jobs: {
-				plan: {
-					steps: [
-						// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal, not a JS template.
-						{ name: PLAN_STEP, with: { replicas: "${{ inputs.replicas }}" } },
-					],
-				},
-			},
-		});
-		const errors = checkSmokeSingleSandboxDefault(Bun.YAML.parse(yaml), "synthetic.yml");
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain(EXPECTED_SMOKE_REPLICAS_INPUT_EXPR);
-		expect(errors[0]).toContain("R=12");
-	});
-
-	test("flags a missing plan job or plan step rather than passing vacuously", () => {
-		const noJob = Bun.YAML.stringify({ jobs: { suite: {} } });
-		expect(checkSmokeSingleSandboxDefault(Bun.YAML.parse(noJob), "synthetic.yml")[0]).toContain(
-			'job "plan" is missing',
-		);
-		const noStep = Bun.YAML.stringify({ jobs: { plan: { steps: [{ name: "Checkout" }] } } });
-		expect(checkSmokeSingleSandboxDefault(Bun.YAML.parse(noStep), "synthetic.yml")[0]).toContain(
-			`no step named "${PLAN_STEP}"`,
-		);
-	});
+test("production workflows preserve planned account batching and strict promotion", () => {
+	expect(runCheck()).toEqual([]);
 });
 
-describe("checkSuiteMatrixCaller", () => {
-	const realCaller = matrixSuiteCaller(matrix, MATRIX_WORKFLOW);
-	// The matrix lane's complete, declared posture: it owns the publish dependency and must NOT require
-	// a provider. Every call states both — a partial object would silently waive the flag it omits,
-	// which is exactly why the options type has no optional fields.
-	const MATRIX_LANE = { requirePublishNeeds: true, requireProviderAssertion: false } as const;
-	const check = (caller: SuiteMatrixCaller, label = MATRIX_WORKFLOW): string[] =>
-		checkSuiteMatrixCaller(caller, label, MATRIX_LANE);
-
-	test("matrixSuiteCaller extracts the real suite-matrix nesting wiring", () => {
-		expect(realCaller.jobId).toBe("suite");
-		expect(realCaller.name).toBe(EXPECTED_SUITE_NAME_EXPR);
-		expect(realCaller.suiteInput).toBe(EXPECTED_SUITE_NAME_EXPR);
-		expect(realCaller.matrixSuiteExpr).toBe(EXPECTED_SUITE_MATRIX_EXPR);
-		expect(realCaller.publishNeeds).toContain("suite");
-	});
-
-	test("the real suite-matrix caller is wired for native nesting", () => {
-		expect(check(realCaller)).toEqual([]);
-	});
-
-	test("flags a caller whose display name is not matrix.suite", () => {
-		const errors = check({ ...realCaller, name: "Bench suites" });
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("name must be");
-		expect(errors[0]).toContain(EXPECTED_SUITE_NAME_EXPR);
-	});
-
-	test("flags a caller whose with.suite is not matrix.suite", () => {
-		const errors = check({ ...realCaller, suiteInput: "cpu-node" });
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("with.suite must be");
-	});
-
-	test("flags a caller whose suite axis is not plan.outputs.suites", () => {
-		const errors = check({
-			...realCaller,
-			// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal (wrong axis), not a JS template.
-			matrixSuiteExpr: "${{ fromJSON(needs.plan.outputs.providers) }}",
-		});
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("strategy.matrix.suite must be");
-		expect(errors[0]).toContain(EXPECTED_SUITE_MATRIX_EXPR);
-	});
-
-	test("flags publish that does not need the suite-matrix caller", () => {
-		const errors = check({ ...realCaller, publishNeeds: ["plan"] });
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain('publish" must need "suite"');
-	});
-
-	test("matrixSuiteCaller throws when no job calls the reusable", () => {
-		const yaml = Bun.YAML.stringify({ jobs: { plan: { "runs-on": "ubuntu-24.04" } } });
-		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
-			"no job calls the reusable bench-suite.yml",
-		);
-	});
-
-	test("matrixSuiteCaller throws on multiple suite-matrix callers", () => {
-		const yaml = Bun.YAML.stringify({
-			jobs: {
-				a: {
-					name: EXPECTED_SUITE_NAME_EXPR,
-					uses: "./.github/workflows/bench-suite.yml",
-					with: { suite: EXPECTED_SUITE_NAME_EXPR, replicates: EXPECTED_REPLICATES_INPUT_EXPR },
-					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
-				},
-				b: {
-					name: EXPECTED_SUITE_NAME_EXPR,
-					uses: "./.github/workflows/bench-suite.yml",
-					with: { suite: EXPECTED_SUITE_NAME_EXPR, replicates: EXPECTED_REPLICATES_INPUT_EXPR },
-					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
-				},
-			},
-		});
-		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
-			"expected exactly one suite-matrix caller",
-		);
-	});
-
-	// The caller-side twin of the run-step bypass: hardcoding the array here passes every other nesting
-	// check while quietly measuring one sandbox per cell.
-	test("flags a caller that hardcodes with.replicates instead of taking the plan's slice", () => {
-		const caller = {
-			...matrixSuiteCaller(matrix, MATRIX_WORKFLOW),
-			replicatesInput: "[0]",
-		};
-		const errors = check(caller, "synthetic.yml");
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("with.replicates must be");
-		expect(errors[0]).toContain(EXPECTED_REPLICATES_INPUT_EXPR);
-	});
-
-	test("matrixSuiteCaller throws on a reusable-caller job with no string replicates", () => {
-		const yaml = Bun.YAML.stringify({
-			jobs: {
-				bad: {
-					uses: "./.github/workflows/bench-suite.yml",
-					with: { suite: EXPECTED_SUITE_NAME_EXPR },
-					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
-				},
-			},
-		});
-		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
-			'without a string "replicates" input',
-		);
-	});
-
-	test("matrixSuiteCaller throws on a reusable-caller job with no string suite", () => {
-		const yaml = Bun.YAML.stringify({
-			jobs: { bad: { uses: "./.github/workflows/bench-suite.yml", with: { providers: "[]" } } },
-		});
-		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
-			'without a string "suite" input',
-		);
-	});
-
-	test("matrixSuiteCaller rejects a present non-string require_providers input", () => {
-		const yaml = Bun.YAML.stringify({
-			jobs: {
-				bad: {
-					name: EXPECTED_SUITE_NAME_EXPR,
-					uses: "./.github/workflows/bench-suite.yml",
-					with: {
-						suite: EXPECTED_SUITE_NAME_EXPR,
-						replicates: EXPECTED_REPLICATES_INPUT_EXPR,
-						require_providers: true,
-					},
-					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
-				},
-			},
-		});
-		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
-			'with a non-string "require_providers" input',
-		);
-	});
-});
-
-describe("checkSuiteMatrixCaller on the smoke lane", () => {
-	const smokeCaller = matrixSuiteCaller(smoke, SMOKE_WORKFLOW);
-	// The smoke lane's complete, declared posture — the exact mirror of MATRIX_LANE above.
-	const SMOKE_LANE = { requirePublishNeeds: false, requireProviderAssertion: true } as const;
-
-	// The consolidation in one assertion: the smoke lane's caller is the matrix lane's caller, down to
-	// the job id and every nesting expression. If these diverge, "a smoke is a real run minus the
-	// commit" has stopped being true.
-	test("the smoke caller is wired identically to the matrix caller", () => {
-		const matrixCaller = matrixSuiteCaller(matrix, MATRIX_WORKFLOW);
-		expect(smokeCaller.jobId).toBe(matrixCaller.jobId);
-		expect(smokeCaller.name).toBe(matrixCaller.name);
-		expect(smokeCaller.suiteInput).toBe(matrixCaller.suiteInput);
-		expect(smokeCaller.replicatesInput).toBe(matrixCaller.replicatesInput);
-		expect(smokeCaller.matrixSuiteExpr).toBe(matrixCaller.matrixSuiteExpr);
-	});
-
-	test("the real smoke caller passes its dispatched provider as require_providers", () => {
-		expect(smokeCaller.requireProvidersInput).toBe(EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR);
-		expect(checkSuiteMatrixCaller(smokeCaller, SMOKE_WORKFLOW, SMOKE_LANE)).toEqual([]);
-	});
-
-	// Dropping it is the silent regression: every nesting check still passes, the job still goes green,
-	// and a missing credential is recorded as a skip on a run that benchmarked nothing.
-	test("flags a smoke caller that stopped requiring its provider", () => {
-		const { requireProvidersInput: _dropped, ...caller } = smokeCaller;
-		const errors = checkSuiteMatrixCaller(caller, SMOKE_WORKFLOW, SMOKE_LANE);
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("with.require_providers must be");
-		expect(errors[0]).toContain("no such input");
-	});
-
-	// The smoke lane deliberately has NO publish job — that missing third phase IS the difference
-	// between the lanes — so the publish dependency must not be demanded of it.
-	test("does not demand a publish dependency of the smoke lane", () => {
-		expect(smokeCaller.publishNeeds).toEqual([]);
-		expect(checkSuiteMatrixCaller(smokeCaller, SMOKE_WORKFLOW, SMOKE_LANE)).toEqual([]);
-	});
-
-	// The mirror image, and the reason `requireProviderAssertion: false` asserts ABSENCE rather than
-	// merely not-checking: a stray value on the matrix lane fails every cell whose provider it names —
-	// loudly, but only after a whole matrix run's worth of provider quota is committed.
-	test("flags a matrix-lane caller that grew a require_providers input", () => {
-		const errors = checkSuiteMatrixCaller(
-			{ ...matrixSuiteCaller(matrix, MATRIX_WORKFLOW), requireProvidersInput: "e2b" },
-			MATRIX_WORKFLOW,
-			{ requirePublishNeeds: true, requireProviderAssertion: false },
-		);
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("must not pass with.require_providers");
-	});
-});
-
-describe("checkSuiteWorkflowNesting", () => {
-	const suiteWf = readWorkflow(SUITE_WORKFLOW);
-
-	test("the real reusable fan-out job is named matrix.provider", () => {
-		expect(checkSuiteWorkflowNesting(suiteWf)).toEqual([]);
-	});
-
-	/** A fan-out job that satisfies every nesting invariant; each drift test bends exactly one field. */
-	const wiredRunStep = {
-		name: RUN_STEP,
-		env: { [REPLICATES_ENV_KEY]: EXPECTED_REPLICATES_ENV_EXPR },
-		run: `bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" ${EXPECTED_REPLICATES_ARG}`,
-	};
-	const wiredFanOut = {
-		name: EXPECTED_PROVIDER_NAME_EXPR,
-		"runs-on": "ubuntu-24.04",
-		steps: [wiredRunStep],
-	};
-	const nestingErrors = (job: object): string[] =>
-		checkSuiteWorkflowNesting(
-			Bun.YAML.parse(Bun.YAML.stringify({ jobs: { [SUITE_JOB]: job } })),
-			"synthetic.yml",
-		);
-
-	test("passes a fan-out job named matrix.provider that receives the replicate array", () => {
-		expect(nestingErrors(wiredFanOut)).toEqual([]);
-	});
-
-	test("flags a fan-out job whose display name is not matrix.provider", () => {
-		const errors = nestingErrors({ ...wiredFanOut, name: "Run" });
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("name must be");
-		expect(errors[0]).toContain(EXPECTED_PROVIDER_NAME_EXPR);
-	});
-
-	// Re-adding the axis is the exact regression the in-process fan-out exists to prevent: it would
-	// silently restore one idle runner per replicate.
-	test("flags a reinstated replicate matrix axis", () => {
-		const errors = nestingErrors({
-			...wiredFanOut,
-			strategy: { matrix: { provider: "[]", replicate: "[0,1]" } },
-		});
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain('must not have a "replicate" matrix axis');
-	});
-
-	test("accepts a provider-only matrix", () => {
-		expect(nestingErrors({ ...wiredFanOut, strategy: { matrix: { provider: "[]" } } })).toEqual([]);
-	});
-
-	// Without the env wiring the cell falls back to ONE sandbox — a green run that publishes R=1 while
-	// the plan asked for R=12, so the drift must fail the gate rather than the dataset.
-	test("flags a run step that never receives the replicate array", () => {
-		const errors = nestingErrors({
-			...wiredFanOut,
-			steps: [{ ...wiredRunStep, env: {} }],
-		});
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain(REPLICATES_ENV_KEY);
-		expect(errors[0]).toContain("no such env key");
-	});
-
-	// The bypass that made the env check alone insufficient: keep the env key, drop the flag. The cell
-	// then takes bench-suite's single-sandbox default and commit-dataset's legacy glob collects the one
-	// shard without complaint — a green matrix run publishing R=1.
-	test("flags a run step that sets the env but never passes --replicates", () => {
-		const errors = nestingErrors({
-			...wiredFanOut,
-			steps: [
-				{
-					...wiredRunStep,
-					run: 'bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"',
-				},
-			],
-		});
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain(EXPECTED_REPLICATES_ARG);
-	});
-
-	test("flags a run step with no run: command at all", () => {
-		const { run: _dropped, ...noRun } = wiredRunStep;
-		const errors = nestingErrors({ ...wiredFanOut, steps: [noRun] });
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("no run: command");
-	});
-
-	// `replicas` (the dispatch knob) vs `replicates` (the plan's index array) is the plausible typo:
-	// it's a live input name, so it resolves to a value rather than failing the workflow outright.
-	test("flags a replicate array wired to the wrong expression", () => {
-		// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal, not a JS template.
-		const wrongExpr = "${{ inputs.replicas }}";
-		const errors = nestingErrors({
-			...wiredFanOut,
-			steps: [{ ...wiredRunStep, env: { [REPLICATES_ENV_KEY]: wrongExpr } }],
-		});
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain(EXPECTED_REPLICATES_ENV_EXPR);
-	});
-});
-
-describe("the gate itself", () => {
-	test("the real workflows are in lockstep with the registries", () => {
-		expect(runCheck()).toEqual([]);
-	});
+test("the integrated workflow gate rejects parallel batches, detached plan axes and legacy promotion", async () => {
+	const { checkExperimentNesting } = await import("./lib/workflow-nesting.ts");
+	const docs = Object.fromEntries(
+		[
+			"bench-matrix.yml",
+			"bench-smoke.yml",
+			"bench-account.yml",
+			"bench-round.yml",
+			"bench-suite.yml",
+			"commit-dataset.yml",
+		].map((file) => [file, readWorkflow(`.github/workflows/${file}`)]),
+	);
+	const source = JSON.stringify(docs);
+	for (const [before, after] of [
+		['"max-parallel":1', '"max-parallel":2'],
+		["fromJSON(needs.plan.outputs.accounts)", "fromJSON(needs.plan.outputs.suites)"],
+		["data/dataset experiment/manifest/plan.json experiment/attempts", "data/dataset"],
+		["workflow-experiment.ts execute", "bench-suite.ts"],
+	] as const) {
+		expect(source).toContain(before);
+		expect(
+			checkExperimentNesting(JSON.parse(source.replace(before, after))).length,
+		).toBeGreaterThan(0);
+	}
 });


### PR DESCRIPTION
## Summary

Matrix and smoke runs now freeze one immutable experiment plan and dispatch it account → collection round → batch. Every allocating worker verifies the plan and source revision, reconciles its account once through a durable per-account journal branch, runs one bounded wave through the shared harness, and uploads identity-bound execution and cleanup receipts. Publication (`aggregate-experiment` → `promote`) refuses anything the receipts and journal do not confirm.

Commits, bottom to top:

- `feat(results)`: bind experiment publication to planned attempt evidence (schema 1 plans and receipts, schema 7 Run linkage, coverage evaluation).
- `fix(harness)`: preserve durable outcomes and unresolved cleanup.
- `fix(ci)`: queue allocating jobs by account and preserve run attempts.
- `refactor(harness)`: share replicate execution and enforce phase deadlines.
- `feat(cli)`: execute planned batches with durable account ownership.
- `feat(ci)`: dispatch frozen experiment batches and verify publication evidence.
- `fix`: address the review findings (final-attempt step judgement, journal ordering, per-runner secret snapshot, single coverage evaluation, registry-generated account concurrency groups).

`docs/benchmark-execution-rollout.md` is the implementation status record, including what remains before live rollout.

## Validation

- Local: typecheck, Biome, full test suite (2,046 tests), catalog/registry/wiring drift gates.
- Live: a `tama` smoke on this branch (`allow_branch`) once the `benchmark-account-journal-tama` branch is provisioned; only `tama` currently has the inventory capability admission requires.

https://claude.ai/code/session_011FKKE96sUxrtHQdo3GJWRs
