### PR TITLE
fix(benchmarks): preserve fio bandwidth units and GiB trials

### DIFF
--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -757,6 +757,16 @@ install_vendored_pts_profile() {
 	echo "Staged vendored PTS override: ${profile_dst} (removed ${installed_dst})"
 }
 
+# Stage only fio's result definitions after installation. Keep the compiled binary and upstream
+# install metadata; each new PTS process resolves the local profile before its upstream cache.
+_stage_fio_pts_parser() {
+	local destination
+	destination="$(pts_user_dir)/test-profiles/pts/fio-2.1.0" || return 1
+	mkdir -p "$destination" || return 1
+	cp "${REPO_ROOT}/packages/schema/src/pts-profiles/fio-2.1.0/test-definition.xml" "$destination/" || return 1
+	cp "${REPO_ROOT}/packages/schema/src/pts-profiles/fio-2.1.0/results-definition.xml" "$destination/"
+}
+
 # Count the <Value> elements in a PTS composite whose content is a plain number. Failed PTS trials
 # leave empty <Value></Value> elements behind while batch-run still exits 0, so this count is the
 # only in-sandbox signal separating a measured composite from an all-trials-failed one. Always
@@ -837,6 +847,10 @@ run_pts_benchmark() {
 			skip_result "PTS install of ${test_name} failed (exit 0, not in list-installed-tests)" "$prefix"
 			return 0
 		fi
+	fi
+
+	if [ "$test_name" = "pts/fio-2.1.0" ]; then
+		_stage_fio_pts_parser || return 1
 	fi
 
 	# Stamp the instant before the run: the composite search below must only accept output THIS

--- a/lib/pts/fio/README.md
+++ b/lib/pts/fio/README.md
@@ -1,0 +1,21 @@
+# fio result parser repair
+
+The pinned upstream fio profile drops bandwidth trials reported in GiB/s. Its older KiB/s and MiB/s
+conversions also do not match the declared decimal MB/s scale. The vendored parser converts KiB/s,
+MiB/s, and GiB/s to MB/s using 0.001024, 1.048576, and 1073.741824 respectively; IOPS stays unchanged.
+The benchmark stages these definitions after installation, preserving the installed fio executable.
+
+This is a prospective measurement revision, bound to the source revision in each new experiment.
+It does not rewrite historical values or supply missing historical samples. Compare runs only within
+matching workload revisions. The separate direct/buffered eligibility contract and PTS's cross-scale
+numeric deduplication remain independent concerns.
+
+Exercise the actual pinned PTS parser without running a benchmark:
+
+```sh
+php lib/pts/fio/parser-selftest.php /path/to/phoronix-test-suite-10.8.4
+```
+
+The self-test requires PHP with XML support and the PTS 10.8.4 source tree. It checks exact conversions
+for all three bandwidth units and preserves numeric and abbreviated IOPS values. The ordinary Bun
+suite also verifies that staging replaces stale definitions without deleting the installed executable.

--- a/lib/pts/fio/parser-selftest.php
+++ b/lib/pts/fio/parser-selftest.php
@@ -1,0 +1,34 @@
+<?php
+// Run with PHP and the pinned PTS 10.8.4 source directory as argv[1]. No benchmark is executed.
+error_reporting(E_ERROR | E_PARSE);
+define('PTS_MODE', 'SILENT');
+define('PTS_AUTO_LOAD_OBJECTS', true);
+define('PTS_AUTO_LOAD_ALL_OBJECTS', true);
+require $argv[1] . '/pts-core/phoronix-test-suite.php';
+define('PTS_TEST_PROFILE_PATH', dirname(__DIR__, 3) . '/packages/schema/src/pts-profiles/');
+$cases = [
+    ['1024KiB/s', '17', 1.048576, 17],
+    ['9758MiB/s', '9756', 10232.004608, 9756],
+    ['12.9GiB/s', '13.2k', 13851.2695296, 13200],
+];
+foreach ($cases as [$bandwidth, $iops, $expectedBandwidth, $expectedIops]) {
+    $profile = new pts_test_profile('fio-2.1.0', null, false);
+    $result = new pts_test_result($profile);
+    $log = tempnam(sys_get_temp_dir(), 'fio-parser-');
+    try {
+        file_put_contents($log, "  read: IOPS=$iops, BW=$bandwidth (10.2GB/s)(572GiB/60004msec)\n   READ: bw=$bandwidth (10.2GB/s), io=572GiB (614GB), run=60004-60004msec\n");
+        pts_test_result_parser::parse_result($result, $log);
+        $actual = [];
+        foreach ($result->generated_result_buffers as $entry) {
+            $actual[$entry->test_profile->get_result_scale()] = $entry->active->results;
+        }
+        foreach (['MB/s' => $expectedBandwidth, 'IOPS' => $expectedIops] as $scale => $expected) {
+            if (!isset($actual[$scale]) || count($actual[$scale]) !== 1 || abs($actual[$scale][0] - $expected) > 0.000001) {
+                throw new RuntimeException("$bandwidth: incorrect $scale samples: " . json_encode($actual));
+            }
+        }
+    } finally {
+        unlink($log);
+    }
+}
+echo "PTS fio parser: KiB/s, MiB/s, GiB/s and IOPS passed\n";

--- a/packages/schema/src/pts-profiles/fio-2.1.0/results-definition.xml
+++ b/packages/schema/src/pts-profiles/fio-2.1.0/results-definition.xml
@@ -6,7 +6,7 @@
     <LineHint>: bw=</LineHint>
     <ResultAfterString>bw</ResultAfterString>
     <StripFromResult>KiB/s</StripFromResult>
-    <DivideResultBy>1000</DivideResultBy>
+    <MultiplyResultBy>0.001024</MultiplyResultBy>
     <ResultScale>MB/s</ResultScale>
     <ResultProportion>HIB</ResultProportion>
   </ResultsParser>
@@ -15,6 +15,16 @@
     <LineHint>: bw=</LineHint>
     <ResultAfterString>bw</ResultAfterString>
     <StripFromResult>MiB/s</StripFromResult>
+    <MultiplyResultBy>1.048576</MultiplyResultBy>
+    <ResultScale>MB/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>   READ: bw=#_RESULT_# (861MB/s), 821MiB/s-821MiB/s (861MB/s-861MB/s), io=16.4GiB (17.3GB), run=20002-20002msec</OutputTemplate>
+    <LineHint>: bw=</LineHint>
+    <ResultAfterString>bw</ResultAfterString>
+    <StripFromResult>GiB/s</StripFromResult>
+    <MultiplyResultBy>1073.741824</MultiplyResultBy>
     <ResultScale>MB/s</ResultScale>
     <ResultProportion>HIB</ResultProportion>
   </ResultsParser>

--- a/tooling/repo-checks/src/fio-parser-staging.test.ts
+++ b/tooling/repo-checks/src/fio-parser-staging.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findRepoRoot } from "./lib/workspace.ts";
+
+test("fio parser staging replaces stale definitions without deleting the installed executable", () => {
+	const root = findRepoRoot();
+	const temporary = mkdtempSync(join(tmpdir(), "fio-parser-"));
+	try {
+		const profile = join(temporary, "test-profiles/pts/fio-2.1.0");
+		const installed = join(temporary, "installed-tests/pts/fio-2.1.0");
+		mkdirSync(profile, { recursive: true });
+		mkdirSync(installed, { recursive: true });
+		writeFileSync(join(profile, "results-definition.xml"), "stale");
+		writeFileSync(join(installed, "fio-run"), "compiled executable");
+		const result = Bun.spawnSync(
+			[
+				"bash",
+				"-euc",
+				'source "$REPO_ROOT/lib/bench.sh"; pts_user_dir() { echo "$TEST_PTS_ROOT"; }; _stage_fio_pts_parser',
+			],
+			{ env: { ...process.env, REPO_ROOT: root, TEST_PTS_ROOT: temporary } },
+		);
+		expect(result.exitCode).toBe(0);
+		for (const file of ["test-definition.xml", "results-definition.xml"]) {
+			expect(readFileSync(join(profile, file), "utf8")).toBe(
+				readFileSync(join(root, "packages/schema/src/pts-profiles/fio-2.1.0", file), "utf8"),
+			);
+		}
+		expect(readFileSync(join(installed, "fio-run"), "utf8")).toBe("compiled executable");
+	} finally {
+		rmSync(temporary, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
A fast fio trial can report `12.9GiB/s`; the pinned PTS parser recognizes only KiB/s and MiB/s, so the trial disappears from the result XML despite successful execution. Add GiB/s parsing and convert all three binary units to the declared decimal MB/s scale. For example, 12.9 GiB/s becomes 13851.2695296 MB/s. IOPS remains unchanged.

Stage the vendored definitions after fio installation so both baked and newly installed sandboxes use the repair without rebuilding the executable. This is a prospective measurement revision, bound to each new experiment's source revision. Historical values and missing historical samples are not rewritten. Existing KiB/s and MiB/s bandwidth values change because their previous conversions did not match the declared unit; comparison must remain within matching workload revisions.

Validation: reproduced the missing bandwidth result with the actual PTS 10.8.4 parser, then passed its KiB/s, MiB/s, GiB/s and IOPS self-test in an offline Docker container. A Bun regression verifies stale-definition replacement and executable preservation. Full typecheck, tests, lint, spelling, catalog drift and shell checks pass.

This does not resolve the separate direct/buffered eligibility mismatch or PTS cross-scale numeric deduplication. Fresh provider verification remains required before publication.
