### PR TITLE
fix(admission): release recovered terminal allocations

### DIFF
--- a/apps/cli/src/lib/account-journal.test.ts
+++ b/apps/cli/src/lib/account-journal.test.ts
@@ -78,3 +78,32 @@ test("unavailable observation does not append a release", async () => {
 	).rejects.toThrow("unavailable");
 	expect(events).toEqual([]);
 });
+
+for (const initiallyTerminal of [false, true]) {
+	test(`retained terminal allocations release journal ownership (initially terminal: ${initiallyTerminal})`, async () => {
+		const records: AccountRecord[] = [intent, { ...intent, kind: "allocated", ref }];
+		const { driver, journal, events } = fixture(records);
+		let terminal = initiallyTerminal;
+		const retained: SandboxDriver = {
+			...driver,
+			probes: { observe: async () => ({ state: terminal ? "terminal" : "running" }) },
+			destroyById: async () => {
+				terminal = true;
+				events.push("destroy");
+			},
+		};
+		await recoverAccount("tama", new Map([["tama", retained]]), journal, AbortSignal.timeout(50));
+		expect(events).toEqual(initiallyTerminal ? ["release"] : ["destroy", "release"]);
+		expect(records.at(-1)).toMatchObject({ kind: "released", outcome: "absent", ref });
+	});
+}
+
+test("a delete acknowledgement cannot release a still-running allocation", async () => {
+	const records: AccountRecord[] = [intent, { ...intent, kind: "allocated", ref }];
+	const { driver, journal } = fixture(records);
+	driver.destroyById = async () => {};
+	await expect(
+		recoverAccount("tama", new Map([["tama", driver]]), journal, AbortSignal.timeout(20)),
+	).rejects.toThrow();
+	expect(records).toHaveLength(2);
+});

--- a/apps/cli/src/lib/account-journal.ts
+++ b/apps/cli/src/lib/account-journal.ts
@@ -74,7 +74,7 @@ export async function recoverAccount(
 	}
 }
 
-/** Only observed absence releases a known allocation. Transport failures preserve ownership. */
+/** Observed absence or a retained terminal record releases ownership; transport failures do not. */
 export async function confirmRemoval(
 	driver: SandboxDriver,
 	ref: SandboxRef,
@@ -100,12 +100,12 @@ export async function confirmRemoval(
 		}
 	};
 	signal.throwIfAborted();
-	if ((await bounded(driver.probes.observe(ref))).state === "absent") return;
+	if ((await bounded(driver.probes.observe(ref))).state !== "running") return;
 	signal.throwIfAborted();
 	await bounded(driver.destroyById(ref, { signal }));
 	for (;;) {
 		signal.throwIfAborted();
-		if ((await bounded(driver.probes.observe(ref))).state === "absent") return;
+		if ((await bounded(driver.probes.observe(ref))).state !== "running") return;
 		await bounded(new Promise((resolve) => setTimeout(resolve, 100)));
 	}
 }


### PR DESCRIPTION
Recovery previously waited indefinitely when a provider retained a terminal sandbox record after deletion. Accept terminal observations as confirmed removal, matching the existing reconciliation contract. Failed observations and delete acknowledgements for still-running sandboxes continue to preserve journal ownership.

Validation: regression tests cover resources already terminal, resources becoming terminal after deletion, and acknowledged deletes that remain running. Typecheck, tests, lint, and spelling checks pass.

Merge this two-PR stack bottom-up: #446 (artifact lookup), then #447 (terminal allocation recovery). This is PR 2/2, based on #446.
