### PR TITLE
docs: record the tama live canary and the deployment-branch `*` pattern caveat

### DIFF
--- a/docs/benchmark-execution-rollout.md
+++ b/docs/benchmark-execution-rollout.md
@@ -97,8 +97,14 @@ baseline result has been inferred from offline tests.
 
 ## Remaining rollout work
 
-1. Provision protected account journals and run the integrated privileged canary. Confirm artifact
-   upload/download and Git journal permissions in the actual Actions environment.
+1. Provision protected account journals for the remaining accounts and run each account's integrated
+   privileged canary. Done for `tama` on 2026-09-10: branch `benchmark-account-journal-tama` seeded
+   with the empty journal (ruleset "Protect benchmark account journals" blocks deletion and
+   force-push on `benchmark-account-journal-*`), then smoke run 34537171216 on main (`tama` ×
+   `system`, one replicate) wrote intent → allocated → released(absent) as three fast-forward
+   commits, uploaded the plan and the attempt from the CLI, confirmed sandbox absence, and its
+   downloaded evidence passed collect → evaluate → aggregate → strict promote locally. Artifact
+   upload/download and journal permissions are confirmed in the Actions environment.
 2. Add complete inventories to remaining provider drivers and migrate legacy allocating paths,
    including GPU and toolchain validation, onto the account owner before sharing publication accounts.
 3. Reproduce E2B launch/descendant/filesystem/exec behaviors and Daytona's nested launch failure through

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -201,7 +201,10 @@ Do this in the GitHub UI (Settings → Environments / Rules / Actions), then del
    branch dispatch still fails at the environment with *"Branch is not allowed to deploy to
    privileged"* until this list admits the branch. To use `allow_branch`, add the branch patterns you
    want to reach it — e.g. `claude/*`, or a dedicated `bench/*` prefix maintainers push validation
-   branches to. Prefer a narrow pattern over `All branches`: anyone who can push a matching branch can
+   branches to. Patterns use branch-protection syntax, where `*` does not match `/`: a bare `*` admits
+   `main`-style names only, so a `codex/…` branch needs its own entry or a `codex/*` pattern (a smoke
+   dispatch on such a branch otherwise fails in 2 s with *"not allowed to deploy to privileged"*).
+   Prefer a narrow pattern over `All branches`: anyone who can push a matching branch can
    then request a `privileged` run (a reviewer still has to approve it, and the workflows' own
    same-repo guard still excludes forks, so this widens *who can ask*, not *what runs unattended*).
    Leave the list at `main` alone if you do not want branch dispatches at all — the input is inert


### PR DESCRIPTION
Two operator notes from validating PR #430 live:

- `docs/benchmark-execution-rollout.md`: the `tama` account canary is done. Branch `benchmark-account-journal-tama` was provisioned (with a ruleset blocking deletion and force-push on `benchmark-account-journal-*`), and smoke run [34537171216](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/34537171216) on main wrote intent → allocated → released(absent), uploaded the plan and the attempt from the CLI, confirmed sandbox absence, and its downloaded evidence passed collect → evaluate → aggregate → strict promote locally. Remaining accounts still need their journals provisioned.
- `docs/ci-secrets.md`: a smoke dispatch on `codex/benchmark-evidence` failed at the `privileged` environment with *"not allowed to deploy to privileged"* even though the deployment-branch list contains `*`. GitHub's pattern syntax does not let `*` match `/`, so a slashed branch needs its own entry or a `codex/*`-style pattern.

https://claude.ai/code/session_011FKKE96sUxrtHQdo3GJWRs
