### PR TITLE
feat(admission): define inventory admission scope

### DIFF
--- a/apps/cli/src/bin/account-inventory.ts
+++ b/apps/cli/src/bin/account-inventory.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // Print each provider account as the reconciliation gate sees it: the benchmark's own leftovers
-// (which the next batch's admission would delete) and foreign resources (which block allocation
-// outright). Read-only — the operator's "clean vendor baseline" check before provisioning an
+// (which the next batch's admission would delete) and foreign resources (which block account-scoped
+// admission). Read-only — the operator's "clean vendor baseline" check before provisioning an
 // account journal or dispatching a matrix. Credentials come from the environment (Bun loads .env).
 import { describeDriverFailure } from "@sandbox-benchmarks/driver";
 import { diagnosticSecretsFromEnv } from "@sandbox-benchmarks/driver/env";

--- a/apps/cli/src/lib/account-inventory.test.ts
+++ b/apps/cli/src/lib/account-inventory.test.ts
@@ -20,6 +20,29 @@ const capable = (owned: readonly string[], foreignCount: number): SandboxDriver 
 	},
 });
 
+test("benchmark-scoped inventory reports foreign counts without blocking admission", async () => {
+	const rows = await inventoryAccounts(
+		["daytona-vm", "daytona-container", "novita"],
+		async () => ({ driver: capable([], 42) }),
+		String,
+	);
+	expect(inventoryBlocksAdmission(rows)).toBe(false);
+	expect(formatAccountInventory(rows)).toContain("foreign=42 scope=benchmark");
+	expect(rows.map((row) => row.account)).toEqual(["daytona", "daytona", "novita"]);
+});
+
+test("benchmark-scoped listing failure still blocks admission", async () => {
+	const rows = await inventoryAccounts(
+		["daytona-container", "novita"],
+		async () => {
+			throw new Error("inventory unavailable");
+		},
+		String,
+	);
+	expect(inventoryBlocksAdmission(rows)).toBe(true);
+	expect(rows.every((row) => row.status === "failed")).toBe(true);
+});
+
 test("reports every account the way admission sees it and never skips a failure", async () => {
 	const rows = await inventoryAccounts(
 		["tama", "e2b", "novita", "modal-vm"],

--- a/apps/cli/src/lib/account-inventory.ts
+++ b/apps/cli/src/lib/account-inventory.ts
@@ -1,5 +1,6 @@
 import type { InventorySnapshot, ProviderId, SandboxDriver } from "@sandbox-benchmarks/driver";
 import { quotaDomain } from "@sandbox-benchmarks/schema";
+import { accountInventoryScope } from "./account-policy.ts";
 
 export type AccountInventoryRow = {
 	readonly id: ProviderId;
@@ -12,7 +13,8 @@ export type AccountInventoryRow = {
 
 /**
  * Observe every requested provider's account exactly as admission will: reconciliation refuses a
- * driver without inventory, destroy-by-id and probes, and any foreign resource blocks allocation.
+ * driver without inventory, destroy-by-id and probes. Foreign resources block account-scoped admission;
+ * benchmark-scoped admission retains foreign counts without authorizing deletion.
  * Nothing here allocates or deletes, and a failed open or listing is reported, never skipped.
  */
 export async function inventoryAccounts<P extends ProviderId>(
@@ -42,9 +44,13 @@ export async function inventoryAccounts<P extends ProviderId>(
 	return rows;
 }
 
-/** Admission would block on any row here: an unsupported driver, a failed listing, or a foreign resource. */
+/** Benchmark-scoped exceptions permit foreign resources, never unavailable inventory. */
 export function inventoryBlocksAdmission(rows: readonly AccountInventoryRow[]): boolean {
-	return rows.some((row) => row.status !== "listed" || row.snapshot.foreignCount > 0);
+	return rows.some(
+		(row) =>
+			row.status !== "listed" ||
+			(row.snapshot.foreignCount > 0 && accountInventoryScope(row.id) === "account"),
+	);
 }
 
 export function formatAccountInventory(rows: readonly AccountInventoryRow[]): string {
@@ -56,7 +62,7 @@ export function formatAccountInventory(rows: readonly AccountInventoryRow[]): st
 				row.snapshot.owned.length === 0
 					? "none"
 					: row.snapshot.owned.map((ref) => ref.id).join(", ");
-			return `${head} owned=${row.snapshot.owned.length} [${owned}] foreign=${row.snapshot.foreignCount}`;
+			return `${head} owned=${row.snapshot.owned.length} [${owned}] foreign=${row.snapshot.foreignCount} scope=${accountInventoryScope(row.id)}`;
 		})
 		.join("\n");
 }

--- a/apps/cli/src/lib/account-policy.ts
+++ b/apps/cli/src/lib/account-policy.ts
@@ -1,0 +1,8 @@
+import type { ProviderId } from "@sandbox-benchmarks/driver";
+import { quotaDomain } from "@sandbox-benchmarks/schema";
+
+/** Reviewed inventory scopes (ADR-0011), bound to the experiment's source revision. */
+export function accountInventoryScope(id: ProviderId): "account" | "benchmark" {
+	const account = quotaDomain(id);
+	return account === "daytona" || account === "novita" ? "benchmark" : "account";
+}

--- a/apps/cli/src/lib/account-reconciliation.test.ts
+++ b/apps/cli/src/lib/account-reconciliation.test.ts
@@ -1,8 +1,85 @@
 import { expect, test } from "bun:test";
-import type { SandboxDriver, SandboxRef } from "@sandbox-benchmarks/driver";
+import type { ProviderId, SandboxDriver, SandboxRef } from "@sandbox-benchmarks/driver";
 import { reconcileAccount } from "./account-reconciliation.ts";
 
 const ref: SandboxRef = { provider: "tama", id: "machine-owned" };
+
+for (const id of ["daytona-vm", "daytona-container", "novita"] as const) {
+	test(`${id} permits foreign churn but removes only benchmark-owned sandboxes`, async () => {
+		const owned: SandboxRef = { provider: id, id: "benchmark-owned" };
+		const deleted: SandboxRef[] = [];
+		let scans = 0;
+		const candidate = driver({
+			inventory: {
+				list: async () => ({
+					owned: deleted.length === 0 ? [owned] : [],
+					foreignCount: ++scans * 10,
+				}),
+			},
+			destroyById: async (ref) => {
+				deleted.push(ref);
+			},
+			probes: { observe: async () => ({ state: "absent" }) },
+		});
+		const result = await reconcileAccount([{ id, driver: candidate }], { timeoutMs: 100 });
+		expect(deleted).toEqual([owned]);
+		expect(result.removed).toEqual([owned]);
+		expect(scans).toBe(2);
+	});
+}
+
+test("benchmark-scoped admission still reject malformed inventory, uncertain cleanup and new owned allocations", async () => {
+	const id = "novita";
+	const owned: SandboxRef = { provider: id, id: "benchmark-owned" };
+	for (const candidate of [
+		driver({ inventory: { list: async () => ({ owned: [], foreignCount: -1 }) } }),
+		driver({ inventory: { list: async () => ({ owned: [ref], foreignCount: 5 }) } }),
+		driver({ inventory: { list: async () => ({ owned: [owned, owned], foreignCount: 5 }) } }),
+		driver({
+			inventory: { list: async () => ({ owned: [owned], foreignCount: 5 }) },
+			destroyById: async () => {},
+			probes: { observe: async () => ({ state: "running" }) },
+		}),
+		driver({
+			inventory: { list: async () => ({ owned: [owned], foreignCount: 5 }) },
+			probes: { observe: async () => ({ state: "absent" }) },
+		}),
+	]) {
+		await expect(
+			reconcileAccount([{ id, driver: candidate }], { timeoutMs: 20, pollMs: 1 }),
+		).rejects.toThrow();
+	}
+});
+
+test("foreign resources still block every account-scoped inventory before any deletion", async () => {
+	const accountScoped: ProviderId[] = [
+		"e2b",
+		"modal-gvisor",
+		"modal-vm",
+		"tama",
+		"blaxel",
+		"microsandbox-cloud",
+		"runloop",
+		"runcloud",
+		"namespace",
+		"vercel",
+	];
+	let deletes = 0;
+	for (const id of accountScoped) {
+		const candidate = driver({
+			inventory: {
+				list: async () => ({ owned: [{ provider: id, id: "owned" }], foreignCount: 1 }),
+			},
+			destroyById: async () => {
+				deletes++;
+			},
+		});
+		await expect(reconcileAccount([{ id, driver: candidate }], { timeoutMs: 100 })).rejects.toThrow(
+			"account-scoped inventory contains unowned resources",
+		);
+	}
+	expect(deletes).toBe(0);
+});
 function driver(overrides: Partial<SandboxDriver> = {}): SandboxDriver {
 	let present = true;
 	return {

--- a/apps/cli/src/lib/account-reconciliation.ts
+++ b/apps/cli/src/lib/account-reconciliation.ts
@@ -4,6 +4,7 @@ import type {
 	SandboxDriver,
 	SandboxRef,
 } from "@sandbox-benchmarks/driver";
+import { accountInventoryScope } from "./account-policy.ts";
 
 export interface AccountDriver {
 	id: ProviderId;
@@ -70,8 +71,10 @@ export async function reconcileAccount(
 			!Array.isArray(snapshot.owned)
 		)
 			throw new Error(`${id} returned invalid account inventory`);
-		if (snapshot.foreignCount > 0)
-			throw new Error(`${id} dedicated account contains unowned resources; allocation blocked`);
+		if (snapshot.foreignCount > 0 && accountInventoryScope(id) === "account")
+			throw new Error(
+				`${id} account-scoped inventory contains unowned resources; allocation blocked`,
+			);
 		const ids = new Set<string>();
 		for (const ref of snapshot.owned) {
 			if (ref.provider !== id || typeof ref.id !== "string" || ref.id === "" || ids.has(ref.id))

--- a/docs/adr/0010-experiment-completeness.md
+++ b/docs/adr/0010-experiment-completeness.md
@@ -4,6 +4,9 @@ status: accepted
 
 # Frozen experiments and evidence-based publication
 
+The inventory admission condition is refined by
+[ADR-0011](./0011-inventory-admission-scope.md). All other requirements remain.
+
 ## Decision
 
 An experiment plan owns the expected provider, suite, replicate, metric, revision, artifact, resource,

--- a/docs/adr/0011-inventory-admission-scope.md
+++ b/docs/adr/0011-inventory-admission-scope.md
@@ -1,0 +1,34 @@
+---
+status: accepted
+---
+
+# Inventory admission scope
+
+## Context
+
+Resource ownership and account-wide emptiness are separate admission conditions. Recovery must only
+remove resources carrying benchmark ownership markers, regardless of the inventory admission scope.
+
+## Decision
+
+Refine ADR-0010 with two inventory scopes: `account` rejects any unowned resources; `benchmark`
+requires benchmark-owned resources to be reconciled while retaining the unowned count for diagnostics.
+Use benchmark scope for the `daytona` and `novita` quota domains, including both Daytona variants.
+All other domains retain account scope.
+
+CLI composition owns the policy. Drivers continue to report complete inventories and accurate
+ownership. The frozen experiment's source revision binds the policy; there is no dispatch flag or
+credential-derived override.
+
+Every variant must still supply complete inventory, destroy-by-id and probes. Invalid inventory,
+unknown creates, uncertain cleanup and new benchmark-owned allocations block admission under either
+scope. Unowned resources are never deleted by reconciliation. Protected journals and benchmark
+account queues remain required.
+
+## Consequences
+
+Admission scope does not establish performance isolation or reserve vendor capacity. Capacity limits
+bound benchmark allocations; quota failures remain failed attempts. Neither retries nor evidence and
+publication requirements change. The account-inventory command displays its scope alongside owned
+and unowned counts. Only the durable account owner may use benchmark markers and the journal;
+legacy benchmark allocators require separate development accounts until they adopt that owner.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,4 @@ here changes, supersede the ADR (leave it in place, note what replaced it) rathe
 | [0008](./0008-driver-conformance-gate.md) | Driver conformance: the behavioral drift gate |
 | [0009](./0009-harness-operations-and-gpu-allocation.md) | Separate harness operations and typed provider-specific GPU allocation |
 | [0010](./0010-experiment-completeness.md) | Frozen experiments, immutable attempts and strict completeness |
+| [0011](./0011-inventory-admission-scope.md) | Inventory admission scope and ownership-safe recovery |

--- a/docs/benchmark-execution-rollout.md
+++ b/docs/benchmark-execution-rollout.md
@@ -33,8 +33,10 @@ This is an implementation status record, not a claim that the live fleet meets t
   validates all variant inventories before deletion, requires the control plane to observe each
   deleted sandbox as no longer running (absent, or terminal where the vendor retains terminated
   records — Modal and run.cloud never report absence), and checks every inventory again before
-  admission. Unavailable inventory, foreign resources, cancellation,
-  timeout, or new allocations block admission. It is called once by each account-owned batch before allocation.
+  admission. Unavailable inventory, cancellation, timeout, or new benchmark allocations block
+  admission. Foreign resources block account-scoped admission;
+  [ADR-0011](./adr/0011-inventory-admission-scope.md) defines benchmark-scoped admission without
+  authorizing deletion of unowned resources. It is called once by each account-owned batch before allocation.
 - Strict `promote` requires the original plan and attempt directories and independently reconstructs
   the candidate before writing the dataset. Legacy Runs remain available for validation and reading.
 - Publication verifies identity-bound execution and cleanup receipts, including a control-plane
@@ -86,7 +88,7 @@ one blob avoids a REST request per historical record on every new batch.
 An operator must provision these branches after quiescing existing account writers and confirming a
 clean vendor baseline. `bun apps/cli/src/bin/account-inventory.ts [provider...]` reads every migrated
 provider's account exactly as admission will — the benchmark's own leftovers (removed by the next
-batch's reconciliation) and foreign resources (which block allocation outright) — without allocating
+batch's reconciliation) and foreign resources (which block account-scoped admission) — without allocating
 or deleting anything; it exits non-zero when any account would block admission. Protect them against deletion and force pushes, retain their history, and
 permit the privileged workflow token to append commits. Do not reset a journal to recover an account.
 For an unknown create, obtain the vendor's request outcome and resource identity before recording

--- a/packages/harness/CONTEXT.md
+++ b/packages/harness/CONTEXT.md
@@ -4,6 +4,11 @@ This context describes performing benchmark work and recording the evidence used
 
 ## Language
 
+**Inventory admission scope**:
+The resources whose presence prevents admission. Account scope rejects unowned resources; benchmark
+scope requires only benchmark-owned resources to be reconciled. Neither scope permits deleting
+unowned resources or establishes performance isolation.
+
 **Benchmark step**:
 A command workload executed as part of benchmark preparation, measurement, or collection, with
 its own completion outcome. A step is not necessarily a measured sample.


### PR DESCRIPTION
Separate inventory admission scope from resource ownership. Account scope rejects unowned resources; benchmark scope requires benchmark-owned resources to be reconciled while preserving complete inventory reporting. Apply benchmark scope to the Daytona and Novita quota domains, including both Daytona variants; retain account scope elsewhere.

Both scopes validate complete inventories and ownership before recovery, delete only benchmark-marked resources, confirm removal through the control plane, and reject uncertain cleanup or new benchmark allocations. The inventory command reports the effective scope alongside owned and unowned counts. ADR-0011 records the decision; the frozen experiment's source revision binds the policy. Admission scope does not establish performance isolation or reserve vendor capacity.

Validation: the implementation passed 2,159 offline tests. Following the terminology refinement, all 15 inventory/reconciliation tests, typecheck, lint, and spelling passed. No admission or cleanup behavior changed in the refinement.
