### PR TITLE
fix(benchmarks): retain equal-valued PTS metrics by identity

### DIFF
--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -853,6 +853,14 @@ run_pts_benchmark() {
 		_stage_fio_pts_parser || return 1
 	fi
 
+	# The supported toolchain installs PTS under the launcher's ../share directory. Repair only the
+	# checksum-pinned parser; an unknown installation fails before measurement rather than losing data.
+	local pts_parser
+	pts_parser="$(dirname "$(command -v phoronix-test-suite)")/../share/phoronix-test-suite/pts-core/objects/pts_test_result_parser.php"
+	# SUDO deliberately contains either no words or the configured sudo command and flags.
+	# shellcheck disable=SC2086
+	${SUDO:-} php "${REPO_ROOT}/lib/pts/patches/result-parser.php" "$pts_parser" || return 1
+
 	# Stamp the instant before the run: the composite search below must only accept output THIS
 	# batch-run wrote. Suites now run several PTS leaves in one sandbox (fio ×4 + hardlink; pybench +
 	# sqlite + pgbench ×2), so a bare "newest composite" would, when a later batch-run produces

--- a/lib/pts/fio/README.md
+++ b/lib/pts/fio/README.md
@@ -7,12 +7,13 @@ The benchmark stages these definitions after installation, preserving the instal
 
 This is a prospective measurement revision, bound to the source revision in each new experiment.
 It does not rewrite historical values or supply missing historical samples. Compare runs only within
-matching workload revisions. The separate direct/buffered eligibility contract and PTS's cross-scale
-numeric deduplication remain independent concerns.
+matching workload revisions. The separate direct/buffered eligibility contract remains an independent concern. The
+[PTS identity repair](../patches/README.md) handles equal-valued metrics without changing their values.
 
 Exercise the actual pinned PTS parser without running a benchmark:
 
 ```sh
+php lib/pts/patches/result-parser.php /path/to/phoronix-test-suite-10.8.4/pts-core/objects/pts_test_result_parser.php
 php lib/pts/fio/parser-selftest.php /path/to/phoronix-test-suite-10.8.4
 ```
 

--- a/lib/pts/fio/parser-selftest.php
+++ b/lib/pts/fio/parser-selftest.php
@@ -8,6 +8,7 @@ require $argv[1] . '/pts-core/phoronix-test-suite.php';
 define('PTS_TEST_PROFILE_PATH', dirname(__DIR__, 3) . '/packages/schema/src/pts-profiles/');
 $cases = [
     ['1024KiB/s', '17', 1.048576, 17],
+    ['976.5625KiB/s', '1', 1, 1],
     ['9758MiB/s', '9756', 10232.004608, 9756],
     ['12.9GiB/s', '13.2k', 13851.2695296, 13200],
 ];

--- a/lib/pts/patches/README.md
+++ b/lib/pts/patches/README.md
@@ -1,0 +1,20 @@
+# PTS result identity repair
+
+PTS 10.8.4 deduplicates results by numeric value across all parser blocks. Two different metrics
+with equal numbers therefore lose one observation. The repair keys that existing deduplication by
+PTS's own comparison hash, which already identifies each result buffer. Equal values within one
+metric remain deduplicated; equal values across different metrics survive unchanged.
+
+The PHP patcher accepts only the exact upstream 10.8.4 parser or its own repaired bytes. Unknown
+revisions fail before measurement. Replacement is atomic and preserves file permissions. The
+benchmark invokes it against the supported packaged PTS installation before each PTS measurement;
+repeated calls are harmless. This does not reconstruct lost historical data.
+
+To verify offline, copy a PTS 10.8.4 source tree, apply the repair, then run the real parser regression:
+
+```sh
+php lib/pts/patches/result-parser.php /path/to/pts/pts-core/objects/pts_test_result_parser.php
+php lib/pts/fio/parser-selftest.php /path/to/pts
+```
+
+The equal-value fixture must retain both 1 MB/s and 1 IOPS. The unmodified parser drops IOPS.

--- a/lib/pts/patches/result-parser.php
+++ b/lib/pts/patches/result-parser.php
@@ -1,0 +1,40 @@
+<?php
+// Narrow repair for PTS 10.8.4: equal values from distinct metric identities are not duplicates.
+// Usage: php result-parser.php /path/to/pts_test_result_parser.php
+$path = $argv[1] ?? '';
+$source = @file_get_contents($path);
+if ($source === false) {
+    throw new RuntimeException('Cannot read the pinned PTS result parser');
+}
+$originalHash = '12705541b1876fda4790210997b39265994e4991d18dbd13cbfe830d8b0bea92';
+$before = [
+    'if(in_array($test_result, $avoid_duplicates))',
+    '$avoid_duplicates[] = $test_result;',
+];
+$after = [
+    'if(in_array($test_result, $avoid_duplicates[$tr->get_comparison_hash(true, false)] ?? array()))',
+    '$avoid_duplicates[$tr->get_comparison_hash(true, false)][] = $test_result;',
+];
+// Accept only the original pinned bytes or exactly this repair; never patch an unknown version.
+$restored = str_replace($after, $before, $source, $restoredCount);
+if ($restoredCount === 2 && hash('sha256', $restored) === $originalHash) {
+    exit(0);
+}
+if (hash('sha256', $source) !== $originalHash) {
+    throw new RuntimeException('Unsupported PTS result parser revision');
+}
+$patched = str_replace($before, $after, $source, $count);
+if ($count !== 2) {
+    throw new RuntimeException('PTS result parser repair did not match');
+}
+$temporary = tempnam(dirname($path), '.pts-parser-');
+try {
+    if ($temporary === false || file_put_contents($temporary, $patched) !== strlen($patched)
+        || !chmod($temporary, fileperms($path) & 0777) || !rename($temporary, $path)) {
+        throw new RuntimeException('Could not persist PTS result parser repair');
+    }
+} finally {
+    if ($temporary !== false && is_file($temporary)) {
+        unlink($temporary);
+    }
+}


### PR DESCRIPTION
PTS 10.8.4 deduplicates parser results by numeric value across different metrics. A fixture reporting both 1 MB/s and 1 IOPS therefore loses IOPS. Key the existing duplicate check by PTS's own result comparison hash, preserving both values while retaining deduplication within one metric.

A narrow PHP patcher accepts only the exact pinned upstream parser or this repair's exact output. It rejects unknown versions before measurement, writes atomically, preserves permissions, and is idempotent. Benchmark execution applies it to the supported packaged PTS installation before measurement. This changes producer behavior for new source-bound experiments and does not reconstruct historical samples.

Validation: the actual PTS 10.8.4 parser reproduced the equal-value loss and passes after repair; bandwidth unit fixtures remain green. Offline Docker checks confirm repeat application leaves bytes unchanged and unknown files are rejected without mutation. Full repository typecheck, tests, lint, spelling, and shell checks pass. Live provider verification remains required. The separate disk direct/buffered contract is not changed here.
