### PR TITLE
fix(admission): accept observed terminal resources as removed

### DIFF
--- a/apps/cli/src/bin/driver-check.test.ts
+++ b/apps/cli/src/bin/driver-check.test.ts
@@ -15,7 +15,14 @@ async function runCli(...args: string[]) {
 	const env = Object.fromEntries(
 		Object.entries(process.env).filter(([name]) => !name.startsWith("E2B_")),
 	);
-	const proc = Bun.spawn(["bun", CLI, ...args], { env, stdout: "pipe", stderr: "pipe" });
+	// `--env-file=/dev/null`: Bun otherwise loads the repo-root `.env` into the child regardless of
+	// the filtered `env` above, and a developer's real E2B_API_KEY turned this credentials-skip test
+	// into a live create + teardown on every local `bun run test`.
+	const proc = Bun.spawn(["bun", "--env-file=/dev/null", CLI, ...args], {
+		env,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
 	const [stdout, stderr, exitCode] = await Promise.all([
 		new Response(proc.stdout).text(),
 		new Response(proc.stderr).text(),

--- a/apps/cli/src/lib/account-reconciliation.test.ts
+++ b/apps/cli/src/lib/account-reconciliation.test.ts
@@ -42,14 +42,30 @@ test("unavailable inventory, foreign resources and uncertain destroy block admis
 			reconcileAccount([{ id: "tama", driver: candidate }], { timeoutMs: 100 }),
 		).rejects.toThrow();
 });
-test("a successful delete response cannot replace observed absence", async () => {
+test("a successful delete response cannot replace the control plane's observation", async () => {
 	const candidate = driver({
 		destroyById: async () => {},
-		probes: { observe: async () => ({ state: "terminal" }) },
+		probes: { observe: async () => ({ state: "running" }) },
 	});
 	await expect(
 		reconcileAccount([{ id: "tama", driver: candidate }], { timeoutMs: 15, pollMs: 1 }),
 	).rejects.toThrow("deadline exceeded");
+});
+test("a terminal observation confirms removal where the vendor retains terminated records", async () => {
+	// Modal and run.cloud keep a terminated sandbox observable forever; it holds no allocation.
+	let present = true;
+	const candidate = driver({
+		inventory: { list: async () => ({ owned: present ? [ref] : [], foreignCount: 0 }) },
+		destroyById: async () => {
+			present = false;
+		},
+		probes: { observe: async () => ({ state: present ? "running" : "terminal" }) },
+	});
+	const result = await reconcileAccount([{ id: "tama", driver: candidate }], {
+		timeoutMs: 100,
+		pollMs: 1,
+	});
+	expect(result.removed).toEqual([ref]);
 });
 test("cancellation cannot turn an unobserved account into an admitted one", async () => {
 	const controller = new AbortController();

--- a/apps/cli/src/lib/account-reconciliation.ts
+++ b/apps/cli/src/lib/account-reconciliation.ts
@@ -92,7 +92,10 @@ export async function reconcileAccount(
 			if (!destroy || !probes) throw new Error("managed recovery capability disappeared");
 			for (const ref of snapshot.owned) {
 				await bounded(() => destroy.call(driver, ref, { signal: controller.signal }));
-				while ((await bounded(() => probes.observe(ref))).state !== "absent") {
+				// Only the control plane's own observation releases the loop, never the delete response.
+				// `absent` and `terminal` both qualify: a terminated sandbox holds no allocation, and some
+				// vendors (Modal, run.cloud) retain terminated records forever, so absence never arrives.
+				while ((await bounded(() => probes.observe(ref))).state === "running") {
 					await bounded(
 						() => new Promise((resolve) => setTimeout(resolve, options.pollMs ?? 1000)),
 					);

--- a/docs/adr/0010-experiment-completeness.md
+++ b/docs/adr/0010-experiment-completeness.md
@@ -43,7 +43,9 @@ and complete verified attempts.
 
 Account queues alone cannot detect an interrupted create that has not yet appeared in inventory.
 Before create, CLI composition appends an intent to a protected, account-specific GitHub journal
-branch. After create returns it appends the sandbox reference; release requires observed absence.
+branch. After create returns it appends the sandbox reference; release requires the control plane
+to observe the sandbox as no longer running (absent, or terminal for vendors that retain terminated
+records), never a destroy response alone.
 Unknown creates block admission. Updates are fast-forward only and existing records cannot be
 replaced. Independent accounts use different branches; concurrent cells serialize journal appends.
 

--- a/docs/benchmark-execution-rollout.md
+++ b/docs/benchmark-execution-rollout.md
@@ -30,13 +30,16 @@ This is an implementation status record, not a claim that the live fleet meets t
 - Native command projections retain their errors until the shared redaction boundary, instead of
   replacing them with a generic callback failure. Regression tests cover both exec and launch.
 - A narrow complete-inventory driver capability and Tama ownership projection. Account reconciliation
-  validates all variant inventories before deletion, requires observed absence after deletion, and
-  checks every inventory again before admission. Unavailable inventory, foreign resources, cancellation,
+  validates all variant inventories before deletion, requires the control plane to observe each
+  deleted sandbox as no longer running (absent, or terminal where the vendor retains terminated
+  records — Modal and run.cloud never report absence), and checks every inventory again before
+  admission. Unavailable inventory, foreign resources, cancellation,
   timeout, or new allocations block admission. It is called once by each account-owned batch before allocation.
 - Strict `promote` requires the original plan and attempt directories and independently reconstructs
   the candidate before writing the dataset. Legacy Runs remain available for validation and reading.
-- Publication verifies identity-bound execution and cleanup receipts, including observed absence,
-  benchmark and collection completion, and sandbox attribution. Matching byte digests alone do not
+- Publication verifies identity-bound execution and cleanup receipts, including a control-plane
+  observation that the sandbox is no longer running, benchmark and collection completion, and
+  sandbox attribution. Matching byte digests alone do not
   satisfy the gate. Unterminated allocation intents also block publication.
 - Aggregation selects only planned eligible measurements. Published Runs carry a comparison cohort
   digest covering workload/environment revisions, passes, resources and eligible metrics; leaderboard
@@ -45,7 +48,8 @@ This is an implementation status record, not a claim that the live fleet meets t
 - Launch-settlement timeouts now collect diagnostic tails through the same recovery path as polling
   timeouts. Unreadable output has an unknown cause, not an inferred memory or agent failure.
 - Raw exception formatting in the reviewed CLI and collection failure sinks uses diagnostic projection.
-  Failed teardown fails suite execution; driver-session execution observes absence after destruction.
+  Failed teardown fails suite execution; driver-session execution confirms destruction from a
+  control-plane observation (absent or terminal), never from the destroy response.
   Implicit create retries default to zero. Explicit retries cannot follow an owner timeout or unresolved
   failed-create cleanup.
 

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -861,7 +861,11 @@ export async function executeSuite(options: ExecuteSuiteOptions): Promise<void> 
 						Math.max(1, deadline - Date.now()),
 						"Cleanup observation timeout",
 					);
-					if (observation.state === "absent") return;
+					// Removal is confirmed by the control plane's own observation, never by the destroy
+					// response. `terminal` counts alongside `absent`: a terminated sandbox holds no
+					// allocation, and vendors that retain terminated records (Modal, run.cloud) never
+					// report it absent.
+					if (observation.state !== "running") return;
 					await new Promise((resolve) =>
 						setTimeout(resolve, Math.min(250, Math.max(1, deadline - Date.now()))),
 					);


### PR DESCRIPTION
**Driver admission — merge bottom-up:** #433 → #439 → #441 → #435 → #436 → #437 → #438 → #440 → #442.

This PR is 2/9, based on #433.

Modal and RunCloud retain terminal records after an allocation stops consuming resources. Reconciliation and harness teardown now accept either `terminal` or `absent` from the control-plane observation; a successful destroy call alone still cannot confirm removal. Regression tests cover retained tombstones and a destroy response followed by a still-running observation.

The CLI subprocess tests also disable Bun's automatic `.env` loading, preserving their missing-credentials contract on developer machines. This shared lifecycle correction lands before the provider migrations that require it.

**Validation:** 2060 tests pass at this branch; frozen install, repository typecheck, Biome, and generated wiring pass independently.
