### PR TITLE
fix(planner): overlap suites within account capacity

### DIFF
--- a/apps/cli/src/lib/execute-experiment.test.ts
+++ b/apps/cli/src/lib/execute-experiment.test.ts
@@ -241,3 +241,59 @@ test("a typed clean create refusal releases its intent while an ambiguous failur
 		).toBe(true);
 	}
 });
+
+test("different suites enter measurement together and retain independent attempt identities", async () => {
+	const f = await fixture("mixed-suites");
+	const mixed = workflowExperiment(
+		{
+			GITHUB_RUN_ID: "mixed",
+			GITHUB_SHA: plan.sha,
+			BENCH_PROVIDERS: "tama",
+			BENCH_SUITES: "cpu-node,memory",
+			BENCH_REPLICAS: "1",
+			BENCH_ACCOUNT_CAPACITY: '{"tama":{"sandboxes":2}}',
+		},
+		"2026-09-10",
+	);
+	const opened = await f.options.open();
+	const started = new Set<string>();
+	const gate = Promise.withResolvers<void>();
+	const timeout = setTimeout(() => gate.reject(new Error("suites did not overlap")), 2000);
+	try {
+		const attempts = await executeExperimentBatch({
+			...f.options,
+			plan: mixed,
+			open: async () => ({
+				...opened,
+				driver: {
+					...opened.driver,
+					create: async (...args) => {
+						const session = await opened.driver.create(...args);
+						return {
+							...session,
+							exec: async (command, options) => {
+								if (command.includes("benchmark:cpu") || command.includes("benchmark:memory")) {
+									started.add(session.sandboxRef.id);
+									if (started.size === 2) gate.resolve();
+									await gate.promise;
+								}
+								return session.exec(command, options);
+							},
+						};
+					},
+				},
+			}),
+		});
+		expect(started.size).toBe(2);
+		expect(f.peak()).toBe(2);
+		expect(attempts.map((attempt) => attempt.cellId)).toEqual(mixed.cells.map((cell) => cell.id));
+		expect(
+			attempts.every((attempt) => attempt.measurementStarted && attempt.cleanup === "confirmed"),
+		).toBe(true);
+		// The CPU-only fixture cannot fabricate the missing memory metrics.
+		expect(batchIsComplete(mixed, f.options.root, attempts)).toBe(false);
+		expect(f.present.size).toBe(0);
+	} finally {
+		clearTimeout(timeout);
+	}
+});

--- a/apps/cli/src/lib/experiment-plan.test.ts
+++ b/apps/cli/src/lib/experiment-plan.test.ts
@@ -528,3 +528,45 @@ test("stock boots do not require verification of an artifact they never requeste
 	attempt.evidence.runDigest = evidenceDigest(attempt.run);
 	expect(evaluateExperiment(stockPlan, [attempt]).complete).toBe(true);
 });
+
+test("mixed suites share resource-bounded waves with the longest member budget", () => {
+	const cells = [
+		cell(),
+		{
+			...cell(),
+			id: "e2b-system-r0",
+			suite: "system",
+			workloadRevision: "system-fixed-v1",
+			workloadMinutes: 60,
+			passes: 1,
+		},
+		cell(1),
+	];
+	const result = planExperiment(
+		{ id: "mixed", sha, createdOn: "2026-09-10", cells },
+		{ "e2b-benchmark": { sandboxes: 30, vcpus: 8, memoryGb: 16 } },
+	);
+	expect(result.batches.map((batch) => batch.cells)).toEqual([
+		["e2b-memory-r0", "e2b-system-r0"],
+		["e2b-memory-r1"],
+	]);
+	expect(result.batches.map((batch) => batch.budgetMinutes)).toEqual([105, 85]);
+});
+
+test("different allocation requirements stay in separate waves", () => {
+	for (const change of [
+		{ artifactIdentity: "other" },
+		{ environmentRevision: "other" },
+		{ startupMinutes: 30 },
+	]) {
+		const cells = [
+			cell(),
+			{ ...cell(), id: "e2b-system-r0", suite: "system", workloadRevision: "system-v1", ...change },
+		];
+		const result = planExperiment(
+			{ id: "mixed", sha, createdOn: "2026-09-10", cells },
+			{ "e2b-benchmark": { sandboxes: 30 } },
+		);
+		expect(result.batches).toHaveLength(2);
+	}
+});

--- a/apps/cli/src/lib/experiment-plan.ts
+++ b/apps/cli/src/lib/experiment-plan.ts
@@ -18,6 +18,19 @@ export interface AccountCapacity {
  */
 export const ROUND_BATCH_LIMIT = 64;
 
+// Suite workloads retain their own identities and deadlines inside a concurrent wave.
+function allocationIdentity(cell: ExperimentCell): string {
+	return evidenceDigest({
+		provider: cell.provider,
+		quotaDomain: cell.quotaDomain,
+		target: cell.target,
+		gpu: cell.gpu ?? null,
+		artifactIdentity: cell.artifactIdentity,
+		environmentRevision: cell.environmentRevision,
+		startupMinutes: cell.startupMinutes,
+	});
+}
+
 /** Pure admission planning. No credential reads, remote calls, or implicit wall-clock input. */
 export function planExperiment(
 	request: {
@@ -53,7 +66,7 @@ export function planExperiment(
 		if (cap < 1) throw new Error(`target exceeds account capacity: ${cell.id}`);
 		const budgetMinutes = cell.startupMinutes + cell.workloadMinutes + cell.finishMinutes + 15;
 		if (budgetMinutes > 180) throw new Error(`replicate cannot fit a 180-minute job: ${cell.id}`);
-		// A batch is one simultaneous wave of identical requests. Never hide serial waves in a job.
+		// A batch is one simultaneous wave of compatible allocations. Never hide serial waves in a job.
 		const previous = batches.at(-1);
 		const first = cells.find((entry) => entry.id === previous?.cells[0]);
 		if (
@@ -62,11 +75,10 @@ export function planExperiment(
 			previous.quotaDomain === cell.quotaDomain &&
 			previous.cells.length < cap &&
 			first.provider === cell.provider &&
-			first.suite === cell.suite &&
-			evidenceDigest({ ...first, id: "", replicate: 0 }) ===
-				evidenceDigest({ ...cell, id: "", replicate: 0 })
+			allocationIdentity(first) === allocationIdentity(cell)
 		) {
 			previous.cells.push(cell.id);
+			previous.budgetMinutes = Math.max(previous.budgetMinutes, budgetMinutes);
 		} else {
 			batches.push({
 				id: `batch-${batches.length}`,

--- a/apps/cli/src/lib/workflow-experiment.test.ts
+++ b/apps/cli/src/lib/workflow-experiment.test.ts
@@ -25,9 +25,12 @@ test("workflow planning preserves samples and defaults shared accounts to one sa
 	]);
 });
 test("convergence and implicit per-cell quota overrides fail admission", () => {
-	expect(() => workflowExperiment({ ...env, BENCH_SUITES: "memory" }, "2026-09-10")).toThrow(
-		"convergence",
-	);
+	expect(() =>
+		workflowExperiment(
+			{ ...env, BENCH_SUITES: "memory", BENCH_PTS_PASSES: "converge" },
+			"2026-09-10",
+		),
+	).toThrow("convergence");
 	expect(() => workflowExperiment({ ...env, BENCH_MAX_CONCURRENCY: "12" }, "2026-09-10")).toThrow(
 		"retired",
 	);
@@ -39,4 +42,30 @@ test("large account cohorts partition into bounded collection rounds", () => {
 	);
 	expect(plan.rounds.map((round) => round.batches.length)).toEqual([64, 64, 64, 64, 1]);
 	expect(plan.cells.at(-1)?.replicate).toBe(256);
+});
+
+test("full provider plans overlap suites under the account cap without adding replicas", () => {
+	const plan = workflowExperiment(
+		{
+			...env,
+			BENCH_PROVIDERS: "e2b",
+			BENCH_SUITES: "",
+			BENCH_ACCOUNT_CAPACITY: JSON.stringify({ e2b: { sandboxes: 30 } }),
+		},
+		"2026-09-10",
+	);
+	expect(plan.cells).toHaveLength(54);
+	expect(plan.batches.map((batch) => batch.cells.length)).toEqual([30, 24]);
+	for (const suite of new Set(plan.cells.map((cell) => cell.suite))) {
+		const cells = plan.cells.filter((cell) => cell.suite === suite);
+		const realworld = suite.startsWith("realworld-");
+		expect(cells.map((cell) => cell.replicate)).toEqual(
+			Array.from({ length: realworld ? 12 : 3 }, (_, i) => i),
+		);
+		expect(cells.every((cell) => cell.passes === (realworld ? 1 : 2))).toBe(true);
+	}
+	expect(workflowAxes(plan, "e2b", plan.rounds[0]?.id)).toEqual([
+		{ batch: "batch-0", provider: "e2b", suite: "mixed" },
+		{ batch: "batch-1", provider: "e2b", suite: "mixed" },
+	]);
 });

--- a/apps/cli/src/lib/workflow-experiment.ts
+++ b/apps/cli/src/lib/workflow-experiment.ts
@@ -46,10 +46,7 @@ export function workflowExperiment(env: NodeJS.ProcessEnv, createdOn: string): E
 		);
 		for (const suiteName of selectSuites(env.BENCH_SUITES)) {
 			const suite = SUITES[suiteName];
-			if (
-				passOverride === "converge" ||
-				(!passOverride && "ptsConverge" in suite && suite.ptsConverge)
-			)
+			if (passOverride === "converge")
 				throw new Error(
 					`${suiteName}: convergence is not admitted for bounded publication; select an explicitly versioned fixed-pass experiment`,
 				);
@@ -105,6 +102,9 @@ export function workflowAxes(plan: ExperimentPlan, account?: string, round?: str
 		const cell = plan.cells.find((entry) => entry.id === batch?.cells[0]);
 		if (!batch || !cell || batch.quotaDomain !== quotaDomain(cell.provider))
 			throw new Error("invalid workflow quota domain");
-		return { batch: id, provider: cell.provider, suite: cell.suite };
+		const suites = new Set(
+			plan.cells.filter((entry) => batch.cells.includes(entry.id)).map((entry) => entry.suite),
+		);
+		return { batch: id, provider: cell.provider, suite: suites.size === 1 ? cell.suite : "mixed" };
 	});
 }

--- a/docs/benchmark-execution-rollout.md
+++ b/docs/benchmark-execution-rollout.md
@@ -59,10 +59,18 @@ This is an implementation status record, not a claim that the live fleet meets t
 
 Matrix and smoke now freeze one immutable plan and dispatch account → collection round → batch.
 Every allocating worker verifies the plan and source revision, reconciles its account once, and runs
-one bounded wave through the existing harness and normalizer. The account and round matrices use
-`max-parallel: 1`; independent accounts can proceed together. Fixed suite defaults and replicate
-indices are preserved. Convergence is rejected by publication planning until its separately reviewed
-measurement revision is admitted; an explicit fixed-pass input is part of the workload identity.
+one bounded wave through the existing harness and normalizer. Different suites with compatible
+provider allocations share a wave up to the account's sandbox and resource caps. Each cell retains
+its suite, replica index, pass count, and phase deadlines; the batch reserves the longest member's
+budget. Collection rounds proceed sequentially, and the account concurrency group serializes batches;
+independent accounts can proceed together.
+
+Bounded publication uses each suite's fixed pass default (two unless the suite declares another
+count). An explicit fixed-pass override changes every selected suite's workload identity; explicit
+convergence remains inadmissible. With a 30-sandbox cap, all nine suites use 54 sandboxes per provider
+in waves of 30 and 24, preserving three replicas per synthetic suite and twelve per real-world suite.
+These are peak wave sizes, not a promise of 30 continuously occupied slots: the next batch waits for
+all current members and cleanup to finish. Scheduling changes apply only to newly frozen plans.
 
 Each attempt uploads independently. The CLI performs those uploads (and the plan's) through
 `@actions/artifact`, which needs the run-scoped artifact runtime GitHub injects only into action


### PR DESCRIPTION
A 30-sandbox account cap still produced only three concurrent synthetic replicas because batches were restricted to one suite. Pack different suites with compatible provider allocations into the same bounded wave, preserving each cell’s workload identity, replica index, pass count, deadlines, and evidence.

The nine-suite default now plans 54 sandboxes per provider in waves of 30 and 24, instead of nine separate suite jobs. Bounded publication uses each suite’s fixed pass default, allowing synthetic and real-world suites in one workflow. Explicit convergence remains rejected. Resource caps and exclusive account ownership remain enforced; each wave waits for all members and cleanup before advancing. Already-frozen experiments retain their original schedule.

Validation: full typecheck, test, lint, and spelling checks pass. Regression tests cover mixed-suite grouping, resource limits, maximum phase budgets, unchanged replica/pass counts, and simultaneous measurement through the real executor with separate attempt evidence. Depends on the journal consistency repair below this PR before increasing concurrent allocations.
