### PR TITLE
fix(driver): detach background commands in native SDK projections

### DIFF
--- a/packages/driver/src/native.test.ts
+++ b/packages/driver/src/native.test.ts
@@ -37,3 +37,32 @@ test("native projection preserves typed handles, create errors, and cancellation
 	await expect(compute.sandbox.create(options, operation)).rejects.toThrow("cancelled");
 	expect(creates).toBe(2);
 });
+
+test("native background commands acknowledge launch before the workload finishes", async () => {
+	const { mkdtempSync, existsSync, rmSync } = await import("node:fs");
+	const { tmpdir } = await import("node:os");
+	const { join } = await import("node:path");
+	const root = mkdtempSync(join(tmpdir(), "native-launch-"));
+	const done = join(root, "done");
+	const compute = nativeSdkCompute(
+		async () => ({ id: "sandbox-1" }),
+		() => ({
+			sandboxId: "sandbox-1",
+			runCommand: async (command) => ({
+				exitCode: await Bun.spawn(["sh", "-c", command], { stdout: "ignore", stderr: "ignore" })
+					.exited,
+			}),
+			destroy: async () => {},
+		}),
+	);
+	try {
+		const sandbox = await compute.sandbox.create(undefined);
+		await sandbox.runCommand(`sleep 0.5; touch '${done}'`, { background: true });
+		expect(existsSync(done)).toBe(false);
+		await Bun.sleep(700);
+		expect(existsSync(done)).toBe(true);
+	} finally {
+		await Bun.sleep(700);
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/packages/driver/src/native.ts
+++ b/packages/driver/src/native.ts
@@ -2,6 +2,7 @@
 // ComputeSDK's error-erasing wrappers. The SDK's exact native type survives inference.
 import type { DriverOperationOptions } from "@sandbox-benchmarks/driver";
 import type { ComputeSdkSandboxLike } from "./computesdk.ts";
+import { detachedShellCommand } from "./lib/shell.ts";
 
 export function nativeSdkCompute<Options, Native>(
 	create: (options: Options, operation: DriverOperationOptions) => Promise<Native>,
@@ -12,7 +13,18 @@ export function nativeSdkCompute<Options, Native>(
 			async create(options: Options, operation: DriverOperationOptions = {}) {
 				operation.signal?.throwIfAborted();
 				const native = await create(options, operation);
-				return { ...project(native), getInstance: () => native };
+				const projected = project(native);
+				return {
+					...projected,
+					getInstance: () => native,
+					// Native projections execute synchronously; explicit commands.launch hooks own
+					// vendor background APIs. Honor the wrapper convention through the shared shell.
+					runCommand: (command: string, options?: Parameters<typeof projected.runCommand>[1]) =>
+						projected.runCommand(options?.background ? detachedShellCommand(command) : command, {
+							...options,
+							background: false,
+						}),
+				};
 			},
 		},
 	};


### PR DESCRIPTION
Smoke failure fixes — merge bottom-up: #449 → #450 → #451 → #452 → #453.
This PR is 1/5.

Native SDK commands requested in the background still held the synchronous exec connection open, causing long Microsandbox workloads to lose their session. Apply the shared shell launcher at the native SDK projection boundary. Explicit provider launch hooks retain their native behavior.

Validation: Regression fails before the fix and passes afterward. Full typecheck, tests, lint and spell pass; GitHub CI passes. A live Microsandbox launch returned in 830 ms, the detached command completed, and cleanup was confirmed.
