### PR TITLE
fix(ci): scope experiment artifact reads to their workflow run

### DIFF
--- a/apps/cli/src/bin/workflow-experiment.ts
+++ b/apps/cli/src/bin/workflow-experiment.ts
@@ -16,7 +16,7 @@ if (import.meta.main) {
 		const [command, account, round] = process.argv.slice(2);
 		const id = process.env.BENCH_EXPERIMENT_ID ?? process.env.GITHUB_RUN_ID;
 		if (!id) throw new Error("experiment id is required");
-		const store = githubExperimentStore();
+		const store = githubExperimentStore(id);
 		const root = "experiment";
 		const planRoot = join(root, "manifest");
 		mkdirSync(planRoot, { recursive: true });

--- a/apps/cli/src/lib/experiment-store.test.ts
+++ b/apps/cli/src/lib/experiment-store.test.ts
@@ -1,8 +1,8 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import { githubExperimentStore, scanArtifactPages } from "./experiment-store.ts";
 
 test("an upload outside the artifact runtime names the step that provides it", async () => {
-	const store = githubExperimentStore({ GITHUB_REPOSITORY: "owner/repo", GH_TOKEN: "token" });
+	const store = githubExperimentStore("1", { GITHUB_REPOSITORY: "owner/repo", GH_TOKEN: "token" });
 	await expect(store.upload("experiment-plan-1", ".")).rejects.toThrow(
 		"run .github/actions/artifact-runtime before this step",
 	);
@@ -13,6 +13,45 @@ const artifact = (id: number) => ({
 	name: `artifact-${id}`,
 	expired: false,
 	workflow_run: { id: 1 },
+});
+
+test("unrelated workflow uploads cannot invalidate a frozen-plan inventory", async () => {
+	const requests: string[] = [];
+	const fetchMock = spyOn(globalThis, "fetch").mockImplementation(
+		Object.assign(
+			async (input: Parameters<typeof fetch>[0]) => {
+				const url = String(input);
+				requests.push(url);
+				if (url.includes("/actions/runs/123/artifacts"))
+					return Response.json({
+						total_count: 1,
+						artifacts: [{ ...artifact(1), name: "experiment-plan-123", workflow_run: { id: 123 } }],
+					});
+				const page = Number(new URL(url).searchParams.get("page"));
+				return Response.json({ total_count: page + 1, artifacts: [artifact(page)] });
+			},
+			{ preconnect: fetch.preconnect },
+		),
+	);
+	try {
+		const store = githubExperimentStore("123", {
+			// Backfill executes in a different run; artifact reads must use the explicit source id.
+			GITHUB_REPOSITORY: "owner/repo",
+			GH_TOKEN: "token",
+			GITHUB_RUN_ID: "999",
+		});
+		expect((await store.list("experiment-plan-123")).map((item) => item.id)).toEqual([1]);
+		expect(requests).toHaveLength(1);
+	} finally {
+		fetchMock.mockRestore();
+	}
+});
+
+test("artifact run identity rejects malformed paths before making requests", () => {
+	for (const id of ["", "0", "../artifacts", "123?page=2"])
+		expect(() =>
+			githubExperimentStore(id, { GITHUB_REPOSITORY: "owner/repo", GH_TOKEN: "token" }),
+		).toThrow();
 });
 test("artifact scans require complete stable pagination", async () => {
 	expect(

--- a/apps/cli/src/lib/experiment-store.ts
+++ b/apps/cli/src/lib/experiment-store.ts
@@ -12,6 +12,7 @@ const artifactPage = type({
 		workflow_run: { id: "number.integer > 0" },
 	}).array(),
 });
+const workflowRunId = type(/^[1-9][0-9]*$/);
 export type StoredArtifact = (typeof artifactPage.infer.artifacts)[number];
 export interface ExperimentStore {
 	list(prefix: string): Promise<readonly StoredArtifact[]>;
@@ -19,7 +20,7 @@ export interface ExperimentStore {
 	download(artifact: StoredArtifact, directory: string): Promise<void>;
 }
 
-/** The account queue is the exclusive writer. Concurrent repository changes invalidate a scan. */
+/** Require a complete inventory within the selected workflow run. */
 export async function scanArtifactPages(
 	read: (page: number) => Promise<unknown>,
 ): Promise<StoredArtifact[]> {
@@ -44,7 +45,11 @@ export async function scanArtifactPages(
 	throw new Error("artifact history exceeds supported scan; archival reconciliation is required");
 }
 
-export function githubExperimentStore(env: NodeJS.ProcessEnv = process.env): ExperimentStore {
+export function githubExperimentStore(
+	runId: string,
+	env: NodeJS.ProcessEnv = process.env,
+): ExperimentStore {
+	const run = workflowRunId.assert(runId);
 	const repository = env.GITHUB_REPOSITORY;
 	const token = env.GH_TOKEN || env.GITHUB_TOKEN;
 	if (!repository || !/^[\w.-]+\/[\w.-]+$/.test(repository) || !token)
@@ -56,7 +61,7 @@ export function githubExperimentStore(env: NodeJS.ProcessEnv = process.env): Exp
 		async list(prefix) {
 			const entries = await scanArtifactPages(async (page) => {
 				const response = await fetch(
-					`https://api.github.com/repos/${repository}/actions/artifacts?per_page=100&page=${page}`,
+					`https://api.github.com/repos/${repository}/actions/runs/${run}/artifacts?per_page=100&page=${page}`,
 					{
 						headers: {
 							Authorization: `Bearer ${token}`,


### PR DESCRIPTION
Concurrent workflow uploads could make account planning fail with `artifact inventory changed during scan; retry admission` because frozen-plan lookup scanned every artifact in the repository. List artifacts from the explicit source workflow run instead, including when collection backfills an earlier run. Complete pagination, expiry, immutable-name, and provenance checks remain in place.

Validation: regression test reproduces the original race and verifies source-run selection; invalid run IDs are rejected. Confirmed lookup against an existing failed run's artifact. Typecheck, tests, lint, and spelling checks pass.

Merge this two-PR stack bottom-up: #446 (artifact lookup), then #447 (terminal allocation recovery). This is PR 1/2, based on main.
