### PR TITLE
fix(admission): recover proven completed creates with audited account clearance

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -24,7 +24,8 @@
     "plan-experiment": "./src/bin/plan-experiment.ts",
     "evaluate-experiment": "./src/bin/evaluate-experiment.ts",
     "aggregate-experiment": "./src/bin/aggregate-experiment.ts",
-    "workflow-experiment": "./src/bin/workflow-experiment.ts"
+    "workflow-experiment": "./src/bin/workflow-experiment.ts",
+    "recover-completed-create": "./src/bin/recover-completed-create.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/apps/cli/src/bin/recover-completed-create.ts
+++ b/apps/cli/src/bin/recover-completed-create.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+import { parseArgs } from "node:util";
+import { providerIdSchema, suiteNameSchema } from "@sandbox-benchmarks/schema";
+import { type } from "arktype";
+import { recoverCompletedCreate } from "../lib/completed-create-recovery.ts";
+import { openDriver } from "../lib/driver-run.ts";
+import { githubAccountJournal, githubGitRequest } from "../lib/github-account-journal.ts";
+
+const { values, positionals } = parseArgs({
+	args: process.argv.slice(2),
+	allowPositionals: true,
+	options: { "exclusive-account": { type: "boolean", default: false } },
+});
+if (!values["exclusive-account"] || positionals.length !== 3)
+	throw new Error(
+		"usage: recover-completed-create --exclusive-account <provider> <suite> <original-attempt-directory>; stop all local account writers first",
+	);
+const provider = providerIdSchema.assert(positionals[0]);
+const suite = suiteNameSchema.assert(positionals[1]);
+const directory = type("string >= 1").assert(positionals[2]);
+const operator = type(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/).assert(process.env.GITHUB_ACTOR);
+const request = githubGitRequest();
+const workflow = type({ status: "'completed'", head_sha: /^[a-f0-9]{40}$/ });
+const activeRuns = type({ total_count: "number.integer >= 0" });
+const { driver } = await openDriver(provider);
+await recoverCompletedCreate({
+	directory,
+	provider,
+	suite,
+	operator,
+	drivers: [{ id: provider, driver }],
+	journal: githubAccountJournal(request),
+	signal: AbortSignal.timeout(240_000),
+	assertQuiescent: async (id, sha) => {
+		const run = workflow.assert(await request("GET", `/actions/runs/${id}`));
+		if (run.head_sha !== sha) throw new Error("original workflow source mismatch");
+		for (const status of ["queued", "in_progress", "waiting", "pending", "requested"]) {
+			const runs = activeRuns.assert(
+				await request("GET", `/actions/runs?status=${status}&per_page=1`),
+			);
+			if (runs.total_count !== 0)
+				throw new Error(`repository has ${status} workflows; stop writers before recovery`);
+		}
+	},
+});
+console.log(
+	`Recorded completed-create reconciliation for ${provider}/${suite}; original attempt remains failed.`,
+);

--- a/apps/cli/src/lib/account-journal.ts
+++ b/apps/cli/src/lib/account-journal.ts
@@ -18,6 +18,19 @@ export const accountRecordSchema = type.or(
 		"reject",
 	),
 	type({ ...base, kind: "'released'", outcome: "'not-allocated'" }).onUndeclaredKey("reject"),
+	type({
+		...base,
+		kind: "'released'",
+		outcome: "'reconciled'",
+		evidence: {
+			kind: "'completed-create'",
+			sourceSha: /^[a-f0-9]{40}$/,
+			attemptDigest: /^sha256:[a-f0-9]{64}$/,
+			workflowRun: /^[0-9]+$/,
+			confirmedAt: "string.date.iso",
+			operator: identity,
+		},
+	}).onUndeclaredKey("reject"),
 );
 export type AccountRecord = typeof accountRecordSchema.infer;
 export interface AccountJournal {
@@ -47,11 +60,16 @@ export async function recoverAccount(
 		const intent = records.find((entry) => entry.kind === "intent");
 		const allocated = records.find((entry) => entry.kind === "allocated");
 		const released = records.find((entry) => entry.kind === "released");
-		if (!intent || records.some((entry) => entry.planDigest !== intent.planDigest))
+		if (
+			!intent ||
+			records.some(
+				(entry) => entry.planDigest !== intent.planDigest || entry.cellId !== intent.cellId,
+			)
+		)
 			throw new Error("incomplete account journal provenance");
 		if (released) {
 			if (
-				released.outcome === "not-allocated"
+				released.outcome !== "absent"
 					? allocated !== undefined
 					: !allocated ||
 						allocated.ref.provider !== released.ref.provider ||

--- a/apps/cli/src/lib/completed-create-recovery.test.ts
+++ b/apps/cli/src/lib/completed-create-recovery.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SandboxDriver } from "@sandbox-benchmarks/driver";
+import { evidenceDigest } from "@sandbox-benchmarks/results";
+import type { ExperimentAttempt } from "@sandbox-benchmarks/schema";
+import type { AccountRecord } from "./account-journal.ts";
+import { recoverAccount } from "./account-journal.ts";
+import { COMPLETED_CREATE_REVISION, recoverCompletedCreate } from "./completed-create-recovery.ts";
+import { rawTreeDigest } from "./experiment-artifacts.ts";
+
+const directories: string[] = [];
+afterEach(() => {
+	for (const dir of directories.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+function fixture() {
+	const directory = mkdtempSync(join(tmpdir(), "completed-create-"));
+	directories.push(directory);
+	const raw = join(directory, "raw");
+	mkdirSync(join(raw, "e2b", "memory"), { recursive: true });
+	const marker = join(raw, "e2b", "memory", "sandbox-e2b-memory--failed.json");
+	writeFileSync(
+		marker,
+		JSON.stringify({
+			provider: "e2b",
+			suite: "memory",
+			outcome: "failed",
+			reason: "Failed to create sandbox: account journal PATCH HTTP 422; allocation blocked",
+			cause: {
+				kind: "sandbox-create-failed",
+				detail: "account journal PATCH HTTP 422; allocation blocked",
+			},
+		}),
+	);
+	const run = {
+		schemaVersion: "6",
+		runId: "123",
+		sha: COMPLETED_CREATE_REVISION,
+		generatedAt: "2026-09-11T00:00:00Z",
+		targetSpec: { vcpus: 4, memoryGb: 8 },
+		providers: [],
+	};
+	writeFileSync(join(directory, "run.json"), JSON.stringify(run));
+	const evidence: ExperimentAttempt = {
+		schemaVersion: "1",
+		id: "attempt-1",
+		cellId: "e2b-memory-r0",
+		planDigest: `sha256:${"a".repeat(64)}`,
+		sha: COMPLETED_CREATE_REVISION,
+		workloadRevision: "memory",
+		environmentRevision: "env",
+		artifactIdentity: "image",
+		passes: 2,
+		workflowRun: "123",
+		workflowAttempt: 1,
+		job: "bench",
+		sequence: 0,
+		outcome: "failed",
+		measurementStarted: false,
+		retryable: false,
+		cleanup: "unresolved",
+		completion: "unknown",
+		runDigest: evidenceDigest(run),
+		rawDigest: rawTreeDigest(raw),
+	};
+	const save = () => writeFileSync(join(directory, "attempt.json"), JSON.stringify(evidence));
+	save();
+	const records: AccountRecord[] = [
+		{
+			version: "1",
+			kind: "intent",
+			account: "e2b",
+			attempt: evidence.id,
+			cellId: evidence.cellId,
+			planDigest: evidence.planDigest,
+		},
+	];
+	const events: string[] = [];
+	const driver: SandboxDriver = {
+		create: async () => {
+			throw new Error("must not allocate");
+		},
+		inventory: {
+			list: async () => {
+				events.push("inventory");
+				return { owned: [], foreignCount: 0 };
+			},
+		},
+		probes: { observe: async () => ({ state: "absent" }) },
+		destroyById: async () => {},
+	};
+	const journal = {
+		read: async () => records,
+		append: async (r: AccountRecord) => {
+			events.push("release");
+			records.push(r);
+		},
+	};
+	const options = {
+		directory,
+		provider: "e2b" as const,
+		suite: "memory" as const,
+		operator: "operator",
+		drivers: [{ id: "e2b" as const, driver }],
+		journal,
+		assertQuiescent: async () => {
+			events.push("quiescent");
+		},
+		signal: AbortSignal.timeout(1000),
+	};
+	return { options, records, events, evidence, save, marker, driver };
+}
+test("completed create clearance preserves evidence and requires two complete inventory sweeps", async () => {
+	const f = fixture();
+	const original = readFileSync(join(f.options.directory, "attempt.json"), "utf8");
+	await recoverCompletedCreate(f.options);
+	expect(f.events).toEqual(["quiescent", "inventory", "inventory", "quiescent", "release"]);
+	expect(f.records.at(-1)).toMatchObject({
+		outcome: "reconciled",
+		evidence: {
+			kind: "completed-create",
+			attemptDigest: evidenceDigest(f.evidence),
+			operator: "operator",
+		},
+	});
+	expect(readFileSync(join(f.options.directory, "attempt.json"), "utf8")).toBe(original);
+	await recoverAccount("e2b", new Map([["e2b", f.driver]]), f.options.journal, f.options.signal);
+});
+for (const change of [
+	"source",
+	"measured",
+	"digest",
+	"marker",
+	"identity",
+	"allocated",
+	"busy",
+	"inventory",
+	"variant",
+] as const) {
+	test(`completed-create clearance rejects ${change} without releasing ownership`, async () => {
+		const f = fixture();
+		switch (change) {
+			case "source":
+				f.evidence.sha = "c".repeat(40);
+				break;
+			case "measured":
+				f.evidence.measurementStarted = true;
+				break;
+			case "digest":
+				f.evidence.rawDigest = `sha256:${"c".repeat(64)}`;
+				break;
+			case "marker":
+				writeFileSync(f.marker, "{}");
+				f.evidence.rawDigest = rawTreeDigest(join(f.options.directory, "raw"));
+				break;
+			case "identity":
+				f.evidence.cellId = "e2b-disk-r0";
+				break;
+			case "allocated":
+				f.records.push({
+					version: "1",
+					account: "e2b",
+					attempt: f.evidence.id,
+					cellId: f.evidence.cellId,
+					planDigest: f.evidence.planDigest,
+					kind: "allocated",
+					ref: { provider: "e2b", id: "known" },
+				});
+				break;
+			case "busy":
+				f.options.assertQuiescent = async () => {
+					throw new Error("workflow running");
+				};
+				break;
+			case "inventory":
+				f.options.drivers.splice(0, 1, {
+					id: "e2b",
+					driver: {
+						...f.driver,
+						inventory: {
+							list: async () => {
+								throw new Error("unavailable");
+							},
+						},
+					},
+				});
+				break;
+			case "variant":
+				f.options.drivers.push({ id: "e2b", driver: f.driver });
+				break;
+		}
+		f.save();
+		await expect(recoverCompletedCreate(f.options)).rejects.toThrow();
+		expect(f.records.some((r) => r.kind === "released")).toBe(false);
+	});
+}

--- a/apps/cli/src/lib/completed-create-recovery.ts
+++ b/apps/cli/src/lib/completed-create-recovery.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { evidenceDigest } from "@sandbox-benchmarks/results";
+import { providerIdSchema, quotaDomain, suiteNameSchema } from "@sandbox-benchmarks/schema";
+import { type } from "arktype";
+import type { AccountJournal } from "./account-journal.ts";
+import { accountRecordSchema } from "./account-journal.ts";
+import type { AccountDriver } from "./account-reconciliation.ts";
+import { reconcileAccount } from "./account-reconciliation.ts";
+import { readExperimentAttempt } from "./experiment-artifacts.ts";
+
+// At this reviewed revision, this exact premeasurement failure can only occur AFTER SDK create
+// returned: the intent append happens outside runReplicate, the allocation append inside create.
+// New revisions persist allocation.json instead and use identity-based recovery.
+export const COMPLETED_CREATE_REVISION = "b061d9f201d787e3c87045c1fe2a1db24122691e";
+const failedMarker = type({
+	provider: providerIdSchema,
+	suite: suiteNameSchema,
+	outcome: "'failed'",
+	reason: "'Failed to create sandbox: account journal PATCH HTTP 422; allocation blocked'",
+	cause: {
+		kind: "'sandbox-create-failed'",
+		detail: "'account journal PATCH HTTP 422; allocation blocked'",
+	},
+});
+
+/** Explicit operator recovery under exclusive account ownership; never part of normal admission. */
+export async function recoverCompletedCreate(options: {
+	directory: string;
+	provider: typeof providerIdSchema.infer;
+	suite: typeof suiteNameSchema.infer;
+	operator: string;
+	drivers: readonly AccountDriver[];
+	journal: AccountJournal;
+	/** Recheck that the original workflow terminated and no allocating workflows can run. */
+	assertQuiescent: (workflowRun: string, sourceSha: string) => Promise<void>;
+	signal: AbortSignal;
+}): Promise<void> {
+	const { evidence, execution, cleanup } = readExperimentAttempt(options.directory);
+	if (
+		evidence.sha !== COMPLETED_CREATE_REVISION ||
+		evidence.outcome !== "failed" ||
+		evidence.measurementStarted ||
+		evidence.cleanup !== "unresolved" ||
+		!evidence.rawDigest ||
+		!evidence.runDigest ||
+		execution ||
+		cleanup
+	)
+		throw new Error("attempt does not prove the reviewed completed-create failure");
+	const marker = failedMarker.assert(
+		JSON.parse(
+			readFileSync(
+				join(
+					options.directory,
+					"raw",
+					options.provider,
+					options.suite,
+					`sandbox-${options.provider}-${options.suite}--failed.json`,
+				),
+				"utf8",
+			),
+		),
+	);
+	if (
+		marker.provider !== options.provider ||
+		marker.suite !== options.suite ||
+		!evidence.cellId.startsWith(`${marker.provider}-${marker.suite}-r`)
+	)
+		throw new Error("recovery marker identity mismatch");
+	const account = quotaDomain(options.provider);
+	// This historical incident affected single-provider accounts only. Do not silently extend
+	// the clearance to a quota domain whose other variants were not reconciled.
+	if (
+		account !== options.provider ||
+		options.drivers.length !== 1 ||
+		options.drivers[0]?.id !== options.provider
+	)
+		throw new Error("completed-create recovery requires the complete single-provider account");
+	const readIntent = async () => {
+		const records = (await options.journal.read(account))
+			.map((r) => accountRecordSchema.assert(r))
+			.filter((r) => r.attempt === evidence.id);
+		const intent = records[0];
+		if (
+			records.length !== 1 ||
+			intent?.kind !== "intent" ||
+			intent.account !== account ||
+			intent.cellId !== evidence.cellId ||
+			intent.planDigest !== evidence.planDigest
+		)
+			throw new Error("recovery requires a matching unresolved intent without allocation evidence");
+		return intent;
+	};
+	await readIntent();
+	await options.assertQuiescent(evidence.workflowRun, evidence.sha);
+	const reconciliation = await reconcileAccount(options.drivers, {
+		timeoutMs: 180_000,
+		signal: options.signal,
+	});
+	await options.assertQuiescent(evidence.workflowRun, evidence.sha);
+	const intent = await readIntent();
+	options.signal.throwIfAborted();
+	await options.journal.append(
+		accountRecordSchema.assert({
+			...intent,
+			kind: "released",
+			outcome: "reconciled",
+			evidence: {
+				kind: "completed-create",
+				sourceSha: evidence.sha,
+				attemptDigest: evidenceDigest(evidence),
+				workflowRun: evidence.workflowRun,
+				confirmedAt: reconciliation.confirmedAt,
+				operator: options.operator,
+			},
+		}),
+	);
+}

--- a/docs/adr/0010-experiment-completeness.md
+++ b/docs/adr/0010-experiment-completeness.md
@@ -62,3 +62,33 @@ they adopt the owner. Account-wide capacity is guaranteed only after that admiss
 See [GitHub's reference API](https://docs.github.com/en/rest/git/refs) for fast-forward ref updates and
 [tree API](https://docs.github.com/en/rest/git/trees) for complete tree enumeration. Truncated histories
 and competing ref updates fail admission rather than discarding ownership facts.
+
+## Operator recovery of a completed create with a lost journal append
+
+A returned create is distinct from an interrupted vendor request. At revision
+`b061d9f201d787e3c87045c1fe2a1db24122691e`, the exact premeasurement
+`sandbox-create-failed` marker containing `account journal PATCH HTTP 422; allocation blocked`
+can only arise after SDK create returned and the subsequent allocation append failed. The intent
+append occurs outside the harness and cannot produce this marker. Later revisions persist the
+allocation reference locally before appending it; use ordinary identity-based recovery for those.
+
+For that reviewed historical failure only, an operator may append a `released/reconciled` record
+without inventing a sandbox reference. Recovery validates the original attempt's raw and Run digests,
+source revision, marker and intent identities, absence of measurement and execution receipts, and
+absence of an existing allocation record. The original workflow must have completed. All workflow
+and local account writers must be stopped; the command checks repository workflow quiescence before
+and after reconciliation. It requires complete account inventory, normal owned-resource destruction
+and control-plane confirmation, and a second complete empty inventory sweep. The initial recovery
+path supports only single-provider quota domains.
+
+The append preserves the operator, confirmation time, original workflow, source revision and attempt
+digest in the protected journal. It records account clearance, not a recovered sandbox identity or a
+claim that allocation never happened. It does not modify original attempt evidence or make it eligible
+for publication. Unknown or still-in-flight creates continue to block even when inventory is empty.
+This exception is an explicit operator command, never an automatic admission fallback.
+
+Run `recover-completed-create --exclusive-account <provider> <suite> <original-attempt-directory>`
+with provider credentials, `GITHUB_REPOSITORY`, a journal-write `GH_TOKEN`, and `GITHUB_ACTOR` identifying
+the operator. Obtain the immutable original attempt artifact first and stop local account writers.
+The flag asserts exclusive operational ownership; it does not acquire a distributed lock. Normal
+benchmark queues and complete journal admission remain mandatory after recovery.


### PR DESCRIPTION
A historical allocation-journal failure occurred after SDK create returned but before its sandbox reference was persisted. Normal admission correctly blocks those unresolved intents, even after inventory becomes empty.

Add an explicit operator recovery command for the exact reviewed source revision and failure marker. It verifies original raw/Run digests and intent identity, rejects measured attempts and existing allocation evidence, requires a completed source workflow and stopped writers, then performs complete account reconciliation and a second inventory sweep. Only then may it append an audited `released/reconciled` record. The initial path supports single-provider quota domains.

This deliberately refines ADR-0010: account clearance does not reconstruct the missing sandbox identity. Original failed attempts remain immutable and ineligible for publication. Unknown or in-flight creates still block ordinary admission; there is no automatic empty-inventory fallback. Later revisions retain allocation IDs and use existing identity-based recovery.

Validation: full tests, typecheck, lint and spelling pass, including rejection tests for wrong source, altered evidence, measurement, identity mismatch, existing allocation, active workflows, unavailable inventory and incomplete account coverage. Based directly on merged #459. Apply recovery after this policy is reviewed and merged, then perform fresh live verification before a new full benchmark run.
