### PR TITLE
fix(e2b): leave detached workload deadlines to the harness

### DIFF
--- a/packages/e2b/src/index.test.ts
+++ b/packages/e2b/src/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, spyOn, test } from "bun:test";
 import type { CreateRequest } from "@sandbox-benchmarks/driver";
 import { DriverError, FailedCreateCleanupError, sandboxRef } from "@sandbox-benchmarks/driver";
 import type { ComputeSdkSandboxOf } from "@sandbox-benchmarks/driver/computesdk";
+import type { CommandStartOpts } from "e2b";
 import {
 	AuthenticationError,
 	CommandExitError,
@@ -554,15 +555,12 @@ describe("E2B proof driver", () => {
 		}
 	});
 
-	test("splits foreground results from genuine background acceptance", async () => {
-		const calls: Array<[string, { readonly user?: string; readonly background?: boolean }]> = [];
+	test("background acceptance leaves the workload deadline to the harness", async () => {
+		const calls: Array<[string, CommandStartOpts]> = [];
 		const wrapper = {
 			getInstance: () => ({
 				commands: {
-					run: async (
-						command: string,
-						options: { readonly user?: string; readonly background?: boolean },
-					) => {
+					run: async (command: string, options: CommandStartOpts) => {
 						calls.push([command, options]);
 						return options.background ? { pid: 42 } : { exitCode: 0, stdout: "0\n", stderr: "" };
 					},
@@ -578,7 +576,7 @@ describe("E2B proof driver", () => {
 		expect(await launchE2bCommandAsRoot(wrapper, "daemon")).toBeUndefined();
 		expect(calls).toEqual([
 			["id -u", { user: "root", background: false }],
-			["daemon", { user: "root", background: true }],
+			["daemon", { user: "root", background: true, timeoutMs: 0 }],
 		]);
 	});
 

--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -158,6 +158,8 @@ export async function launchE2bCommandAsRoot(
 	const handle = await sandbox.getInstance().commands.run(command, {
 		user: "root",
 		background: true,
+		// E2B's default 60-second timeout kills the receipt-writing shell. The harness owns this deadline.
+		timeoutMs: 0,
 		...(options?.signal === undefined ? {} : { signal: options.signal }),
 	});
 	if (!Number.isSafeInteger(handle.pid) || handle.pid <= 0) {


### PR DESCRIPTION
Smoke failure fixes — merge bottom-up: #449 → #450 → #451 → #452 → #453.
This PR is 5/5.

E2B's background launch inherited the SDK's 60-second command timeout. It killed the outer shell while the child benchmark continued, leaving completed work without a completion receipt and the harness polling indefinitely until its own deadline. Disable the SDK command timeout for background launches; the harness retains its workload deadline and sandbox cleanup.

Validation: The regression fails before the fix and passes afterward. A live 65-second comparison produced TimeoutError and no receipt with the default, and successful completion with `timeoutMs: 0`. Full typecheck, tests, lint and spell pass.
