### PR TITLE
fix(results): admit stock boots without named artifact verification

### DIFF
--- a/apps/cli/src/lib/experiment-plan.test.ts
+++ b/apps/cli/src/lib/experiment-plan.test.ts
@@ -496,3 +496,35 @@ test("an attempt from another workflow cannot satisfy experiment coverage", () =
 	attempt.evidence.workflowRun = "another-workflow";
 	expect(evaluateExperiment(plan(), [attempt]).complete).toBe(false);
 });
+
+test("stock boots do not require verification of an artifact they never requested", () => {
+	const stockCell = {
+		...cell(),
+		id: "blaxel-memory-r0",
+		provider: "blaxel" as const,
+		quotaDomain: "blaxel",
+		artifactIdentity: evidenceDigest({ kind: "none" }),
+	};
+	const stockPlan = planExperiment({
+		id: "experiment-1",
+		sha,
+		createdOn: "2026-09-10",
+		cells: [stockCell],
+	});
+	const attempt = successful();
+	if (!attempt.run || !attempt.execution) throw new Error("fixture incomplete");
+	const provider = attempt.run.providers[0];
+	if (!provider?.artifactEvidence?.[0]) throw new Error("fixture missing artifact");
+	provider.providerId = "blaxel";
+	provider.artifactEvidence[0].cell.providerId = "blaxel";
+	provider.artifactEvidence[0].provenance = {
+		source: "request-fallback",
+		requested: { kind: "none" },
+	};
+	attempt.execution.provider = "blaxel";
+	attempt.evidence.cellId = stockCell.id;
+	attempt.evidence.planDigest = stockPlan.digest;
+	attempt.evidence.artifactIdentity = stockCell.artifactIdentity;
+	attempt.evidence.runDigest = evidenceDigest(attempt.run);
+	expect(evaluateExperiment(stockPlan, [attempt]).complete).toBe(true);
+});

--- a/packages/results/src/lib/experiment.ts
+++ b/packages/results/src/lib/experiment.ts
@@ -316,7 +316,9 @@ export function evaluateExperiment(
 				(entry) => entry.providerId === cell.provider || providerReportedNothing(entry),
 			) &&
 			artifact !== undefined &&
-			artifactVerified(artifact) &&
+			// Stock boots have no artifact to verify, matching driver conformance. Named
+			// artifacts still require observed attribution, never the request alone.
+			(artifact.provenance.requested.kind === "none" || artifactVerified(artifact)) &&
 			evidenceDigest(effectiveArtifact(artifact.provenance)) === cell.artifactIdentity &&
 			selected?.run?.replicateIndex === cell.replicate &&
 			provider?.suitesCovered.includes(cell.suite) &&


### PR DESCRIPTION
Smoke failure fixes — merge bottom-up: #449 → #450 → #451 → #452 → #453.
This PR is 2/5.

Blaxel produced all required smoke metrics but failed completeness because its stock boot has no named image to verify. Match the existing conformance rule for requested artifact kind `none`, while retaining observed identity requirements for named images and templates.

Validation: Regression fails before the fix and passes afterward. Replaying the retained Blaxel attempt now yields complete coverage without modifying its evidence. Full local checks and GitHub CI pass.
