### PR TITLE
fix(benchmarks): align disk plans with buffered fio execution

### DIFF
--- a/apps/cli/src/lib/suite-tasks.ts
+++ b/apps/cli/src/lib/suite-tasks.ts
@@ -54,7 +54,7 @@ export interface SuiteTaskPlan {
 	metrics: SuiteMetricInfo[];
 }
 
-const MISE_RUN_RE = /^\s*mise\s+run\s+(\S+)/;
+const MISE_RUN_RE = /^\s*(?:[A-Za-z_][A-Za-z0-9_]*=[A-Za-z0-9_.-]+\s+)*mise\s+run\s+(\S+)/;
 const RUN_TASK_RE = /^\s*run_task\s+(\S+)/gm;
 const PTS_BENCHMARK_RE = /^\s*run_(?:pts_benchmark|pinned_pts)\s+"([^"]+)"\s+"([^"]+)"/gm;
 const FIO_PTS_RE = /^\s*run_fio_pts\s+"[^"]+"\s+"[^"]+"\s+"([^"]+)"/gm;

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -958,6 +958,11 @@ run_pts_benchmark() {
 # scenario. The chosen mode is part of the fio option matrix, so it travels in the metric identity
 # (each scenario has an O_DIRECT and a buffered catalog variant) instead of being silently mixed.
 fio_direct_choice() {
+	case "${BENCH_FIO_DIRECT:-}" in
+		Yes | No) printf '%s\n' "$BENCH_FIO_DIRECT"; return 0 ;;
+		"") ;;
+		*) echo "ERROR: BENCH_FIO_DIRECT must be Yes or No" >&2; return 1 ;;
+	esac
 	local dir probe cache choice
 	# Without PTS the answer is irrelevant (the leaf's availability guard skips before running fio) —
 	# return without probing OR caching, so a dep-less dry run can't persist a verdict probed against
@@ -1064,8 +1069,8 @@ run_pinned_pts() {
 run_fio_pts() {
 	local type_name="$1" bs_name="$2" prefix="$3"
 	local direct
-	direct="$(fio_direct_choice)"
-	echo "fio scenario: Type=${type_name} Block Size=${bs_name} Direct=${direct} (O_DIRECT probe)"
+	direct="$(fio_direct_choice)" || return 1
+	echo "fio scenario: Type=${type_name} Block Size=${bs_name} Direct=${direct}"
 
 	run_pinned_pts "pts/fio-2.1.0" "$prefix" \
 		"fio.type=${type_name};fio.engine=Linux AIO;fio.direct=${direct};fio.size=${bs_name};fio.cpu-threads=0;fio.auto-disk-mount-points=Default Test Directory"

--- a/lib/pts/fio/README.md
+++ b/lib/pts/fio/README.md
@@ -20,3 +20,10 @@ php lib/pts/fio/parser-selftest.php /path/to/phoronix-test-suite-10.8.4
 The self-test requires PHP with XML support and the PTS 10.8.4 source tree. It checks exact conversions
 for all three bandwidth units and preserves numeric and abbreviated IOPS values. The ordinary Bun
 suite also verifies that staging replaces stale definitions without deleting the installed executable.
+
+The publication disk suite explicitly sets `BENCH_FIO_DIRECT=No` and requires only buffered fio
+metrics plus hardlink. This gives every provider the same I/O mode; buffered results include page
+cache effects and are labelled accordingly. Direct-mode catalog entries remain readable for historical or explicit standalone measurements.
+Standalone leaves without an explicit mode retain their filesystem probe. Invalid explicit modes
+fail before measurement. Changing the suite command and eligible metrics changes its frozen workload
+identity; no old experiment denominator is modified.

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -33,6 +33,7 @@ import {
 	canonicalJsonEqual,
 	deriveEconomics,
 	describeOffDimensionEmission,
+	FIO_SCENARIO_METRICS,
 	getProvider,
 	MAX_PROVIDER_ARTIFACT_EVIDENCE_FILE_BYTES,
 	MAX_PROVIDER_COST_EVIDENCE_FILE_BYTES,
@@ -436,7 +437,10 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 		// the gap reason is byte-stable.
 		const produced = new Set(ext.contributions.map((c) => c.metricId));
 		const declared = new Set<string>(
-			(SUITES as Partial<Record<string, { metrics: readonly string[] }>>)[suite]?.metrics ?? [],
+			suite === "disk"
+				? [...SUITES.disk.metrics, ...FIO_SCENARIO_METRICS]
+				: ((SUITES as Partial<Record<string, { metrics: readonly string[] }>>)[suite]?.metrics ??
+						[]),
 		);
 		const missingById = new Map<string, AttemptedEmptyResult>();
 		for (const e of ext.attemptedEmpty) {

--- a/packages/results/src/lib/pts-golden.test.ts
+++ b/packages/results/src/lib/pts-golden.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { isPtsResultFile, ptsOverrides, SUITES } from "@sandbox-benchmarks/schema";
+import { FIO_SCENARIO_METRICS, isPtsResultFile, ptsOverrides } from "@sandbox-benchmarks/schema";
 import { parsePtsComposite, ptsResultToMetric } from "./pts.ts";
 
 const FIXTURES_DIR = join(import.meta.dir, "__fixtures__");
@@ -117,16 +117,11 @@ describe("golden composite byte-match (design §3.7)", () => {
 	}
 });
 
-describe("recorded fio fixtures pin the DECLARED disk-suite subset", () => {
-	// With fio's full 960-combination matrix catalogued, "resolves to a catalogued Metric" cannot
-	// falsify the combination SELECTION: a fixture re-recorded under drifted presets (a different
-	// engine or block size) — or a preset drift in run_fio_pts's PRESET_OPTIONS — would still resolve
-	// against some catalogued draft entry and stay green while the 16 declared metrics (disk headline
-	// included) silently never receive samples. The fixtures were recorded through the real producer
-	// path, so requiring every resolved fio id to be a DECLARED SUITES.disk metric transitively pins
-	// the bash presets, the curated ids, and the scale routing in one place.
-	it("every fio fixture <Result> resolves to a metric the disk suite declares", () => {
-		const declared = new Set<string>(SUITES.disk.metrics.filter((id) => id.startsWith("fio_")));
+describe("recorded fio fixtures pin supported historical disk scenarios", () => {
+	// Historical direct-mode fixtures must remain recognized after new plans select buffered I/O.
+	// The supported scenario list also rejects drift into uncurated fio combinations.
+	it("every fio fixture resolves to a supported scenario metric", () => {
+		const declared = new Set<string>(FIO_SCENARIO_METRICS);
 		expect(declared.size).toBeGreaterThan(0);
 		const fioComposites = composites.filter(([name]) => name.includes("fio"));
 		expect(fioComposites.length).toBeGreaterThan(0);

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -121,7 +121,9 @@ describe("suite registry", () => {
 		] as const;
 		for (const { suite, prefix } of subsets) {
 			const declared: string[] = SUITES[suite].metrics.filter((id) => id.startsWith(prefix)).sort();
-			const curated = overrideKeys.filter((id) => id.startsWith(prefix)).sort();
+			const curated = overrideKeys
+				.filter((id) => id.startsWith(prefix) && (suite !== "disk" || id.includes("_direct_no_")))
+				.sort();
 			expect(declared.length).toBeGreaterThan(0);
 			expect(declared).toEqual(curated);
 		}
@@ -145,4 +147,14 @@ describe("padded suite tokens", () => {
 		expect(list.includes(paddedSuiteToken("cpu-node"))).toBe(true);
 		expect(list.includes(paddedSuiteToken("pgbench"))).toBe(true);
 	});
+});
+
+it("disk freezes a uniform buffered workload with exactly its eligible metrics", () => {
+	expect(SUITES.disk.commands).toEqual(["BENCH_FIO_DIRECT=No mise run benchmark:disk:all"]);
+	expect(SUITES.disk.metrics).toHaveLength(9);
+	expect(
+		SUITES.disk.metrics
+			.filter((id) => id.startsWith("fio_"))
+			.every((id) => id.includes("_direct_no_")),
+	).toBe(true);
 });

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -82,6 +82,26 @@ export interface Suite {
 	commands: string[];
 }
 
+/** Supported fio scenario identities, including historical direct-mode observations. */
+export const FIO_SCENARIO_METRICS: readonly string[] = [
+	"fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+	"fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+	"fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+	"fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+	"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+	"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+	"fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+	"fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+	"fio_type_sequential_read_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+	"fio_type_sequential_read_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+	"fio_type_sequential_write_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+	"fio_type_sequential_write_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+	"fio_type_random_read_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+	"fio_type_random_read_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+	"fio_type_random_write_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+	"fio_type_random_write_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+];
+
 /**
  * The suite registry. Suite names fan out into the in-sandbox mise tasks under
  * `/.mise/tasks/benchmark/**`; keep the two in sync (a drift gate lands with the multi-suite work).
@@ -189,24 +209,10 @@ export const SUITES = {
 		dimensions: ["disk"],
 		metrics: [
 			"hardlink_bogo_ops_per_s",
-			"fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
-			"fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
-			"fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
-			"fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
-			"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
-			"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
-			"fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
-			"fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
-			"fio_type_sequential_read_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
-			"fio_type_sequential_read_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
-			"fio_type_sequential_write_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
-			"fio_type_sequential_write_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
-			"fio_type_random_read_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
-			"fio_type_random_read_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
-			"fio_type_random_write_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
-			"fio_type_random_write_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+			...FIO_SCENARIO_METRICS.filter((id) => id.includes("_direct_no_")),
 		],
-		commands: ["mise run benchmark:disk:all"],
+		// One fixed mode across providers; the command and eligible metrics share a workload revision.
+		commands: ["BENCH_FIO_DIRECT=No mise run benchmark:disk:all"],
 	},
 	// The network dimension, iperf composition (benchmark:network:suite): iperf3 over localhost
 	// isolates the sandbox's network stack/virtualization overhead (virtio/KVM vs gVisor netstack vs

--- a/tooling/repo-checks/src/fio-parser-staging.test.ts
+++ b/tooling/repo-checks/src/fio-parser-staging.test.ts
@@ -33,3 +33,19 @@ test("fio parser staging replaces stale definitions without deleting the install
 		rmSync(temporary, { recursive: true, force: true });
 	}
 });
+
+test("an explicit fio mode overrides the probe and invalid modes fail before measurement", () => {
+	for (const mode of ["No", "Yes", "invalid"]) {
+		const result = Bun.spawnSync(
+			[
+				"bash",
+				"-euc",
+				'source "$REPO_ROOT/lib/bench.sh"; have() { echo unexpected-probe >&2; return 1; }; fio_direct_choice',
+			],
+			{ env: { ...process.env, REPO_ROOT: findRepoRoot(), BENCH_FIO_DIRECT: mode } },
+		);
+		expect(result.exitCode).toBe(mode === "invalid" ? 1 : 0);
+		if (mode !== "invalid") expect(result.stdout.toString().trim()).toBe(mode);
+		expect(result.stderr.toString()).not.toContain("unexpected-probe");
+	}
+});


### PR DESCRIPTION
New disk plans expected both direct and buffered fio results even though each sandbox ran only one mode. That made a complete disk comparison impossible. Pin new disk workloads to buffered I/O and declare the eight corresponding fio metrics plus hardlink; the command participates in the frozen workload revision.

Preserve historical direct-mode parsing and missing-result detection. Standalone fio leaves retain automatic mode selection unless explicitly overridden. Teach task discovery to recognize the environment assignment in the suite command.

Validation: full tests, typecheck, lint, spelling, shell checks, and targeted historical fixture/normalization and shell mode-selection tests pass. This changes future measurement semantics; historical measurements are unchanged. Live verification follows merge.
