### PR TITLE
fix(results): isolate artifact collection and workflow provenance

### DIFF
--- a/apps/cli/src/lib/experiment-plan.test.ts
+++ b/apps/cli/src/lib/experiment-plan.test.ts
@@ -113,7 +113,7 @@ function successful(): AttemptWithRun {
 			environmentRevision: cell().environmentRevision,
 			artifactIdentity: cell().artifactIdentity,
 			passes: cell().passes,
-			workflowRun: "123",
+			workflowRun: "experiment-1",
 			workflowAttempt: 1,
 			job: "memory",
 			sequence: 0,
@@ -489,4 +489,10 @@ test("unverified GPU capacity and mixed workload revisions fail admission", () =
 			cells: [cell(), { ...cell(1), workloadRevision: "changed" }],
 		}),
 	).toThrow("inconsistent comparison cohort");
+});
+
+test("an attempt from another workflow cannot satisfy experiment coverage", () => {
+	const attempt = successful();
+	attempt.evidence.workflowRun = "another-workflow";
+	expect(evaluateExperiment(plan(), [attempt]).complete).toBe(false);
 });

--- a/apps/cli/src/lib/experiment-store.test.ts
+++ b/apps/cli/src/lib/experiment-store.test.ts
@@ -1,5 +1,11 @@
-import { expect, spyOn, test } from "bun:test";
+import { afterAll, expect, spyOn, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { githubExperimentStore, scanArtifactPages } from "./experiment-store.ts";
+
+const root = mkdtempSync(join(tmpdir(), "plan-lookup-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
 
 test("an upload outside the artifact runtime names the step that provides it", async () => {
 	const store = githubExperimentStore("1", { GITHUB_REPOSITORY: "owner/repo", GH_TOKEN: "token" });
@@ -40,7 +46,7 @@ test("unrelated workflow uploads cannot invalidate a frozen-plan inventory", asy
 			GH_TOKEN: "token",
 			GITHUB_RUN_ID: "999",
 		});
-		expect((await store.list("experiment-plan-123")).map((item) => item.id)).toEqual([1]);
+		expect((await store.list({ name: "experiment-plan-123" })).map((item) => item.id)).toEqual([1]);
 		expect(requests).toHaveLength(1);
 	} finally {
 		fetchMock.mockRestore();
@@ -68,4 +74,47 @@ test("artifact scans require complete stable pagination", async () => {
 	await expect(scanArtifactPages(async () => ({ total_count: 1, artifacts: [] }))).rejects.toThrow(
 		"incomplete",
 	);
+});
+
+test("same-run attempt uploads do not disturb exact frozen-plan lookup", async () => {
+	const requests: string[] = [];
+	const fetchMock = spyOn(globalThis, "fetch").mockImplementation(
+		Object.assign(
+			async (input: Parameters<typeof fetch>[0]) => {
+				const url = new URL(String(input));
+				requests.push(url.toString());
+				if (url.searchParams.get("name") === "experiment-plan-123")
+					return Response.json({
+						total_count: 1,
+						artifacts: [{ ...artifact(1), name: "experiment-plan-123", workflow_run: { id: 123 } }],
+					});
+				const page = Number(url.searchParams.get("page"));
+				return Response.json({ total_count: 101 + page, artifacts: [artifact(page)] });
+			},
+			{ preconnect: fetch.preconnect },
+		),
+	);
+	try {
+		const store = githubExperimentStore("123", {
+			GITHUB_REPOSITORY: "owner/repo",
+			GH_TOKEN: "token",
+		});
+		// Exercise the real transfer caller, which must ask for an exact name.
+		const { downloadExperimentPlan } = await import("./experiment-transfer.ts");
+		await expect(
+			downloadExperimentPlan(
+				{
+					...store,
+					download: async () => {
+						throw new Error("plan selected");
+					},
+				},
+				"123",
+				root,
+			),
+		).rejects.toThrow("plan selected");
+		expect(requests).toHaveLength(1);
+	} finally {
+		fetchMock.mockRestore();
+	}
 });

--- a/apps/cli/src/lib/experiment-store.ts
+++ b/apps/cli/src/lib/experiment-store.ts
@@ -15,7 +15,7 @@ const artifactPage = type({
 const workflowRunId = type(/^[1-9][0-9]*$/);
 export type StoredArtifact = (typeof artifactPage.infer.artifacts)[number];
 export interface ExperimentStore {
-	list(prefix: string): Promise<readonly StoredArtifact[]>;
+	list(query: { name: string } | { prefix: string }): Promise<readonly StoredArtifact[]>;
 	upload(name: string, directory: string): Promise<void>;
 	download(artifact: StoredArtifact, directory: string): Promise<void>;
 }
@@ -58,10 +58,10 @@ export function githubExperimentStore(
 	if (!repositoryOwner || !repositoryName) throw new Error("invalid repository identity");
 	const client = new DefaultArtifactClient();
 	return {
-		async list(prefix) {
+		async list(query) {
 			const entries = await scanArtifactPages(async (page) => {
 				const response = await fetch(
-					`https://api.github.com/repos/${repository}/actions/runs/${run}/artifacts?per_page=100&page=${page}`,
+					`https://api.github.com/repos/${repository}/actions/runs/${run}/artifacts?per_page=100&page=${page}${"name" in query ? `&name=${encodeURIComponent(query.name)}` : ""}`,
 					{
 						headers: {
 							Authorization: `Bearer ${token}`,
@@ -74,7 +74,9 @@ export function githubExperimentStore(
 				if (!response.ok) throw new Error(`artifact inventory HTTP ${response.status}`);
 				return response.json();
 			});
-			const selected = entries.filter((entry) => entry.name.startsWith(prefix));
+			const selected = entries.filter((entry) =>
+				"name" in query ? entry.name === query.name : entry.name.startsWith(query.prefix),
+			);
 			if (selected.some((entry) => entry.expired))
 				throw new Error(
 					"required artifact history expired; vendor-confirmed recovery or retained archive is required",

--- a/apps/cli/src/lib/experiment-transfer.test.ts
+++ b/apps/cli/src/lib/experiment-transfer.test.ts
@@ -62,3 +62,35 @@ test("a plan artifact from another workflow cannot supply experiment provenance"
 		),
 	).rejects.toThrow("workflow provenance");
 });
+
+test("collection refuses stale local attempts even when the remote inventory is empty", async () => {
+	const directory = join(root, "stale-collection");
+	mkdirSync(join(directory, "old-attempt"), { recursive: true });
+	writeImmutableJson(join(directory, "old-attempt", "attempt.json"), { stale: true });
+	await expect(
+		downloadExperimentAttempts(
+			store,
+			{ read: async () => [], append: async () => {} },
+			plan,
+			directory,
+		),
+	).rejects.toThrow("empty");
+});
+
+test("plan extraction cannot reuse a stale local plan when an archive omits it", async () => {
+	const directory = join(root, "stale-plan");
+	mkdirSync(directory);
+	writeImmutableJson(join(directory, "plan.json"), plan);
+	await expect(
+		downloadExperimentPlan(
+			{
+				...store,
+				list: async () => [
+					{ id: 1, name: "experiment-plan-123", expired: false, workflow_run: { id: 123 } },
+				],
+			},
+			"123",
+			directory,
+		),
+	).rejects.toThrow("empty");
+});

--- a/apps/cli/src/lib/experiment-transfer.ts
+++ b/apps/cli/src/lib/experiment-transfer.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import { lstatSync, mkdirSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { ExperimentPlan } from "@sandbox-benchmarks/schema";
 import type { AccountJournal } from "./account-journal.ts";
@@ -15,11 +15,12 @@ export async function downloadExperimentPlan(
 	root: string,
 ): Promise<ExperimentPlan> {
 	if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(id)) throw new Error("invalid experiment identity");
-	const artifacts = (await store.list(`experiment-plan-${id}`)).filter(
+	const artifacts = (await store.list({ name: `experiment-plan-${id}` })).filter(
 		(entry) => entry.name === `experiment-plan-${id}`,
 	);
 	if (artifacts.length !== 1 || !artifacts[0])
 		throw new Error("one immutable experiment plan is required");
+	prepareDownloadDirectory(root);
 	await store.download(artifacts[0], root);
 	const plan = readExperimentPlan(join(root, "plan.json"));
 	if (plan.id !== id || String(artifacts[0].workflow_run.id) !== id)
@@ -34,9 +35,9 @@ export async function downloadExperimentAttempts(
 	plan: ExperimentPlan,
 	root: string,
 ): Promise<void> {
-	mkdirSync(root, { recursive: true });
+	prepareDownloadDirectory(root);
 	const terminals = new Map<string, ReturnType<typeof readExperimentAttempt>>();
-	for (const artifact of await store.list(`experiment-attempt-${plan.id}-`)) {
+	for (const artifact of await store.list({ prefix: `experiment-attempt-${plan.id}-` })) {
 		const directory = join(root, String(artifact.id));
 		await store.download(artifact, directory);
 		const attempt = readExperimentAttempt(directory);
@@ -89,4 +90,11 @@ export async function downloadExperimentAttempts(
 			writeImmutableJson(join(directory, "intent.json"), record);
 		}
 	}
+}
+
+/** A download must never inherit evidence from an earlier collection or partial extraction. */
+function prepareDownloadDirectory(root: string): void {
+	mkdirSync(root, { recursive: true });
+	if (lstatSync(root).isSymbolicLink() || readdirSync(root).length !== 0)
+		throw new Error("artifact download requires an empty regular directory");
 }

--- a/packages/results/src/lib/experiment.ts
+++ b/packages/results/src/lib/experiment.ts
@@ -217,6 +217,7 @@ export function evaluateExperiment(
 		ids.add(evidence.id);
 		if (
 			!knownCells.has(evidence.cellId) ||
+			evidence.workflowRun !== plan.id ||
 			evidence.planDigest !== plan.digest ||
 			evidence.sha !== plan.sha
 		) {

--- a/scripts/backfill-dataset.sh
+++ b/scripts/backfill-dataset.sh
@@ -2,7 +2,7 @@
 # Backfill the committed dataset from a previous Bench matrix run by dispatching commit-dataset.yml.
 #
 # When a matrix run's dataset commit fails (or was never reached), a codeowner re-runs the aggregate +
-# promote + commit step standalone against that run's still-retained bench-* shard artifacts — no
+# promote + commit step standalone against that run's still-retained experiment plan and attempt artifacts — no
 # re-benching. This is a thin wrapper over `gh workflow run` so the dispatch is one command instead of
 # a hand-assembled API call; the same thing is doable from the Actions UI (Actions → Commit dataset →
 # Run workflow). See docs/ci-secrets.md rule 6.
@@ -12,7 +12,7 @@
 # a codeowner is necessary but the environment's reviewer still has to approve the run.
 #
 # Usage: scripts/backfill-dataset.sh <run-id>
-#   <run-id>   The Bench matrix run id whose bench-* shard artifacts to aggregate + commit.
+#   <run-id>   The Bench matrix run id whose experiment plan and attempt artifacts to aggregate + commit.
 set -euo pipefail
 
 # commit-dataset.yml only runs on main (its job `if:` pins to refs/heads/main), and workflow_dispatch is
@@ -44,7 +44,7 @@ fi
 # The workflow intentionally skips its only job outside the canonical repository. Always dispatch the
 # upstream copy so invoking this helper from a fork cannot report success for a run that immediately skips.
 
-# Best-effort heads-up: backfill only works while the run's bench-* shard artifacts are still inside the
+# Best-effort heads-up: backfill only works while the run's experiment plan and attempt artifacts are still inside the
 # repo's retention window. A missing set isn't fatal here (the workflow fails loudly with the same
 # diagnosis), but warning now saves a round-trip through the approval gate for a run whose shards expired.
 # The lookup must stay non-fatal under `set -euo pipefail`: a transient gh error (5xx, 404 on a bad run
@@ -52,12 +52,12 @@ fi
 # abort the script before dispatch. Guard the assignment with `if !` so a failed lookup only warns.
 if ! artifact_count="$(gh api --paginate \
   "repos/${REPO}/actions/runs/${RUN_ID}/artifacts" \
-  -q '[.artifacts[] | select(.expired == false) | select(.name | startswith("bench-"))] | length' \
+  -q "[.artifacts[] | select(.expired == false and .name == \"experiment-plan-${RUN_ID}\")] | length" \
   2>/dev/null | awk '{ sum += $1 } END { print sum + 0 }')"; then
   echo "⚠️  Could not inspect retained artifacts for run ${RUN_ID}; continuing to dispatch anyway." >&2
 elif [ "$artifact_count" -eq 0 ]; then
-  echo "⚠️  No un-expired bench-* shard artifacts found on run ${RUN_ID} of ${REPO}." >&2
-  echo "    Backfill re-aggregates those shards, so it will fail if they've aged out of retention." >&2
+  echo "⚠️  No retained frozen experiment plan found on run ${RUN_ID} of ${REPO}." >&2
+  echo "    Backfill requires the frozen plan and original attempts; legacy bench-* shards are insufficient." >&2
   echo "    Continuing anyway — dispatch the workflow to see its own diagnosis." >&2
 fi
 


### PR DESCRIPTION
Large experiments could still fail frozen-plan lookup when concurrent attempts changed the same run's artifact pages. Query the exact plan name through GitHub's run-scoped API; attempt collection retains complete prefix inventory and its existing completeness guards.

This follow-up also closes two dataset evidence gaps: collection now refuses non-empty destinations, preventing old attempts or a stale plan from filling missing archive contents, and coverage rejects attempts whose recorded workflow differs from the frozen plan. The backfill helper checks for the current immutable plan instead of legacy bench-* shards.

Validation: four regression cases cover same-run upload races, stale attempt directories, stale plan extraction, and foreign workflow identity. All 2,168 tests, typecheck, lint, spelling, and ShellCheck pass. Exact-name filtering was verified against retained GitHub artifacts; backfill was exercised with dispatch mocked out. No benchmark or dataset publication was started.

Follow-up to merged #446 and #447, based directly on main. The exact-name API filter is documented in [GitHub's artifact API](https://docs.github.com/en/rest/actions/artifacts#list-workflow-run-artifacts).
