### PR TITLE
fix(admission): preserve acknowledged journal commits and recover ref updates

### DIFF
--- a/apps/cli/src/lib/github-account-journal.test.ts
+++ b/apps/cli/src/lib/github-account-journal.test.ts
@@ -1,7 +1,7 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import { type } from "arktype";
 import type { GitRequest } from "./github-account-journal.ts";
-import { githubAccountJournal } from "./github-account-journal.ts";
+import { githubAccountJournal, githubGitRequest } from "./github-account-journal.ts";
 
 const intent = {
 	version: "1",
@@ -88,12 +88,12 @@ test("a transient append failure does not poison later appends or reads", async 
 	let blip = true;
 	const journal = githubAccountJournal((method, path, body) => {
 		if (method === "PATCH" && blip) {
-			blip = false;
 			throw new Error("HTTP 502");
 		}
 		return f.request(method, path, body);
 	});
 	await expect(journal.append(intent)).rejects.toThrow("502");
+	blip = false;
 	// The same client keeps working: the next cell's record lands and reads see it.
 	await journal.append({ ...intent, attempt: "attempt-2" });
 	expect(await journal.read("tama")).toEqual([{ ...intent, attempt: "attempt-2" }]);
@@ -101,13 +101,89 @@ test("a transient append failure does not poison later appends or reads", async 
 });
 test("a competing writer rejects the append rather than forcing the journal ref", async () => {
 	const f = fixture();
+	let competing = false;
 	const journal = githubAccountJournal((method, path, body) => {
-		if (method === "PATCH") {
+		if (method === "GET" && path.startsWith("/git/ref/") && competing)
+			return Promise.resolve({ object: { sha: "f".repeat(40) } });
+		if (method === "PATCH" && competing) {
 			expect(body).toMatchObject({ force: false });
 			throw new Error("HTTP 422");
 		}
 		return f.request(method, path, body);
 	});
-	await expect(journal.append(intent)).rejects.toThrow("422");
+	await journal.append(intent);
+	competing = true;
 	await expect(journal.append({ ...intent, attempt: "attempt-2" })).rejects.toThrow("422");
+	await expect(journal.append({ ...intent, attempt: "attempt-3" })).rejects.toThrow("422");
+});
+
+test("a rejected ref update retries the same commit only while its parent is unchanged", async () => {
+	const f = fixture();
+	let commits = 0;
+	let patches = 0;
+	const journal = githubAccountJournal((method, path, body) => {
+		if (method === "POST" && path === "/git/commits") commits++;
+		if (method === "PATCH" && ++patches === 1) throw new Error("HTTP 422");
+		return f.request(method, path, body);
+	});
+	await journal.append(intent);
+	expect(await journal.read("tama")).toEqual([intent]);
+	expect(commits).toBe(1);
+	expect(patches).toBe(2);
+});
+
+test("a lost acknowledgement is recovered from the exact committed ref without replay", async () => {
+	const f = fixture();
+	let patches = 0;
+	const journal = githubAccountJournal(async (method, path, body) => {
+		const result = await f.request(method, path, body);
+		if (method === "PATCH") {
+			patches++;
+			throw new Error("response lost");
+		}
+		return result;
+	});
+	await journal.append(intent);
+	expect(await journal.read("tama")).toEqual([intent]);
+	expect(patches).toBe(1);
+});
+
+test("GitHub rejection diagnostics preserve the reason and request ID", async () => {
+	const fetch = spyOn(globalThis, "fetch").mockResolvedValue(
+		new Response(JSON.stringify({ message: "Update is not a fast forward" }), {
+			status: 422,
+			headers: { "x-github-request-id": "request-123" },
+		}),
+	);
+	try {
+		const request = githubGitRequest({ GITHUB_REPOSITORY: "owner/repo", GH_TOKEN: "test-token" });
+		await expect(request("PATCH", "/git/refs/heads/journal", {})).rejects.toThrow(
+			"HTTP 422: Update is not a fast forward [request request-123]",
+		);
+	} finally {
+		fetch.mockRestore();
+	}
+});
+
+test("an acknowledged append remains the parent when a subsequent ref read is stale", async () => {
+	const f = fixture();
+	const reads = new Map<string, unknown>();
+	let stale = false;
+	let head = "a".repeat(40);
+	let parent = "";
+	const journal = githubAccountJournal(async (method, path, body) => {
+		if (method === "GET" && stale && reads.has(path)) return structuredClone(reads.get(path));
+		if (method === "POST" && path === "/git/commits")
+			parent = type({ parents: ["string"] }).assert(body).parents[0];
+		if (method === "PATCH" && parent !== head) throw new Error("HTTP 422: not a fast forward");
+		const result = await f.request(method, path, body);
+		if (method === "GET") reads.set(path, structuredClone(result));
+		if (method === "PATCH") head = type({ object: { sha: "string" } }).assert(result).object.sha;
+		return result;
+	});
+	await journal.append(intent);
+	stale = true;
+	await journal.append({ ...intent, attempt: "attempt-2" });
+	stale = false;
+	expect(await journal.read("tama")).toHaveLength(2);
 });

--- a/apps/cli/src/lib/github-account-journal.ts
+++ b/apps/cli/src/lib/github-account-journal.ts
@@ -10,6 +10,7 @@ const tree = type({
 	tree: type({ path: "string", type: "string", sha: /^[a-f0-9]{40}$/ }).array(),
 });
 const blob = type({ encoding: "'base64'", content: "string <= 16000000" });
+const responseError = type({ message: "string <= 2000" });
 const journalSchema = type({
 	schemaVersion: "'1'",
 	account: "string",
@@ -45,6 +46,7 @@ export function githubAccountJournal(
 			throw new Error("journal account provenance mismatch");
 		return { head, baseTree, journal };
 	};
+	const acknowledged = new Map<string, Awaited<ReturnType<typeof snapshot>>>();
 	return {
 		async read(account) {
 			if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(account))
@@ -55,7 +57,10 @@ export function githubAccountJournal(
 		append(raw) {
 			const record = accountRecordSchema.assert(raw);
 			const pending = tail.then(async () => {
-				const state = await snapshot(record.account);
+				// Chain our own acknowledged writes without depending on ref read-after-write consistency.
+				// A competing writer still fails the non-forced ref update below.
+				const state = acknowledged.get(record.account) ?? (await snapshot(record.account));
+				const nextJournal = { ...state.journal, records: [...state.journal.records, record] };
 				const path = "journal.json";
 				if (
 					state.journal.records.some(
@@ -71,7 +76,7 @@ export function githubAccountJournal(
 								path,
 								mode: "100644",
 								type: "blob",
-								content: `${JSON.stringify({ ...state.journal, records: [...state.journal.records, record] })}\n`,
+								content: `${JSON.stringify(nextJournal)}\n`,
 							},
 						],
 					}),
@@ -83,15 +88,42 @@ export function githubAccountJournal(
 						parents: [state.head],
 					}),
 				);
-				// Never force: another writer advancing the branch makes this append fail closed.
-				const updated = reference.assert(
-					await request("PATCH", `/git/refs/heads/${branch}-${record.account}`, {
-						sha: nextCommit.sha,
-						force: false,
-					}),
-				);
+				let response: unknown;
+				for (let attempt = 0; ; attempt++) {
+					try {
+						response = await request("PATCH", `/git/refs/heads/${branch}-${record.account}`, {
+							sha: nextCommit.sha,
+							force: false,
+						});
+						break;
+					} catch (error) {
+						if (attempt >= 2) throw error;
+						let observed: string;
+						try {
+							observed = reference.assert(
+								await request("GET", `/git/ref/heads/${branch}-${record.account}`),
+							).object.sha;
+						} catch {
+							throw error;
+						}
+						// A lost response is settled by the exact commit, never by guessing or forcing.
+						if (observed === nextCommit.sha) {
+							response = { object: { sha: observed } };
+							break;
+						}
+						// Retry only the same conditional ref update. A competing writer fails closed.
+						if (observed !== state.head) throw error;
+						await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
+					}
+				}
+				const updated = reference.assert(response);
 				if (updated.object.sha !== nextCommit.sha)
 					throw new Error("journal append was not acknowledged");
+				acknowledged.set(record.account, {
+					head: nextCommit.sha,
+					baseTree: nextTree.sha,
+					journal: nextJournal,
+				});
 			});
 			// The chain only orders appends; it must not carry their outcomes. A rejected tail would skip
 			// every later append's callback and fail every read with the first (possibly transient)
@@ -119,8 +151,14 @@ export function githubGitRequest(env: NodeJS.ProcessEnv = process.env): GitReque
 			...(body === undefined ? {} : { body: JSON.stringify(body) }),
 			signal: AbortSignal.timeout(20_000),
 		});
-		if (!response.ok)
-			throw new Error(`account journal ${method} HTTP ${response.status}; allocation blocked`);
+		if (!response.ok) {
+			const payload = responseError(await response.json().catch(() => null));
+			const detail = payload instanceof type.errors ? "" : `: ${payload.message}`;
+			const requestId = response.headers.get("x-github-request-id");
+			throw new Error(
+				`account journal ${method} HTTP ${response.status}${detail}${requestId ? ` [request ${requestId}]` : ""}; allocation blocked`,
+			);
+		}
 		return response.json();
 	};
 }


### PR DESCRIPTION
Concurrent benchmark replicas can fail an account-journal append with GitHub HTTP 422 before measurement. Chain this writer’s appends from its last acknowledged commit, avoiding stale ref reads between its own writes. Preserve the GitHub error message and request ID for future diagnosis.

For a failed ref update, retry only the same candidate commit while the ref remains at the original parent, or accept an exact observed candidate as a lost acknowledgement. A different head still fails closed; updates remain fast-forward only. This does not retry benchmark allocations or measurements.

Regression tests reproduce stale reads, transient ref rejection, lost acknowledgements, and competing writers. The original live 422 response body was unavailable, so its precise cause remains unconfirmed. Full typecheck, test, lint, and spelling checks pass; GitHub CI is green.
