### PR TITLE
chore(codeowners): add @cosmic-emerald as second default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,10 +5,10 @@
 # Everything is owned by default and the LAST matching entry wins; an entry with NO owner un-owns
 # its paths. Only the artifacts the github-actions bot lands hands-off are deliberately unowned
 # (docs/ci-secrets.md rules 5 and 7). A PR touching only those needs no code-owner review; anything
-# else — code, workflows, docs — requires @dbworku. In particular the leaderboard
+# else — code, workflows, docs — requires review from @dbworku or @cosmic-emerald. In particular the leaderboard
 # renderer and its backing packages must stay owned: their output is committed by a job inside the
 # `privileged` environment, so unreviewed renderer changes would run with release credentials.
-* @dbworku
+* @dbworku @cosmic-emerald
 
 # Bot-landed release artifacts — no owner, so the bot's direct merge needs no human review.
 # These must stay in lockstep with the path allowlists the landing jobs assert against


### PR DESCRIPTION
## What & why

`main` requires code-owner review. `CODEOWNERS` was only `@dbworku`, who authors most stacks — GitHub will not count a self-approval, so Graphite merge queue fails (seen on `#419`–`#427`).

Adds `@cosmic-emerald` (Ali) as a second default owner so someone else can approve those PRs.

Ali is also invited as a collaborator on this repo so the CODEOWNERS entry is usable once they accept.