### PR TITLE
fix(execution): retain allocation identity after journal failure

### DIFF
--- a/apps/cli/src/lib/execute-experiment.test.ts
+++ b/apps/cli/src/lib/execute-experiment.test.ts
@@ -297,3 +297,45 @@ test("different suites enter measurement together and retain independent attempt
 		clearTimeout(timeout);
 	}
 });
+
+test("a rejected allocation journal append retains recovery identity without admitting measurement", async () => {
+	const f = await fixture("allocation-journal-failure");
+	const attempts = await executeExperimentBatch({
+		...f.options,
+		journal: {
+			...f.options.journal,
+			append: async (record) => {
+				if (record.kind === "allocated") throw new Error("journal allocation rejected");
+				await f.options.journal.append(record);
+			},
+		},
+	});
+	expect(attempts).toHaveLength(2);
+	expect(
+		attempts.every(
+			(attempt) =>
+				!attempt.measurementStarted &&
+				attempt.cleanup === "unresolved" &&
+				attempt.outcome === "failed",
+		),
+	).toBe(true);
+	expect(f.records.every((record) => record.kind === "intent")).toBe(true);
+	expect(f.present.size).toBe(0);
+	for (const attempt of attempts) {
+		const allocation = JSON.parse(
+			readFileSync(join(f.options.root, attempt.id, "raw", "allocation.json"), "utf8"),
+		);
+		expect(allocation).toMatchObject({
+			kind: "allocated",
+			attempt: attempt.id,
+			cellId: attempt.cellId,
+			planDigest: plan.digest,
+			account: "tama",
+			ref: { provider: "tama" },
+		});
+		expect(allocation.ref.id).toMatch(/^sandbox-[12]$/);
+		expect(readExperimentAttempt(join(f.options.root, attempt.id)).evidence.rawDigest).toBe(
+			attempt.rawDigest,
+		);
+	}
+});

--- a/apps/cli/src/lib/execute-experiment.ts
+++ b/apps/cli/src/lib/execute-experiment.ts
@@ -159,9 +159,15 @@ export async function executeExperimentBatch(
 						});
 						allocated = session.sandboxRef;
 						try {
-							await withinSignal(startupSignal, () =>
-								options.journal.append({ ...intent, kind: "allocated", ref: session.sandboxRef }),
-							);
+							const allocation: AccountRecord = {
+								...intent,
+								kind: "allocated",
+								ref: session.sandboxRef,
+							};
+							// Preserve vendor identity for operator recovery even if the durable append fails.
+							// This artifact is evidence only; it never substitutes for journal admission.
+							writeImmutableJson(join(raw, "allocation.json"), allocation);
+							await withinSignal(startupSignal, () => options.journal.append(allocation));
 							allocationRecorded = true;
 						} catch (error) {
 							// The harness has not received this session yet. Retain the original journal failure.


### PR DESCRIPTION
An allocation can succeed before its durable journal append fails. The harness has not received the session yet, so its usual execution receipt cannot retain the vendor identity. That left operators with an unresolved intent and no resource reference in the uploaded attempt evidence.

Persist the identity-bound allocation record in the attempt's raw directory before appending it to the account journal. It is included in the immutable raw digest and uploaded with the failed attempt. The journal remains authoritative: a rejected append still blocks measurement, attempts cleanup, and leaves ownership unresolved for verified operator recovery. This cannot recover identifiers missing from past attempts or survive a worker loss before artifact upload.

Validation: a regression test reproduces the rejected append and verifies the retained identity, blocked measurement, attempted cleanup, unresolved journal, and intact attempt digest. Full repository typecheck, tests, lint, and spelling pass.
