### PR TITLE
feat(drivers): add complete account inventory and destroy-by-id for admission

### DIFF
--- a/apps/cli/src/bin/account-inventory.ts
+++ b/apps/cli/src/bin/account-inventory.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env bun
+// Print each provider account as the reconciliation gate sees it: the benchmark's own leftovers
+// (which the next batch's admission would delete) and foreign resources (which block allocation
+// outright). Read-only — the operator's "clean vendor baseline" check before provisioning an
+// account journal or dispatching a matrix. Credentials come from the environment (Bun loads .env).
+import { describeDriverFailure } from "@sandbox-benchmarks/driver";
+import { diagnosticSecretsFromEnv } from "@sandbox-benchmarks/driver/env";
+import type { DriverProviderId } from "@sandbox-benchmarks/drivers";
+import { DRIVERS } from "@sandbox-benchmarks/drivers";
+import {
+	formatAccountInventory,
+	inventoryAccounts,
+	inventoryBlocksAdmission,
+} from "../lib/account-inventory.ts";
+import { isDriverProviderId, openDriver } from "../lib/driver-run.ts";
+
+if (import.meta.main) {
+	const requested = process.argv.slice(2);
+	const unknown = requested.filter((id) => !isDriverProviderId(id));
+	if (unknown.length > 0) {
+		console.error(
+			[
+				"usage: account-inventory [provider...]",
+				`unknown or unmigrated provider(s): ${unknown.join(", ")}`,
+				`migrated providers: ${Object.keys(DRIVERS).join(", ")}`,
+			].join("\n"),
+		);
+		process.exit(2);
+	}
+	const ids = (requested.length > 0 ? requested : Object.keys(DRIVERS)) as DriverProviderId[];
+	const rows = await inventoryAccounts(
+		ids,
+		(id) => openDriver(id),
+		(error) => describeDriverFailure(error, diagnosticSecretsFromEnv(process.env)),
+	);
+	console.log(formatAccountInventory(rows));
+	process.exitCode = inventoryBlocksAdmission(rows) ? 1 : 0;
+}

--- a/apps/cli/src/lib/account-inventory.test.ts
+++ b/apps/cli/src/lib/account-inventory.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import type { SandboxDriver } from "@sandbox-benchmarks/driver";
+import {
+	formatAccountInventory,
+	inventoryAccounts,
+	inventoryBlocksAdmission,
+} from "./account-inventory.ts";
+
+const capable = (owned: readonly string[], foreignCount: number): SandboxDriver => ({
+	create: async () => {
+		throw new Error("unused");
+	},
+	destroyById: async () => {},
+	probes: { observe: async () => ({ state: "absent" }) },
+	inventory: {
+		list: async () => ({
+			owned: owned.map((id) => ({ provider: "tama" as const, id })),
+			foreignCount,
+		}),
+	},
+});
+
+test("reports every account the way admission sees it and never skips a failure", async () => {
+	const rows = await inventoryAccounts(
+		["tama", "e2b", "novita", "modal-vm"],
+		async (id) => {
+			if (id === "tama") return { driver: capable(["machine-a"], 0) };
+			if (id === "e2b") return { driver: capable([], 2) };
+			if (id === "novita")
+				return {
+					driver: {
+						create: async () => {
+							throw new Error("unused");
+						},
+					},
+				};
+			throw new Error("MODAL_TOKEN_ID missing");
+		},
+		(error) => (error instanceof Error ? error.message : String(error)),
+	);
+	expect(rows.map((row) => `${row.id}:${row.status}`)).toEqual([
+		"tama:listed",
+		"e2b:listed",
+		"novita:unsupported",
+		"modal-vm:failed",
+	]);
+	// Leftovers alone do not block (reconciliation removes them); foreign resources and gaps do.
+	expect(inventoryBlocksAdmission(rows.slice(0, 1))).toBe(false);
+	expect(inventoryBlocksAdmission(rows.slice(1, 2))).toBe(true);
+	expect(inventoryBlocksAdmission(rows)).toBe(true);
+	const text = formatAccountInventory(rows);
+	expect(text).toContain("tama (account tama): owned=1 [machine-a] foreign=0");
+	expect(text).toContain("e2b (account e2b): owned=0 [none] foreign=2");
+	expect(text).toContain("novita (account novita): unsupported — driver lacks");
+	expect(text).toContain("modal-vm (account modal): failed — MODAL_TOKEN_ID missing");
+});

--- a/apps/cli/src/lib/account-inventory.ts
+++ b/apps/cli/src/lib/account-inventory.ts
@@ -1,0 +1,62 @@
+import type { InventorySnapshot, ProviderId, SandboxDriver } from "@sandbox-benchmarks/driver";
+import { quotaDomain } from "@sandbox-benchmarks/schema";
+
+export type AccountInventoryRow = {
+	readonly id: ProviderId;
+	/** The quota domain the provider is charged to: the account reconciliation actually sweeps. */
+	readonly account: string;
+} & (
+	| { readonly status: "listed"; readonly snapshot: InventorySnapshot }
+	| { readonly status: "unsupported" | "failed"; readonly detail: string }
+);
+
+/**
+ * Observe every requested provider's account exactly as admission will: reconciliation refuses a
+ * driver without inventory, destroy-by-id and probes, and any foreign resource blocks allocation.
+ * Nothing here allocates or deletes, and a failed open or listing is reported, never skipped.
+ */
+export async function inventoryAccounts<P extends ProviderId>(
+	ids: readonly P[],
+	open: (id: P) => Promise<{ readonly driver: SandboxDriver }>,
+	describe: (error: unknown) => string,
+): Promise<AccountInventoryRow[]> {
+	const rows: AccountInventoryRow[] = [];
+	for (const id of ids) {
+		const account = quotaDomain(id);
+		try {
+			const { driver } = await open(id);
+			if (!driver.inventory || !driver.destroyById || !driver.probes) {
+				rows.push({
+					id,
+					account,
+					status: "unsupported",
+					detail: "driver lacks inventory, destroy-by-id, or probes",
+				});
+				continue;
+			}
+			rows.push({ id, account, status: "listed", snapshot: await driver.inventory.list() });
+		} catch (error) {
+			rows.push({ id, account, status: "failed", detail: describe(error) });
+		}
+	}
+	return rows;
+}
+
+/** Admission would block on any row here: an unsupported driver, a failed listing, or a foreign resource. */
+export function inventoryBlocksAdmission(rows: readonly AccountInventoryRow[]): boolean {
+	return rows.some((row) => row.status !== "listed" || row.snapshot.foreignCount > 0);
+}
+
+export function formatAccountInventory(rows: readonly AccountInventoryRow[]): string {
+	return rows
+		.map((row) => {
+			const head = `${row.id} (account ${row.account}):`;
+			if (row.status !== "listed") return `${head} ${row.status} — ${row.detail}`;
+			const owned =
+				row.snapshot.owned.length === 0
+					? "none"
+					: row.snapshot.owned.map((ref) => ref.id).join(", ");
+			return `${head} owned=${row.snapshot.owned.length} [${owned}] foreign=${row.snapshot.foreignCount}`;
+		})
+		.join("\n");
+}

--- a/docs/benchmark-execution-rollout.md
+++ b/docs/benchmark-execution-rollout.md
@@ -80,7 +80,10 @@ The file is an append-only record sequence; immutable Git commits retain every p
 one blob avoids a REST request per historical record on every new batch.
 
 An operator must provision these branches after quiescing existing account writers and confirming a
-clean vendor baseline. Protect them against deletion and force pushes, retain their history, and
+clean vendor baseline. `bun apps/cli/src/bin/account-inventory.ts [provider...]` reads every migrated
+provider's account exactly as admission will — the benchmark's own leftovers (removed by the next
+batch's reconciliation) and foreign resources (which block allocation outright) — without allocating
+or deleting anything; it exits non-zero when any account would block admission. Protect them against deletion and force pushes, retain their history, and
 permit the privileged workflow token to append commits. Do not reset a journal to recover an account.
 For an unknown create, obtain the vendor's request outcome and resource identity before recording
 recovery; an empty inventory is insufficient. No branch is automatically created or reset by a worker.

--- a/packages/drivers/src/_computesdk.test.ts
+++ b/packages/drivers/src/_computesdk.test.ts
@@ -1387,6 +1387,77 @@ describe("computeSdkDriver", () => {
 		expect(calls).toEqual(["observe:i2f3k4abc", "snapshot:i2f3k4abc", "delete:snap-1"]);
 	});
 
+	test("projects inventory and destroy-by-id through the canonical id boundary", async () => {
+		const { compute } = fakeCompute(baseSandbox);
+		const destroyed: string[] = [];
+		const driver = bridge(compute, {
+			inventory: { list: async () => ({ owned: ["i2f3k4abc", "iother"], foreignCount: 2 }) },
+			destroyById: async (_compute, ref) => {
+				destroyed.push(ref.id);
+			},
+		});
+		expect(await driver.inventory?.list()).toEqual({
+			owned: [
+				{ provider: "e2b", id: "i2f3k4abc" },
+				{ provider: "e2b", id: "iother" },
+			],
+			foreignCount: 2,
+		});
+		await driver.destroyById?.({ provider: "e2b", id: "i2f3k4abc" });
+		expect(destroyed).toEqual(["i2f3k4abc"]);
+		await expect(
+			driver.destroyById?.({ provider: "daytona-vm", id: "i2f3k4abc" }),
+		).rejects.toMatchObject({ code: "invalid-sandbox-ref", provider: "e2b" });
+		await expect(driver.destroyById?.({ provider: "e2b", id: "wrong-id" })).rejects.toMatchObject({
+			code: "invalid-sandbox-ref",
+			provider: "e2b",
+		});
+		// A non-canonical owned id crosses the same boundary a bad ref does.
+		await expect(
+			bridge(compute, {
+				inventory: { list: async () => ({ owned: ["not-canonical"], foreignCount: 0 }) },
+			}).inventory?.list(),
+		).rejects.toMatchObject({ code: "invalid-sandbox-ref", provider: "e2b" });
+		// An inventory that could authorize deleting the wrong thing is a contract violation.
+		for (const snapshot of [
+			{ owned: ["i2f3k4abc", "i2f3k4abc"], foreignCount: 0 },
+			{ owned: [], foreignCount: -1 },
+			{ owned: [], foreignCount: 1.5 },
+			{ owned: "i2f3k4abc", foreignCount: 0 },
+			null,
+		]) {
+			const broken = bridge(compute, {
+				inventory: { list: async () => snapshot as never },
+			});
+			await expect(broken.inventory?.list()).rejects.toMatchObject({
+				code: "vendor-contract-violation",
+				provider: "e2b",
+			});
+		}
+		const secret = "inventory-callback-secret";
+		const failing = bridge(compute, {
+			inventory: {
+				list: async () => {
+					throw new Error(secret);
+				},
+			},
+			destroyById: async () => {
+				throw new Error(secret);
+			},
+		});
+		const listError = await failing.inventory?.list().catch((caught: unknown) => caught);
+		expect(listError).toMatchObject({ code: "probe-failed", provider: "e2b" });
+		expect(String((listError as Error).cause)).not.toContain(secret);
+		const destroyError = await failing
+			.destroyById?.({ provider: "e2b", id: "i2f3k4abc" })
+			.catch((caught: unknown) => caught);
+		expect(destroyError).toMatchObject({ code: "destroy-failed", provider: "e2b" });
+		expect(String((destroyError as Error).cause)).not.toContain(secret);
+		const bare = bridge(compute, { hasWorkingFilesystem: false });
+		expect(bare.inventory).toBeUndefined();
+		expect(bare.destroyById).toBeUndefined();
+	});
+
 	test("normalizes successful probe and snapshot envelopes before they escape", async () => {
 		const secret = "capability-envelope-secret";
 		const { compute } = fakeCompute(baseSandbox);

--- a/packages/drivers/src/_computesdk.ts
+++ b/packages/drivers/src/_computesdk.ts
@@ -25,6 +25,7 @@ import type {
 	DriverOperationOptions,
 	DriverPolicy,
 	ExecOptions,
+	InventorySnapshot,
 	MethodTable,
 	ProviderId,
 	ResolvedArtifact,
@@ -122,6 +123,39 @@ export interface ComputeSdkLifecycle<TCompute extends ComputeSdkLike> {
 		recoveryLocator?: ComputeSdkRecoveryLocator,
 	): Promise<void>;
 }
+
+/**
+ * One complete account observation, in vendor ids: every sandbox the benchmark owns on this
+ * account plus a count of everything else. Ownership is the provider's own marker (a create-time
+ * name, label, or metadata key), never a guess from timing or resource shape.
+ */
+const computeSdkInventorySchema = type({
+	owned: "string[]",
+	foreignCount: "number.integer >= 0",
+}).narrow((snapshot) => Number.isSafeInteger(snapshot.foreignCount));
+
+export type ComputeSdkInventorySnapshot = typeof computeSdkInventorySchema.infer;
+
+export interface ComputeSdkInventory<TCompute extends ComputeSdkLike> {
+	/**
+	 * Drain the whole account. A partial or unavailable listing must reject: an empty result is a
+	 * positive claim that the account holds nothing, and account reconciliation deletes on the
+	 * strength of it. Owned ids cross the canonical sandbox-id boundary, so an id this variant
+	 * could never have created is a contract violation rather than a foreign resource.
+	 */
+	list(compute: TCompute, options: DriverOperationOptions): Promise<ComputeSdkInventorySnapshot>;
+}
+
+/**
+ * Canonical-id teardown with no retained handle, for recovering leftovers found through inventory.
+ * Converges silently only on the vendor's typed not-found; every other failure must surface so a
+ * leaked, billable sandbox is never reported as removed.
+ */
+export type ComputeSdkDestroyById<TCompute extends ComputeSdkLike> = (
+	compute: TCompute,
+	ref: SandboxRef,
+	options: DriverOperationOptions,
+) => Promise<void>;
 
 export type ComputeSdkCreateRecoveryObservation =
 	| { readonly status: "destroyed" }
@@ -308,6 +342,14 @@ export interface ComputeSdkDriverSpec<TCompute extends ComputeSdkLike> {
 		): Promise<{ readonly snapshotId: string }>;
 		delete(compute: TCompute, snapshotId: string): Promise<void>;
 	};
+	/**
+	 * Whole-account inventory, supplied only where the vendor can enumerate every sandbox. Together
+	 * with {@link destroyById} and `probes` it is what account admission requires (the CLI's
+	 * reconciliation refuses a driver missing any of the three).
+	 */
+	readonly inventory?: ComputeSdkInventory<TCompute>;
+	/** See {@link ComputeSdkDestroyById}. */
+	readonly destroyById?: ComputeSdkDestroyById<TCompute>;
 }
 
 /**
@@ -822,6 +864,45 @@ function normalizeComputeSdkSnapshot(
 	});
 }
 
+/**
+ * Validate one inventory envelope before it can authorize a deletion: owned ids must be an array
+ * of canonical, distinct sandbox ids for THIS provider, and the foreign count a non-negative safe
+ * integer. Anything else is a contract violation; reconciliation must never act on a guess.
+ */
+function normalizeComputeSdkInventory(
+	provider: ProviderId,
+	value: unknown,
+	schema: ComputeSdkSandboxIdParser,
+	sensitiveValues: readonly string[],
+): InventorySnapshot {
+	let snapshot: ComputeSdkInventorySnapshot;
+	try {
+		snapshot = computeSdkInventorySchema.assert(value);
+	} catch {
+		throw vendorContractFailure(
+			provider,
+			"inventory list result",
+			"inventory requires owned ids and a non-negative safe integer foreignCount",
+			sensitiveValues,
+		);
+	}
+	const seen = new Set<string>();
+	const owned = snapshot.owned.map((raw) => {
+		const id = parseSandboxId(provider, schema, raw, sensitiveValues, "canonical");
+		if (seen.has(id)) {
+			throw vendorContractFailure(
+				provider,
+				"inventory list result",
+				"owned list repeated a sandbox id",
+				sensitiveValues,
+			);
+		}
+		seen.add(id);
+		return sandboxRef(provider, id);
+	});
+	return { owned, foreignCount: snapshot.foreignCount };
+}
+
 /** Compile a computesdk provider instance to a method table. */
 function computeSdkMethodTable<TCompute extends ComputeSdkLike>(
 	provider: ProviderId,
@@ -848,6 +929,9 @@ function computeSdkMethodTable<TCompute extends ComputeSdkLike>(
 		rawSnapshots === undefined
 			? undefined
 			: { create: rawSnapshots.create, delete: rawSnapshots.delete };
+	const rawInventory = options.inventory;
+	const inventory = rawInventory === undefined ? undefined : { list: rawInventory.list };
+	const destroyById = options.destroyById;
 	const rawCommands = options.commands;
 	const commands =
 		rawCommands === undefined ? undefined : { exec: rawCommands.exec, launch: rawCommands.launch };
@@ -1320,6 +1404,54 @@ function computeSdkMethodTable<TCompute extends ComputeSdkLike>(
 					},
 				}
 			: {}),
+		...(inventory === undefined
+			? {}
+			: {
+					inventory: {
+						list: async (compute: TCompute, operationOptions: DriverOperationOptions = {}) =>
+							normalizeComputeSdkInventory(
+								provider,
+								await invokeComputeSdkProviderCallbackAsync(
+									provider,
+									"inventory list",
+									() => inventory.list(compute, operationOptions),
+									{ code: "probe-failed" },
+								),
+								sandboxIds.canonical,
+								sensitiveValuesDefault,
+							),
+					},
+				}),
+		...(destroyById === undefined
+			? {}
+			: {
+					destroyById: async (
+						compute: TCompute,
+						ref: SandboxRef,
+						operationOptions: DriverOperationOptions = {},
+					) => {
+						const canonical = validateRef(
+							provider,
+							sandboxIds.canonical,
+							ref,
+							sensitiveForRef(ref),
+						);
+						if (operationOptions.signal?.aborted) {
+							throw wrapperAborted(
+								provider,
+								operationOptions.signal.reason,
+								"destroy by id",
+								"destroy-failed",
+							);
+						}
+						await invokeComputeSdkProviderCallbackAsync(
+							provider,
+							"destroy by id",
+							() => destroyById(compute, canonical, operationOptions),
+							{ code: "destroy-failed", ref: canonical },
+						);
+					},
+				}),
 		...(probes === undefined
 			? {}
 			: {

--- a/packages/drivers/src/_daytona.test.ts
+++ b/packages/drivers/src/_daytona.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
-import { daytonaCommands } from "./_daytona.ts";
+import type { Daytona } from "@daytona/sdk";
+import { DaytonaNotFoundError } from "@daytona/sdk";
+import { daytonaCommands, daytonaSpec } from "./_daytona.ts";
 
 describe("Daytona session commands", () => {
 	test("reuses one control session and retains separate streams and nonzero exits", async () => {
@@ -124,4 +126,52 @@ test("native allocation sends the resolved target and snapshot without mutating 
 		if (previous === undefined) delete process.env.DAYTONA_TARGET;
 		else process.env.DAYTONA_TARGET = previous;
 	}
+});
+
+describe("Daytona account inventory and recovery", () => {
+	const owned1 = "11111111-1111-4111-8111-111111111111";
+	const owned2 = "22222222-2222-4222-8222-222222222222";
+	const foreign = "33333333-3333-4333-8333-333333333333";
+	const gone = "44444444-4444-4444-8444-444444444444";
+	const rows = [
+		{ id: owned1, name: "benchmark-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", state: "started" },
+		{ id: foreign, name: "dev-box", state: "started" },
+		{ id: gone, name: "benchmark-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", state: "destroyed" },
+		{ id: owned2, name: "benchmark-cccccccc-cccc-4ccc-8ccc-cccccccccccc", state: "stopped" },
+	];
+	const deleted: string[] = [];
+	const client = {
+		list: async function* () {
+			yield* rows;
+		},
+		get: async (id: string) => {
+			const row = rows.find((entry) => entry.id === id);
+			if (!row || row.state === "destroyed") throw new DaytonaNotFoundError("no such sandbox", 404);
+			return row;
+		},
+		delete: async (sandbox: { id: string }) => {
+			deleted.push(sandbox.id);
+		},
+	} as unknown as Daytona;
+	const spec = daytonaSpec(
+		{
+			env: { DAYTONA_API_KEY: "test-key", DAYTONA_TARGET: "us-west-2" },
+			artifact: { kind: "baked" },
+			resolvedArtifact: { kind: "baked", ref: "test-snapshot" },
+		},
+		() => client,
+	);
+
+	test("claims every benchmark-named sandbox, skips the dying, and counts the rest as foreign", async () => {
+		expect(await spec.inventory?.list(spec.compute, {})).toEqual({
+			owned: [owned1, owned2],
+			foreignCount: 1,
+		});
+	});
+
+	test("destroys by id through a fresh lookup and converges on Daytona's own absence", async () => {
+		await spec.destroyById?.(spec.compute, { provider: "daytona-vm", id: owned1 }, {});
+		await spec.destroyById?.(spec.compute, { provider: "daytona-vm", id: gone }, {});
+		expect(deleted).toEqual([owned1]);
+	});
 });

--- a/packages/drivers/src/_daytona.ts
+++ b/packages/drivers/src/_daytona.ts
@@ -13,6 +13,14 @@ import { DAYTONA_PROVENANCE } from "./_provenance.ts";
 type DaytonaId = "daytona-vm" | "daytona-container";
 export const DAYTONA_SANDBOX_ID = type("string.uuid");
 const createInput = type({ name: "string >= 1", snapshot: "string >= 1" });
+/**
+ * Both Daytona variants share one org and create with exactly this name shape, so each variant's
+ * inventory claims every benchmark sandbox it finds: batches on the shared account never overlap
+ * (one concurrency queue), so anything present at admission is a leftover to remove, and a sibling
+ * variant's later teardown of the same id converges on not-found.
+ */
+const DAYTONA_BENCHMARK_NAME =
+	/^benchmark-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const CONTROL_TIMEOUT_MS = 10000;
 type CommandSandbox = {
 	readonly process: Pick<Sandbox["process"], "createSession" | "executeSessionCommand">;
@@ -225,6 +233,39 @@ export function daytonaSpec<P extends DaytonaId>(
 				for await (const sandbox of client.list()) rows.push(sandbox);
 				return rows;
 			},
+		},
+		inventory: {
+			list: async (_compute, options) => {
+				const owned: string[] = [];
+				let foreignCount = 0;
+				for await (const sandbox of client.list()) {
+					options.signal?.throwIfAborted();
+					// A sandbox already on its way out is nobody's resource; everything else is either the
+					// benchmark's (by name shape) or a foreign allocation on what must be a dedicated org.
+					if (sandbox.state === "destroyed" || sandbox.state === "destroying") continue;
+					if (typeof sandbox.name === "string" && DAYTONA_BENCHMARK_NAME.test(sandbox.name))
+						owned.push(sandbox.id);
+					else foreignCount += 1;
+				}
+				return { owned, foreignCount };
+			},
+		},
+		destroyById: async (_compute, ref, options) => {
+			options.signal?.throwIfAborted();
+			let sandbox: Sandbox;
+			try {
+				sandbox = await client.get(ref.id);
+			} catch (error) {
+				if (error instanceof DaytonaNotFoundError) return;
+				throw error;
+			}
+			if (sandbox.id !== ref.id) throw new Error("Daytona returned an unrelated sandbox");
+			try {
+				await client.delete(sandbox, 30, true);
+			} catch (error) {
+				if (error instanceof DaytonaNotFoundError) return;
+				throw error;
+			}
 		},
 		snapshots: {
 			create: async (_compute, session) => {

--- a/packages/drivers/src/_modal.test.ts
+++ b/packages/drivers/src/_modal.test.ts
@@ -23,7 +23,9 @@ import {
 	modalControlPlane,
 	modalCreateOptions,
 	modalCreateRecovery,
+	modalDestroyById,
 	modalDetachedCommand,
+	modalInventory,
 	modalLifecycle,
 	modalProbes,
 	modalSandboxId,
@@ -1275,5 +1277,109 @@ describe("Modal command projection", () => {
 				),
 			).rejects.toThrow(/malformed result/);
 		}
+	});
+});
+
+describe("Modal account inventory and recovery", () => {
+	const v1Owned = "sb-rxWrDWGgOCJXeCSavkiDL6";
+	const v1Foreign = "sb-AAAAAAAAAAAAAAAAAAAAAA";
+	const v2Foreign = "sb-01ARZ3NDEKTSV4RRFFQ69G5FAW";
+	const v2Owned = "sb-01ARZ3NDEKTSV4RRFFQ69G5FAV";
+	function control(appExists: boolean) {
+		return {
+			apps: {
+				list: async () => [...(appExists ? [{ appId: "ap-bench" }] : []), { appId: "ap-foreign" }],
+				fromName: async (name: string) =>
+					appExists && name === MODAL_APP_NAME ? { appId: "ap-bench" } : undefined,
+			},
+			sandboxes: {
+				list: async function* ({ appId }: { appId?: string }) {
+					if (appId === "ap-bench") {
+						yield { sandboxId: v1Owned };
+						return;
+					}
+					if (appId !== undefined) return;
+					yield { sandboxId: v1Owned };
+					yield { sandboxId: v1Foreign };
+				},
+				experimentalList: async function* ({ appId }: { appId: string }) {
+					if (appId === "ap-bench") yield { sandboxId: v2Owned };
+					if (appId === "ap-foreign") yield { sandboxId: v2Foreign };
+				},
+				fromId: async () => {
+					throw new Error("unused");
+				},
+				fromName: async () => {
+					throw new Error("unused");
+				},
+				experimentalFromName: async () => {
+					throw new Error("unused");
+				},
+			},
+		};
+	}
+
+	it("scopes ownership to the benchmark App per generation and counts both generations outside it as foreign", async () => {
+		const runner = directRunner(control(true));
+		expect(await modalInventory("vm", runner).list({} as never, {})).toEqual({
+			owned: [v1Owned],
+			foreignCount: 2,
+		});
+		expect(await modalInventory("gvisor", runner).list({} as never, {})).toEqual({
+			owned: [v2Owned],
+			foreignCount: 2,
+		});
+		// No App yet: nothing can be owned, and every v1 sandbox in the environment is foreign.
+		const fresh = directRunner(control(false));
+		expect(await modalInventory("vm", fresh).list({} as never, {})).toEqual({
+			owned: [],
+			foreignCount: 3,
+		});
+		expect(await modalInventory("gvisor", fresh).list({} as never, {})).toEqual({
+			owned: [],
+			foreignCount: 3,
+		});
+	});
+
+	it("rejects incomplete App enumeration instead of declaring the account clean", async () => {
+		const fake = control(true);
+		fake.apps.list = async () => {
+			throw new Error("App listing unavailable");
+		};
+		await expect(
+			modalInventory("gvisor", directRunner(fake)).list({} as never, {}),
+		).rejects.toThrow("App listing unavailable");
+	});
+
+	it("destroys by id with a waited terminate and converges only on sandbox not-found", async () => {
+		const terminated: string[] = [];
+		const detached: string[] = [];
+		let failure: unknown;
+		const runner = directRunner({
+			sandboxes: {
+				fromId: async (id: string) => ({
+					terminate: async ({ wait }: { wait: true }) => {
+						if (failure !== undefined) throw failure;
+						terminated.push(`${id}:${wait}`);
+						return 0;
+					},
+					detach: () => detached.push(id),
+				}),
+			},
+		});
+		await modalDestroyById(runner)({} as never, modalRef, {});
+		expect(terminated).toEqual([`${modalRef.id}:true`]);
+		failure = new ClientError(
+			"/modal.client.ModalClient/SandboxTerminate",
+			Status.NOT_FOUND,
+			"gone",
+		);
+		await modalDestroyById(runner)({} as never, modalRef, {});
+		failure = new ClientError("/modal.client.ModalClient/AppGetByName", Status.NOT_FOUND, "gone");
+		await expect(modalDestroyById(runner)({} as never, modalRef, {})).rejects.toThrow(/gone/);
+		failure = new Error("control plane unavailable");
+		await expect(modalDestroyById(runner)({} as never, modalRef, {})).rejects.toThrow(
+			/control plane unavailable/,
+		);
 	});
 });

--- a/packages/drivers/src/_modal.ts
+++ b/packages/drivers/src/_modal.ts
@@ -14,7 +14,7 @@ import type {
 } from "@sandbox-benchmarks/driver";
 import { shellQuote } from "@sandbox-benchmarks/driver";
 import { type } from "arktype";
-import { ModalClient, Sandbox } from "modal";
+import { ModalClient, NotFoundError, Sandbox } from "modal";
 import type { ClientMiddleware } from "nice-grpc";
 import { ClientError, Status } from "nice-grpc";
 import type {
@@ -50,11 +50,26 @@ interface ModalControlSandbox {
 	detach(): void;
 }
 
+interface ModalControlApp {
+	readonly appId: string;
+}
+
 interface ModalControlPlane {
+	readonly apps: {
+		/** The named App, or undefined when this workspace has never created it. */
+		fromName(name: string): Promise<ModalControlApp | undefined>;
+		list(): Promise<Awaited<ReturnType<ModalClient["cpClient"]["appList"]>>["apps"]>;
+	};
 	readonly sandboxes: {
 		fromId(id: string): Promise<ModalControlSandbox>;
 		fromName(appName: string, name: string): Promise<ModalControlSandbox>;
 		experimentalFromName(appName: string, name: string): Promise<ModalControlSandbox>;
+		/** Every v1 sandbox in the environment, or only those under `appId`. */
+		list(params: { readonly appId?: string }): AsyncIterable<{ readonly sandboxId: string }>;
+		/** Every v2 sandbox under one App; the SDK cannot enumerate v2 environment-wide. */
+		experimentalList(params: {
+			readonly appId: string;
+		}): AsyncIterable<{ readonly sandboxId: string }>;
 	};
 }
 
@@ -79,6 +94,8 @@ export const MODAL_COST_SDK_PROVENANCE =
 	MODAL_NATIVE_PROVENANCE satisfies ProviderCostEvidenceCapability["sdk"];
 export const MODAL_SANDBOX_LIFETIME_MS = 3 * 60 * 60_000;
 export const MODAL_CONTROL_TIMEOUT_MS = 5_000;
+/** Enumerating an account is a multi-page loop, not one bounded RPC; it gets its own budget. */
+export const MODAL_INVENTORY_TIMEOUT_MS = 60_000;
 export const MODAL_RECOVERY_CONFIRMATION_MS = 2_000;
 export const MODAL_RECOVERY_MAX_ATTEMPTS = 4;
 export const MODAL_READINESS = Object.freeze({ startup: "create-returns-ready" as const });
@@ -143,8 +160,23 @@ export function isModalRetryableCreate(error: unknown): boolean {
  */
 export function modalControlPlane(client: ModalClient): ModalControlPlane {
 	return {
+		apps: {
+			list: async () =>
+				(await client.cpClient.appList({ environmentName: client.environmentName() })).apps,
+			fromName: async (name) => {
+				try {
+					return await client.apps.fromName(name, { createIfMissing: false });
+				} catch (caught) {
+					// Only the SDK's typed absence means "no such App"; an inventory must not create one.
+					if (caught instanceof NotFoundError) return undefined;
+					throw caught;
+				}
+			},
+		},
 		sandboxes: {
 			fromId: (id) => client.sandboxes.fromId(id),
+			list: (params) => client.sandboxes.list(params),
+			experimentalList: (params) => client.sandboxes.experimentalList(params),
 			fromName: async (appName, name) => {
 				const response = await client.cpClient.sandboxGetFromName({
 					appName,
@@ -528,6 +560,68 @@ export function modalProbes(
 	};
 }
 
+/** Enumerate both generations across every App; the benchmark App owns both variants. */
+export function modalInventory(
+	variant: ModalVariant,
+	runner: ModalControlRunner,
+	appName = MODAL_APP_NAME,
+): NonNullable<ComputeSdkDriverSpec<ModalCompute>["inventory"]> {
+	return {
+		list: (_compute, options) =>
+			runner.run(options, async (control) => {
+				const collect = async (rows: AsyncIterable<{ readonly sandboxId: string }>) => {
+					const ids = new Set<string>();
+					for await (const row of rows) ids.add(MODAL_CONTROL_SANDBOX_ID.assert(row.sandboxId));
+					return ids;
+				};
+				const app = await control.apps.fromName(appName);
+				const appV1 =
+					app === undefined
+						? new Set<string>()
+						: await collect(control.sandboxes.list({ appId: app.appId }));
+				const owned =
+					variant === "gvisor"
+						? app === undefined
+							? new Set<string>()
+							: await collect(control.sandboxes.experimentalList({ appId: app.appId }))
+						: appV1;
+				let foreignCount = 0;
+				for (const id of await collect(control.sandboxes.list({}))) {
+					if (!appV1.has(id)) foreignCount += 1;
+				}
+				for (const other of await control.apps.list()) {
+					if (other.appId === app?.appId) continue;
+					foreignCount += (
+						await collect(control.sandboxes.experimentalList({ appId: other.appId }))
+					).size;
+				}
+				return { owned: [...owned], foreignCount };
+			}),
+	};
+}
+
+/** Canonical-id teardown for account recovery; only a sandbox-RPC not-found is convergence. */
+export function modalDestroyById(
+	runner: ModalControlRunner,
+): NonNullable<ComputeSdkDriverSpec<ModalCompute>["destroyById"]> {
+	return async (_compute, ref, options) => {
+		let attached: ModalControlSandbox | undefined;
+		try {
+			await runner.run(
+				options,
+				async (control) => {
+					attached = await control.sandboxes.fromId(ref.id);
+					await attached.terminate({ wait: true });
+				},
+				() => attached?.detach(),
+			);
+		} catch (caught) {
+			if (isModalNotFound(caught)) return;
+			throw caught;
+		}
+	};
+}
+
 /** Preserve the native process result and join output streams before releasing the command. */
 export async function execModalCommand(
 	runner: ModalControlRunner,
@@ -651,15 +745,16 @@ function modalSpec<P extends ModalProviderId>(
 	{ env, resolvedArtifact }: DriverContext<P>,
 ) {
 	const variant = modalVariant(provider);
-	const runner = createModalControlRunner((middleware) =>
+	const control = (middleware: ClientMiddleware) =>
 		modalControlPlane(
 			new ModalClient({
 				tokenId: env.MODAL_TOKEN_ID,
 				tokenSecret: env.MODAL_TOKEN_SECRET,
 				grpcMiddleware: [middleware],
 			}),
-		),
-	);
+		);
+	const runner = createModalControlRunner(control);
+	const inventoryRunner = createModalControlRunner(control, MODAL_INVENTORY_TIMEOUT_MS);
 	return computeSdkSpec(
 		nativeModalCompute(variant, {
 			tokenId: env.MODAL_TOKEN_ID,
@@ -681,6 +776,8 @@ function modalSpec<P extends ModalProviderId>(
 			// Both variants use the kit's direct-exec filesystem fallback.
 			hasWorkingFilesystem: false,
 			probes: modalProbes(runner),
+			inventory: modalInventory(variant, inventoryRunner),
+			destroyById: modalDestroyById(runner),
 		},
 	);
 }

--- a/packages/drivers/src/e2b.test.ts
+++ b/packages/drivers/src/e2b.test.ts
@@ -7,6 +7,7 @@ import {
 	InvalidArgumentError,
 	RateLimitError,
 	Sandbox,
+	SandboxNotFoundError,
 	TimeoutError,
 } from "e2b";
 import type { ComputeSdkSandboxOf } from "./_computesdk.ts";
@@ -14,6 +15,7 @@ import e2bDriver, {
 	E2B_ATTEMPT_METADATA_KEY,
 	E2B_CONTROL_PLANE_TIMEOUT_MS,
 	E2B_EXECUTION,
+	E2B_INVENTORY_STATES,
 	E2B_PROVENANCE,
 	E2B_READINESS,
 	E2B_RECOVERY_MAX_ATTEMPTS,
@@ -675,6 +677,75 @@ describe("E2B proof driver", () => {
 		} finally {
 			create.mockRestore();
 			list.mockRestore();
+		}
+	});
+});
+
+describe("E2B account inventory and recovery", () => {
+	test("drains every live page, owns by the attempt marker, and counts the rest as foreign", async () => {
+		const list = spyOn(Sandbox, "list").mockImplementation(() =>
+			fakeSandboxPaginator([
+				[
+					{ sandboxId: "iowned1", metadata: { [E2B_ATTEMPT_METADATA_KEY]: "benchmark-a" } },
+					{ sandboxId: "iforeign1", metadata: {} },
+					{ sandboxId: "iforeign2", metadata: { [E2B_ATTEMPT_METADATA_KEY]: "someone-else" } },
+				],
+				[{ sandboxId: "iowned2", metadata: { [E2B_ATTEMPT_METADATA_KEY]: "benchmark-b" } }],
+			]),
+		);
+		try {
+			const driver = e2bDriver.driver(context);
+			expect(await driver.inventory?.list()).toEqual({
+				owned: [sandboxRef("e2b", "iowned1"), sandboxRef("e2b", "iowned2")],
+				foreignCount: 2,
+			});
+			expect(list).toHaveBeenCalledTimes(1);
+			expect(list.mock.calls[0]?.[0]).toMatchObject({
+				apiKey: context.env.E2B_API_KEY,
+				requestTimeoutMs: E2B_CONTROL_PLANE_TIMEOUT_MS,
+				query: { state: [...E2B_INVENTORY_STATES] },
+			});
+		} finally {
+			list.mockRestore();
+		}
+	});
+
+	test("refuses a partial or malformed listing instead of reporting an empty account", async () => {
+		const truncated = fakeSandboxPaginator([[]]);
+		Object.defineProperty(truncated, "hasNext", { get: () => true });
+		Object.defineProperty(truncated, "nextToken", { get: () => undefined });
+		const malformed = fakeSandboxPaginator([[{ metadata: {} }]]);
+		for (const paginator of [truncated, malformed]) {
+			const list = spyOn(Sandbox, "list").mockImplementation(() => paginator);
+			try {
+				await expect(e2bDriver.driver(context).inventory?.list()).rejects.toMatchObject({
+					code: "probe-failed",
+					provider: "e2b",
+				});
+			} finally {
+				list.mockRestore();
+			}
+		}
+	});
+
+	test("destroys by canonical id and converges only on E2B's own absence", async () => {
+		const kill = spyOn(Sandbox, "kill").mockResolvedValue(false);
+		try {
+			const driver = e2bDriver.driver(context);
+			await driver.destroyById?.(sandboxRef("e2b", "ileftover"));
+			expect(kill).toHaveBeenCalledWith(
+				"ileftover",
+				expect.objectContaining({ apiKey: context.env.E2B_API_KEY }),
+			);
+			kill.mockRejectedValueOnce(new SandboxNotFoundError("gone"));
+			await driver.destroyById?.(sandboxRef("e2b", "ileftover"));
+			kill.mockRejectedValueOnce(new Error("control plane unavailable"));
+			await expect(driver.destroyById?.(sandboxRef("e2b", "ileftover"))).rejects.toMatchObject({
+				code: "destroy-failed",
+				provider: "e2b",
+			});
+		} finally {
+			kill.mockRestore();
 		}
 	});
 });

--- a/packages/drivers/src/e2b.ts
+++ b/packages/drivers/src/e2b.ts
@@ -45,6 +45,10 @@ export const E2B_CONTROL_PLANE_TIMEOUT_MS = 5_000;
 export const E2B_RECOVERY_CONFIRMATION_MS = 2_000;
 export const E2B_RECOVERY_MAX_ATTEMPTS = 4;
 export const E2B_ATTEMPT_METADATA_KEY = "sandbox-benchmarks-attempt";
+/** Every benchmark create writes `${E2B_ATTEMPT_METADATA_KEY}: benchmark-<uuid>`; inventory keys on it. */
+export const E2B_BENCHMARK_MARKER_PREFIX = "benchmark-";
+/** Live states an account sweep must see: a paused sandbox is still an allocation the account owns. */
+export const E2B_INVENTORY_STATES = ["running", "paused"] as const;
 export const E2B_READINESS = Object.freeze({ startup: "create-returns-ready" as const });
 export const E2B_EXECUTION = Object.freeze({
 	syncCapMs: 60_000,
@@ -221,6 +225,162 @@ function recoverySandboxIds(value: unknown, marker: string): readonly string[] {
 	return sandboxIds;
 }
 
+/**
+ * Drain one E2B paginator through the same defensive reads on every lane, so a malformed page or a
+ * repeated continuation token fails closed instead of manufacturing absence — for recovery that
+ * would leak an accepted create, for inventory it would authorize skipping a leftover.
+ */
+async function drainE2bPaginator(
+	lane: "recovery" | "inventory",
+	paginator: unknown,
+	controlOptions: Readonly<Record<string, unknown>>,
+	consume: (page: unknown) => void,
+): Promise<void> {
+	if ((typeof paginator !== "object" && typeof paginator !== "function") || paginator === null) {
+		throw new Error(`E2B ${lane} list returned no paginator`);
+	}
+	let nextItems: unknown;
+	try {
+		nextItems = Reflect.get(paginator, "nextItems");
+	} catch {
+		throw new Error(`E2B ${lane} paginator method is unreadable`);
+	}
+	if (typeof nextItems !== "function") {
+		throw new Error(`E2B ${lane} paginator method is not callable`);
+	}
+	const seenTokens = new Set<string>();
+	for (let page = 0; page < E2B_RECOVERY_MAX_PAGES; page += 1) {
+		// BasePaginator starts with a mandatory first page. Fetching it unconditionally makes a
+		// malformed initial hasNext=false fail closed instead of manufacturing absence.
+		consume(await Reflect.apply(nextItems, paginator, [controlOptions]));
+		let hasNext: unknown;
+		try {
+			hasNext = Reflect.get(paginator, "hasNext");
+		} catch {
+			throw new Error(`E2B ${lane} paginator state is unreadable`);
+		}
+		if (typeof hasNext !== "boolean") {
+			throw new Error(`E2B ${lane} paginator state is not boolean`);
+		}
+		let nextToken: unknown;
+		try {
+			nextToken = Reflect.get(paginator, "nextToken");
+		} catch {
+			throw new Error(`E2B ${lane} paginator token is unreadable`);
+		}
+		if (!hasNext) {
+			if (nextToken !== undefined) {
+				throw new Error(`E2B ${lane} paginator retained a terminal continuation token`);
+			}
+			return;
+		}
+		if (typeof nextToken !== "string" || nextToken.length === 0) {
+			throw new Error(`E2B ${lane} paginator has no continuation token`);
+		}
+		if (seenTokens.has(nextToken)) {
+			throw new Error(`E2B ${lane} paginator repeated a continuation token`);
+		}
+		seenTokens.add(nextToken);
+	}
+	throw new Error(`E2B ${lane} paginator exceeded its page limit`);
+}
+
+/** Classify one inventory page: a row carrying the benchmark marker is owned, any other is foreign. */
+function inventoryRows(
+	value: unknown,
+): readonly { readonly sandboxId: string; readonly owned: boolean }[] {
+	let length: unknown;
+	try {
+		if (!Array.isArray(value)) throw new Error("non-array result");
+		length = Reflect.get(value, "length");
+	} catch {
+		throw new Error("E2B inventory list returned a non-array result");
+	}
+	if (typeof length !== "number" || !Number.isSafeInteger(length) || length < 0) {
+		throw new Error("E2B inventory list returned an invalid array length");
+	}
+	const rows: { readonly sandboxId: string; readonly owned: boolean }[] = [];
+	for (let index = 0; index < length; index += 1) {
+		let sandboxId: unknown;
+		let marker: unknown;
+		try {
+			const row: unknown = Reflect.get(value, index);
+			if ((typeof row !== "object" && typeof row !== "function") || row === null) {
+				throw new Error("non-object row");
+			}
+			sandboxId = Reflect.get(row, "sandboxId");
+			const metadata: unknown = Reflect.get(row, "metadata");
+			marker =
+				(typeof metadata === "object" || typeof metadata === "function") && metadata !== null
+					? Reflect.get(metadata, E2B_ATTEMPT_METADATA_KEY)
+					: undefined;
+		} catch {
+			throw new Error(`E2B inventory list row ${index} is unreadable`);
+		}
+		if (typeof sandboxId !== "string" || sandboxId.length === 0) {
+			throw new Error(`E2B inventory list row ${index} has no sandbox id`);
+		}
+		rows.push({
+			sandboxId,
+			owned: typeof marker === "string" && marker.startsWith(E2B_BENCHMARK_MARKER_PREFIX),
+		});
+	}
+	return rows;
+}
+
+/** Whole-account inventory: every live sandbox, owned iff it carries the benchmark attempt marker. */
+export function e2bInventory(
+	apiKey: string,
+): NonNullable<ComputeSdkDriverSpec<E2bCompute>["inventory"]> {
+	return {
+		list: async (_compute, options) => {
+			const controlOptions = {
+				apiKey,
+				requestTimeoutMs: E2B_CONTROL_PLANE_TIMEOUT_MS,
+				...(options.signal === undefined ? {} : { signal: options.signal }),
+			};
+			const owned: string[] = [];
+			let foreignCount = 0;
+			await drainE2bPaginator(
+				"inventory",
+				Sandbox.list({ ...controlOptions, query: { state: [...E2B_INVENTORY_STATES] } }),
+				controlOptions,
+				(page) => {
+					for (const row of inventoryRows(page)) {
+						if (row.owned) owned.push(row.sandboxId);
+						else foreignCount += 1;
+					}
+				},
+			);
+			return { owned, foreignCount };
+		},
+	};
+}
+
+/** Canonical-id teardown for account recovery: a sandbox E2B no longer knows is convergence. */
+export function e2bDestroyById(
+	apiKey: string,
+): NonNullable<ComputeSdkDriverSpec<E2bCompute>["destroyById"]> {
+	return async (_compute, ref, options) => {
+		try {
+			// `kill` resolves false for an unknown sandbox, which is convergence, not a failure.
+			await Sandbox.kill(ref.id, {
+				apiKey,
+				requestTimeoutMs: E2B_CONTROL_PLANE_TIMEOUT_MS,
+				...(options.signal === undefined ? {} : { signal: options.signal }),
+			});
+		} catch (caught) {
+			let notFound = false;
+			try {
+				notFound = caught instanceof SandboxNotFoundError;
+			} catch {
+				// A hostile rejection is not convergence; it surfaces below unchanged.
+			}
+			if (!notFound) throw caught;
+		}
+	};
+}
+
 export function e2bLifecycle(apiKey: string): ComputeSdkLifecycle<E2bCompute> {
 	return {
 		destroy: async (sandbox, ref, options) => {
@@ -278,66 +438,18 @@ export function e2bCreateRecovery(apiKey: string): ComputeSdkCreateRecovery<E2bC
 				requestTimeoutMs: E2B_CONTROL_PLANE_TIMEOUT_MS,
 				...(options.signal === undefined ? {} : { signal: options.signal }),
 			};
-			const paginator: unknown = Sandbox.list({
-				...controlOptions,
-				query: { metadata: { [E2B_ATTEMPT_METADATA_KEY]: marker } },
-			});
-			if (
-				(typeof paginator !== "object" && typeof paginator !== "function") ||
-				paginator === null
-			) {
-				throw new Error("E2B recovery list returned no paginator");
-			}
-			let nextItems: unknown;
-			try {
-				nextItems = Reflect.get(paginator, "nextItems");
-			} catch {
-				throw new Error("E2B recovery paginator method is unreadable");
-			}
-			if (typeof nextItems !== "function") {
-				throw new Error("E2B recovery paginator method is not callable");
-			}
 			const sandboxIds = new Set<string>();
-			const seenTokens = new Set<string>();
-			let paginationComplete = false;
-			for (let page = 0; page < E2B_RECOVERY_MAX_PAGES; page += 1) {
-				// BasePaginator starts with a mandatory first page. Fetching it unconditionally makes a
-				// malformed initial hasNext=false fail closed instead of manufacturing absence.
-				const response: unknown = await Reflect.apply(nextItems, paginator, [controlOptions]);
-				for (const sandboxId of recoverySandboxIds(response, marker)) {
-					sandboxIds.add(sandboxId);
-				}
-				let hasNext: unknown;
-				try {
-					hasNext = Reflect.get(paginator, "hasNext");
-				} catch {
-					throw new Error("E2B recovery paginator state is unreadable");
-				}
-				if (typeof hasNext !== "boolean") {
-					throw new Error("E2B recovery paginator state is not boolean");
-				}
-				let nextToken: unknown;
-				try {
-					nextToken = Reflect.get(paginator, "nextToken");
-				} catch {
-					throw new Error("E2B recovery paginator token is unreadable");
-				}
-				if (!hasNext) {
-					if (nextToken !== undefined) {
-						throw new Error("E2B recovery paginator retained a terminal continuation token");
-					}
-					paginationComplete = true;
-					break;
-				}
-				if (typeof nextToken !== "string" || nextToken.length === 0) {
-					throw new Error("E2B recovery paginator has no continuation token");
-				}
-				if (seenTokens.has(nextToken)) {
-					throw new Error("E2B recovery paginator repeated a continuation token");
-				}
-				seenTokens.add(nextToken);
-			}
-			if (!paginationComplete) throw new Error("E2B recovery paginator exceeded its page limit");
+			await drainE2bPaginator(
+				"recovery",
+				Sandbox.list({
+					...controlOptions,
+					query: { metadata: { [E2B_ATTEMPT_METADATA_KEY]: marker } },
+				}),
+				controlOptions,
+				(page) => {
+					for (const sandboxId of recoverySandboxIds(page, marker)) sandboxIds.add(sandboxId);
+				},
+			);
 			if (sandboxIds.size === 0) return { status: "absent" };
 			let destroyed = false;
 			for (const sandboxId of sandboxIds) {
@@ -436,6 +548,8 @@ export function e2bSpec({ env, resolvedArtifact }: DriverContext<"e2b">) {
 			verifyE2bDiskCapacity(native, request, options),
 		hasWorkingFilesystem: true,
 		probes: e2bProbes(apiKey),
+		inventory: e2bInventory(apiKey),
+		destroyById: e2bDestroyById(apiKey),
 	});
 }
 

--- a/packages/drivers/src/novita.test.ts
+++ b/packages/drivers/src/novita.test.ts
@@ -90,3 +90,74 @@ describe("Novita native integration", () => {
 		}
 	});
 });
+
+describe("Novita account inventory and recovery", () => {
+	function fakePaginator(pages: readonly unknown[]) {
+		let index = 0;
+		return {
+			get hasNext() {
+				return index < pages.length;
+			},
+			get nextToken() {
+				return index < pages.length ? `page-${index + 1}` : undefined;
+			},
+			nextItems: async () => {
+				const page = pages[index];
+				index += 1;
+				return page;
+			},
+		} as unknown as ReturnType<typeof Sandbox.list>;
+	}
+
+	test("drains every live page, owns by the attempt marker, and counts the rest as foreign", async () => {
+		const list = spyOn(Sandbox, "list").mockReturnValueOnce(
+			fakePaginator([
+				[
+					{ sandboxId: "owned-1", metadata: { "sandbox-benchmarks-attempt": "benchmark-a" } },
+					{ sandboxId: "foreign-1", metadata: {} },
+					{ sandboxId: "foreign-2" },
+				],
+				[{ sandboxId: "owned-2", metadata: { "sandbox-benchmarks-attempt": "benchmark-b" } }],
+			]),
+		);
+		try {
+			expect(await novita.driver(context).inventory?.list()).toEqual({
+				owned: [
+					{ provider: "novita", id: "owned-1" },
+					{ provider: "novita", id: "owned-2" },
+				],
+				foreignCount: 2,
+			});
+			expect(list.mock.calls[0]?.[0]).toMatchObject({
+				apiKey: "nvta_test",
+				domain: NOVITA_DOMAIN,
+				query: { state: ["running", "paused"] },
+			});
+		} finally {
+			list.mockRestore();
+		}
+	});
+
+	test("destroys by canonical id and converges only on Novita's own absence", async () => {
+		const { SandboxNotFoundError } = createRequire(import.meta.url)(
+			"novita-sandbox",
+		) as typeof import("novita-sandbox");
+		const kill = spyOn(Sandbox, "kill").mockResolvedValueOnce(true);
+		try {
+			const driver = novita.driver(context);
+			await driver.destroyById?.({ provider: "novita", id: "leftover" });
+			expect(kill).toHaveBeenCalledWith(
+				"leftover",
+				expect.objectContaining({ apiKey: "nvta_test" }),
+			);
+			kill.mockRejectedValueOnce(new SandboxNotFoundError("gone"));
+			await driver.destroyById?.({ provider: "novita", id: "leftover" });
+			kill.mockRejectedValueOnce(new Error("control plane unavailable"));
+			await expect(
+				driver.destroyById?.({ provider: "novita", id: "leftover" }),
+			).rejects.toMatchObject({ code: "destroy-failed", provider: "novita" });
+		} finally {
+			kill.mockRestore();
+		}
+	});
+});

--- a/packages/drivers/src/novita.ts
+++ b/packages/drivers/src/novita.ts
@@ -26,6 +26,35 @@ const recoveryRows = type({
 	sandboxId: NOVITA_SANDBOX_ID,
 	metadata: { "[string]": "string" },
 }).array();
+/** Every benchmark create writes `${ATTEMPT_KEY}: benchmark-<uuid>`; the account sweep keys on it. */
+const MARKER_PREFIX = "benchmark-";
+/** A paused sandbox is still an allocation the account owns, so the sweep lists both live states. */
+const INVENTORY_STATES = ["running", "paused"] as const;
+const inventoryRows = type({
+	sandboxId: "string >= 1",
+	"metadata?": { "[string]": "string" },
+}).array();
+
+/** Drain one Novita paginator; a repeated or missing continuation token fails closed. */
+async function drainNovitaList(
+	lane: "recovery" | "inventory",
+	listOptions: Parameters<typeof Sandbox.list>[0],
+	options: { readonly signal?: AbortSignal },
+	consume: (rows: unknown) => void,
+): Promise<void> {
+	const paginator = Sandbox.list(listOptions);
+	const tokens = new Set<string>();
+	for (let page = 0; ; page++) {
+		options.signal?.throwIfAborted();
+		if (page >= 100) throw new Error(`Novita ${lane} exceeded its page limit`);
+		consume(await paginator.nextItems());
+		if (!paginator.hasNext) return;
+		const token = paginator.nextToken;
+		if (!token || tokens.has(token))
+			throw new Error(`Novita ${lane} repeated or omitted a continuation token`);
+		tokens.add(token);
+	}
+}
 const commandFailure = type({
 	name: "'CommandExitError'",
 	exitCode: "number.integer",
@@ -137,26 +166,19 @@ export function novitaSpec({ env, resolvedArtifact }: DriverContext<"novita">) {
 			isRetryableCreate: (error) =>
 				matchesAnyCause(error, (cause) => cause instanceof RateLimitError),
 			cleanup: async (_compute, locator, options) => {
-				const paginator = Sandbox.list({
-					...connection,
-					query: { metadata: { [ATTEMPT_KEY]: locator.value } },
-				});
 				const ids = new Set<string>();
-				const tokens = new Set<string>();
-				for (let page = 0; ; page++) {
-					options.signal?.throwIfAborted();
-					if (page >= 100) throw new Error("Novita recovery exceeded its page limit");
-					for (const row of recoveryRows.assert(await paginator.nextItems())) {
-						if (row.metadata[ATTEMPT_KEY] !== locator.value)
-							throw new Error("Novita recovery returned an unrelated sandbox");
-						ids.add(row.sandboxId);
-					}
-					if (!paginator.hasNext) break;
-					const token = paginator.nextToken;
-					if (!token || tokens.has(token))
-						throw new Error("Novita recovery repeated or omitted a continuation token");
-					tokens.add(token);
-				}
+				await drainNovitaList(
+					"recovery",
+					{ ...connection, query: { metadata: { [ATTEMPT_KEY]: locator.value } } },
+					options,
+					(rows) => {
+						for (const row of recoveryRows.assert(rows)) {
+							if (row.metadata[ATTEMPT_KEY] !== locator.value)
+								throw new Error("Novita recovery returned an unrelated sandbox");
+							ids.add(row.sandboxId);
+						}
+					},
+				);
 				let destroyed = false;
 				for (const id of ids) {
 					options.signal?.throwIfAborted();
@@ -196,6 +218,33 @@ export function novitaSpec({ env, resolvedArtifact }: DriverContext<"novita">) {
 			describe: (_compute, ref) => Sandbox.getInfo(ref.id, connection),
 			// Preserve the existing measurement: one list page, rather than timing full enumeration.
 			list: () => Sandbox.list(connection).nextItems(),
+		},
+		inventory: {
+			list: async (_compute, options) => {
+				const owned: string[] = [];
+				let foreignCount = 0;
+				await drainNovitaList(
+					"inventory",
+					{ ...connection, query: { state: [...INVENTORY_STATES] } },
+					options,
+					(rows) => {
+						for (const row of inventoryRows.assert(rows)) {
+							if (row.metadata?.[ATTEMPT_KEY]?.startsWith(MARKER_PREFIX)) owned.push(row.sandboxId);
+							else foreignCount += 1;
+						}
+					},
+				);
+				return { owned, foreignCount };
+			},
+		},
+		destroyById: async (_compute, ref, options) => {
+			options.signal?.throwIfAborted();
+			try {
+				await Sandbox.kill(ref.id, connection);
+			} catch (error) {
+				if (error instanceof SandboxNotFoundError) return;
+				throw error;
+			}
 		},
 	});
 }


### PR DESCRIPTION
**Driver admission — merge bottom-up:** #433 → #439 → #441 → #435 → #436 → #437 → #438 → #440 → #442.

This PR is 1/9, based on `main`.

Account admission previously rejected six migrated variants because their shared bridge could neither inventory an account nor destroy an allocation by ID. Add declarative `inventory` and `destroyById` members and wire E2B, Novita, both Daytona variants, and both Modal variants.

Owned IDs cross the canonical ID boundary once; an ArkType schema validates the inventory shape and safe foreign count. E2B/Novita drain running and paused resources using benchmark metadata. Daytona shares benchmark names across its two variants. Modal enumerates both API generations across every app, so foreign v2 allocations cannot disappear from admission.

`account-inventory.ts [provider...]` reports owned and foreign counts without allocating or deleting resources. Missing capabilities, incomplete listings, and foreign resources fail closed. Dedicated-account setup remains an operator prerequisite.

**Validation:** 2059 tests pass at this branch; frozen install, repository typecheck, Biome, and generated wiring pass independently.

**Historical live evidence (before this refactor; not rerun):**

| provider | owned | foreign |
| --- | --- | --- |
| e2b | 0 | 27 paused sandboxes from 2026-04-16..24, two templates, no metadata |
| daytona-vm / daytona-container | 0 | 32 |
| modal-gvisor / modal-vm | 0 | 1 live v1 sandbox in another App |
| novita | 0 | 7 running platform-managed sandboxes (runner_name / job_id metadata) |
| tama | 0 | 0 |
