### PR TITLE
feat(ci): release each collection round with one approval wave

### DIFF
--- a/.github/workflows/bench-round.yml
+++ b/.github/workflows/bench-round.yml
@@ -42,7 +42,12 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
-      max-parallel: 1
+      # Deliberately NO max-parallel here. Exclusion per account is the bench job's concurrency group
+      # (`benchmark-account-<domain>`, `queue: max`), so every batch of this round may be created at
+      # once: they all reach the `privileged` approval gate together and ONE approval releases the
+      # whole round, instead of one approval per batch (GitHub approves only the jobs already
+      # pending). The planner caps a round at ROUND_BATCH_LIMIT batches so the released jobs stay
+      # under the 100 that a `queue: max` group can hold before it cancels the overflow.
       matrix:
         include: ${{ fromJSON(needs.plan.outputs.axis) }}
     uses: ./.github/workflows/bench-suite.yml

--- a/apps/cli/src/lib/experiment-plan.test.ts
+++ b/apps/cli/src/lib/experiment-plan.test.ts
@@ -12,7 +12,7 @@ import {
 import type { ExperimentCell, Run } from "@sandbox-benchmarks/schema";
 import { aggregate, parseRun } from "@sandbox-benchmarks/schema";
 import { rawTreeDigest, writeImmutableJson } from "./experiment-artifacts.ts";
-import { planExperiment } from "./experiment-plan.ts";
+import { planExperiment, ROUND_BATCH_LIMIT } from "./experiment-plan.ts";
 
 const sha = "a".repeat(40);
 const digest = `sha256:${"b".repeat(64)}`;
@@ -414,7 +414,8 @@ test("real aggregate and promote commands require intact original evidence", () 
 
 test("large experiments retain every batch in explicit collection rounds", () => {
 	const result = plan(257);
-	expect(result.rounds.map((round) => round.batches.length)).toEqual([256, 1]);
+	expect(ROUND_BATCH_LIMIT).toBe(64);
+	expect(result.rounds.map((round) => round.batches.length)).toEqual([64, 64, 64, 64, 1]);
 	expect(result.rounds.flatMap((round) => round.batches)).toEqual(
 		result.batches.map((batch) => batch.id),
 	);

--- a/apps/cli/src/lib/experiment-plan.ts
+++ b/apps/cli/src/lib/experiment-plan.ts
@@ -9,6 +9,15 @@ export interface AccountCapacity {
 	gpus?: number;
 }
 
+/**
+ * Batches per collection round, and therefore the approval unit of a run: a round's batch jobs are
+ * created together so one `privileged` approval releases them all, and they then queue on the
+ * account's concurrency group. GitHub's `queue: max` holds at most 100 pending jobs per group and
+ * cancels the overflow (a cancelled batch is a failed cell), so a released round must stay well under
+ * that even when the sibling isolation variant and the smoke/toolchain/GPU lanes share the group.
+ */
+export const ROUND_BATCH_LIMIT = 64;
+
 /** Pure admission planning. No credential reads, remote calls, or implicit wall-clock input. */
 export function planExperiment(
 	request: {
@@ -71,11 +80,11 @@ export function planExperiment(
 	const rounds: ExperimentPlan["rounds"] = [];
 	for (const quotaDomain of new Set(cells.map((cell) => cell.quotaDomain))) {
 		const domainBatches = batches.filter((batch) => batch.quotaDomain === quotaDomain);
-		for (let offset = 0; offset < domainBatches.length; offset += 256)
+		for (let offset = 0; offset < domainBatches.length; offset += ROUND_BATCH_LIMIT)
 			rounds.push({
 				id: `round-${rounds.length}`,
 				quotaDomain,
-				batches: domainBatches.slice(offset, offset + 256).map((batch) => batch.id),
+				batches: domainBatches.slice(offset, offset + ROUND_BATCH_LIMIT).map((batch) => batch.id),
 			});
 	}
 	const accounts = [...new Set(cells.map((cell) => cell.quotaDomain))].map((quotaDomain) => ({

--- a/apps/cli/src/lib/workflow-experiment.test.ts
+++ b/apps/cli/src/lib/workflow-experiment.test.ts
@@ -37,6 +37,6 @@ test("large account cohorts partition into bounded collection rounds", () => {
 		{ ...env, BENCH_PROVIDERS: "tama", BENCH_SUITES: "system", BENCH_REPLICAS: "257" },
 		"2026-09-10",
 	);
-	expect(plan.rounds.map((round) => round.batches.length)).toEqual([256, 1]);
+	expect(plan.rounds.map((round) => round.batches.length)).toEqual([64, 64, 64, 64, 1]);
 	expect(plan.cells.at(-1)?.replicate).toBe(256);
 });

--- a/docs/benchmark-execution-rollout.md
+++ b/docs/benchmark-execution-rollout.md
@@ -7,7 +7,10 @@ This is an implementation status record, not a claim that the live fleet meets t
 - Schema 1 experiment plans and attempt receipts; schema 7 Run linkage with historical Run readers.
 - Pure `planExperiment`: unchanged logical replicate identities, default capacity one, CPU/RAM/GPU
   limits, phase budgets plus one 15-minute host margin, 180-minute batch ceiling, collection rounds
-  of at most 256 batches, and uniform reviewed exclusions. Retries default to zero.
+  of at most 64 batches, and uniform reviewed exclusions. Retries default to zero. A round is the
+  approval unit: its batch jobs are created together (the account concurrency queue, not
+  `max-parallel`, serialises them), so one `privileged` approval releases a whole round, and 64 keeps
+  a released round under the 100 pending jobs a `queue: max` group holds before cancelling overflow.
 - Pure coverage evaluation and deterministic whole-attempt aggregation. Missing work, bad provenance,
   conflicting attempts, unapproved retries, missing metrics and unknown cleanup block completeness.
 - File-boundary verification of normalized and raw digests; atomic, no-overwrite JSON publication.

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -176,14 +176,17 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    provider's first release. The plan's visibility guard still checks the package and warns if it is
    ever not public.
 
-> **Two approval gates per bench-matrix run.** The suite-matrix fan-out (each cell calling
-> `bench-suite.yml` with `environment: privileged`) and the `publish` job both carry the environment
-> and run sequentially. Every suite × provider cell becomes pending together the moment `plan`
-> finishes, so they surface as one batch in "Review pending deployments" and a single approval of the
-> `privileged` environment releases the whole matrix; `publish` becomes pending only after the long
-> matrix (~150 min), raising a **second** gate before the dataset is committed. A reviewer who
-> approves only the matrix and walks away leaves the run parked at `publish` until the second approval
-> lands or the protection rule times out.
+> **Approval gates per bench-matrix run: one per collection round, plus `publish`.** Every batch
+> job (each calling `bench-suite.yml` with `environment: privileged`) and the `publish` job carry the
+> environment. GitHub approves only the jobs that are pending at that moment, so the workflows are
+> shaped to make jobs pend together: a round's batch jobs are created at once (no `max-parallel`;
+> the `benchmark-account-<domain>` concurrency queue serialises them), and every account's first
+> round starts as soon as `plan` finishes, so one approval of `privileged` releases the whole first
+> wave. An account with more batches than one round holds (64, see `ROUND_BATCH_LIMIT`) raises a
+> further gate when its next round starts; `publish` becomes pending only after the last account
+> finishes, raising the final gate before the dataset is committed. A reviewer who approves only the
+> first wave and walks away leaves the run parked at the next gate until an approval lands or the
+> protection rule times out.
 
 ## Operator setup (before flipping the repo public)
 

--- a/tooling/repo-checks/src/lib/workflow-nesting.ts
+++ b/tooling/repo-checks/src/lib/workflow-nesting.ts
@@ -124,10 +124,21 @@ export function checkExperimentNesting(docs: Record<string, unknown>): string[] 
 		if (!file || !callee || !axis) continue;
 		const caller = job(file, "execute");
 		const strategy = asRecord(caller.strategy, file);
-		expect(
-			strategy["max-parallel"] === 1 && strategy["fail-fast"] === false,
-			`${file}: account work must be sequential without cancelling peers`,
-		);
+		// Rounds run one at a time so a later round's approval gate is raised only once the previous
+		// round has finished; a round's batches are created together — no max-parallel, the account
+		// concurrency queue serialises them — so ONE `privileged` approval releases the whole round
+		// (GitHub approves only the jobs already pending). Neither level may cancel its peers.
+		if (axis === "round") {
+			expect(
+				strategy["max-parallel"] === 1 && strategy["fail-fast"] === false,
+				`${file}: rounds must run one at a time without cancelling peers`,
+			);
+		} else {
+			expect(
+				strategy["max-parallel"] === undefined && strategy["fail-fast"] === false,
+				`${file}: a round's batches must be created together (no max-parallel) without cancelling peers`,
+			);
+		}
 		expect(caller.uses === `./.github/workflows/${callee}`, `${file}: wrong execution delegate`);
 		expect(
 			asRecord(strategy.matrix, file)[axis] === "${{ fromJSON(needs.plan.outputs.axis) }}",

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -258,7 +258,7 @@ test("production workflows preserve planned account batching and strict promotio
 	expect(runCheck()).toEqual([]);
 });
 
-test("the integrated workflow gate rejects parallel batches, detached plan axes and legacy promotion", async () => {
+test("the integrated workflow gate rejects parallel rounds, serialised batches, detached plan axes and legacy promotion", async () => {
 	const { checkExperimentNesting } = await import("./lib/workflow-nesting.ts");
 	const docs = Object.fromEntries(
 		[
@@ -272,7 +272,13 @@ test("the integrated workflow gate rejects parallel batches, detached plan axes 
 	);
 	const source = JSON.stringify(docs);
 	for (const [before, after] of [
+		// Rounds serialised (bench-account.yml is the only remaining max-parallel: 1).
 		['"max-parallel":1', '"max-parallel":2'],
+		// A round's batches created together: reintroducing max-parallel there is one approval per batch.
+		[
+			'"fail-fast":false,"matrix":{"include":',
+			'"fail-fast":false,"max-parallel":1,"matrix":{"include":',
+		],
 		["fromJSON(needs.plan.outputs.accounts)", "fromJSON(needs.plan.outputs.suites)"],
 		["data/dataset experiment/manifest/plan.json experiment/attempts", "data/dataset"],
 		["workflow-experiment.ts execute", "bench-suite.ts"],


### PR DESCRIPTION
Independent approval-wave PR, based on `main`.

A round previously created only one batch job at a time, requiring repeated privileged approvals. Create the round's batch jobs together while retaining per-account concurrency and serial rounds. Cap each planned round at 64 batches to leave queue headroom.

Update planner tests, workflow-shape checks, and operator documentation together. The checks reject both accidental batch serialization and concurrent rounds. This PR is based directly on `main` and can land independently of the driver migration stack; it does not provision accounts or relax admission.

**Validation:** 2047 tests pass at this branch; frozen install, repository typecheck, Biome, and generated wiring pass independently. Workflow lint and spelling also pass.
