### PR TITLE
fix(admission): release intents after confirmed clean create failures

### DIFF
--- a/apps/cli/src/lib/execute-experiment.test.ts
+++ b/apps/cli/src/lib/execute-experiment.test.ts
@@ -211,3 +211,33 @@ test("a failed terminal upload does not discard its local immutable evidence or 
 	const retry = await executeExperimentBatch({ ...f.options, workflowAttempt: 2 });
 	expect(retry.every((attempt) => !attempt.measurementStarted)).toBe(true);
 });
+
+test("a typed clean create refusal releases its intent while an ambiguous failure does not", async () => {
+	const { DriverError, markRetryableDriverCreate } = await import("@sandbox-benchmarks/driver");
+	for (const clean of [true, false]) {
+		const f = await fixture(`create-refusal-${clean}`);
+		const open = f.options.open;
+		const failure = new DriverError("create-failed", "boot interrupted", { provider: "tama" });
+		if (clean) markRetryableDriverCreate(failure);
+		f.options.open = async () => {
+			const opened = await open();
+			return {
+				...opened,
+				driver: {
+					...opened.driver,
+					create: async () => {
+						throw failure;
+					},
+				},
+			};
+		};
+		const attempts = await executeExperimentBatch(f.options);
+		expect(
+			attempts.every((attempt) => attempt.cleanup === (clean ? "not-allocated" : "unresolved")),
+		).toBe(true);
+		expect(f.records.filter((record) => record.kind === "released")).toHaveLength(clean ? 2 : 0);
+		expect(
+			attempts.every((attempt) => attempt.outcome === "failed" && !attempt.measurementStarted),
+		).toBe(true);
+	}
+});

--- a/apps/cli/src/lib/execute-experiment.ts
+++ b/apps/cli/src/lib/execute-experiment.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import type { SandboxDriver, SandboxRef } from "@sandbox-benchmarks/driver";
-import { describeDriverFailure } from "@sandbox-benchmarks/driver";
+import { describeDriverFailure, isRetryableDriverCreate } from "@sandbox-benchmarks/driver";
 import { diagnosticSecretsFromEnv } from "@sandbox-benchmarks/driver/env";
 import { executeSuite } from "@sandbox-benchmarks/harness";
 import {
@@ -117,6 +117,7 @@ export async function executeExperimentBatch(
 				planDigest: plan.digest,
 			};
 			let createStarted = false;
+			let createRejectedCleanly = false;
 			let allocated: SandboxRef | undefined;
 			let allocationRecorded = false;
 			let failure = admissionFailure;
@@ -151,7 +152,11 @@ export async function executeExperimentBatch(
 						if (Date.now() >= startupDeadline)
 							throw new Error("startup deadline exceeded before create");
 						createStarted = true;
-						const session = await opened.driver.create(request, createOptions);
+						const session = await opened.driver.create(request, createOptions).catch((error) => {
+							// This marker guarantees that the failed create left no allocation behind.
+							createRejectedCleanly = isRetryableDriverCreate(error);
+							throw error;
+						});
 						allocated = session.sandboxRef;
 						try {
 							await withinSignal(startupSignal, () =>
@@ -215,7 +220,7 @@ export async function executeExperimentBatch(
 			const cleanup =
 				receipts.cleanup?.completed && receipts.cleanup.confirmedAbsent
 					? "confirmed"
-					: createStarted
+					: createStarted && !createRejectedCleanly
 						? "unresolved"
 						: "not-allocated";
 			try {
@@ -226,8 +231,12 @@ export async function executeExperimentBatch(
 						outcome: "absent",
 						ref: allocated,
 					});
-				// No intent exists for admission failures. A pre-create deadline can leave a safely closable intent.
-				else if (!createStarted && admissionFailure === undefined && drivers.has(cell.provider)) {
+				// Close only intents known to have no remaining allocation; ambiguous create failures stay open.
+				else if (
+					(!createStarted || createRejectedCleanly) &&
+					admissionFailure === undefined &&
+					drivers.has(cell.provider)
+				) {
 					const records = await options.journal.read(cell.quotaDomain);
 					if (records.some((entry) => entry.kind === "intent" && entry.attempt === id))
 						await options.journal.append({ ...intent, kind: "released", outcome: "not-allocated" });


### PR DESCRIPTION
Smoke failure fixes — merge bottom-up: #449 → #450 → #451 → #452 → #453.
This PR is 4/5.

A failed create can prove that no allocation remains, yet execution discarded that classification and left its durable intent unresolved. Preserve the typed clean-create classification at the allocation boundary and release those intents. Ambiguous failures retain unresolved ownership; frozen experiments still record failure and do not retry.

Validation: Regression covers both a typed clean create failure and an unclassified failure. Full typecheck, tests, lint and spell pass. The earlier failed allocation was independently confirmed absent and its journal reconciled.
