### PR TITLE
fix(admission): recover an unresolved intent from its retained allocation

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -25,7 +25,8 @@
     "evaluate-experiment": "./src/bin/evaluate-experiment.ts",
     "aggregate-experiment": "./src/bin/aggregate-experiment.ts",
     "workflow-experiment": "./src/bin/workflow-experiment.ts",
-    "recover-completed-create": "./src/bin/recover-completed-create.ts"
+    "recover-completed-create": "./src/bin/recover-completed-create.ts",
+    "recover-allocated-intent": "./src/bin/recover-allocated-intent.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/apps/cli/src/bin/recover-allocated-intent.ts
+++ b/apps/cli/src/bin/recover-allocated-intent.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env bun
+import { parseArgs } from "node:util";
+import { type } from "arktype";
+import { recoverAllocatedIntent } from "../lib/allocated-intent-recovery.ts";
+import { isDriverProviderId, openDriver } from "../lib/driver-run.ts";
+import { githubAccountJournal, githubGitRequest } from "../lib/github-account-journal.ts";
+
+const { values, positionals } = parseArgs({
+	args: process.argv.slice(2),
+	allowPositionals: true,
+	options: { "exclusive-account": { type: "boolean", default: false } },
+});
+if (!values["exclusive-account"] || positionals.length !== 1)
+	throw new Error(
+		"usage: recover-allocated-intent --exclusive-account <original-attempt-directory>; stop all local account writers first",
+	);
+const directory = type("string >= 1").assert(positionals[0]);
+const request = githubGitRequest();
+const workflow = type({ status: "'completed'", head_sha: /^[a-f0-9]{40}$/ });
+const activeRuns = type({ total_count: "number.integer >= 0" });
+const ref = await recoverAllocatedIntent({
+	directory,
+	openDriver: async (provider) => {
+		if (!isDriverProviderId(provider))
+			throw new Error(`${provider}: no managed driver for recovery`);
+		return (await openDriver(provider)).driver;
+	},
+	journal: githubAccountJournal(request),
+	signal: AbortSignal.timeout(240_000),
+	assertQuiescent: async (id, sha) => {
+		const run = workflow.assert(await request("GET", `/actions/runs/${id}`));
+		if (run.head_sha !== sha) throw new Error("original workflow source mismatch");
+		for (const status of ["queued", "in_progress", "waiting", "pending", "requested"]) {
+			const runs = activeRuns.assert(
+				await request("GET", `/actions/runs?status=${status}&per_page=1`),
+			);
+			if (runs.total_count !== 0)
+				throw new Error(`repository has ${status} workflows; stop writers before recovery`);
+		}
+	},
+});
+console.log(
+	`Confirmed removal of ${ref.provider} ${ref.id} and released the intent; original attempt remains failed.`,
+);

--- a/apps/cli/src/lib/account-journal.ts
+++ b/apps/cli/src/lib/account-journal.ts
@@ -80,7 +80,7 @@ export async function recoverAccount(
 		}
 		if (!allocated)
 			throw new Error(
-				`unresolved create ${intent.attempt}: no durable sandbox identity; vendor-confirmed recovery required`,
+				`unresolved create ${intent.attempt}: no durable sandbox identity; vendor-confirmed recovery required (recover-allocated-intent when the retained attempt evidence holds allocation.json)`,
 			);
 		const driver = drivers.get(allocated.ref.provider);
 		if (!driver?.destroyById || !driver.probes)

--- a/apps/cli/src/lib/allocated-intent-recovery.test.ts
+++ b/apps/cli/src/lib/allocated-intent-recovery.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SandboxDriver } from "@sandbox-benchmarks/driver";
+import type { ExperimentAttempt } from "@sandbox-benchmarks/schema";
+import type { AccountRecord } from "./account-journal.ts";
+import { recoverAccount } from "./account-journal.ts";
+import { recoverAllocatedIntent } from "./allocated-intent-recovery.ts";
+import { rawTreeDigest } from "./experiment-artifacts.ts";
+
+const directories: string[] = [];
+afterEach(() => {
+	for (const dir of directories.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const REF = { provider: "e2b", id: "sb-orphan-1" } as const;
+const PLAN_DIGEST = `sha256:${"a".repeat(64)}`;
+const SHA = "b".repeat(40);
+
+function fixture(
+	overrides: {
+		evidence?: Partial<ExperimentAttempt>;
+		allocation?: Partial<AccountRecord> | null;
+	} = {},
+) {
+	const directory = mkdtempSync(join(tmpdir(), "allocated-intent-"));
+	directories.push(directory);
+	const raw = join(directory, "raw");
+	mkdirSync(raw, { recursive: true });
+	const intent: AccountRecord = {
+		version: "1",
+		kind: "intent",
+		account: "e2b",
+		attempt: "attempt-1",
+		cellId: "e2b-memory-r0",
+		planDigest: PLAN_DIGEST,
+	};
+	if (overrides.allocation !== null)
+		writeFileSync(
+			join(raw, "allocation.json"),
+			JSON.stringify({ ...intent, kind: "allocated", ref: REF, ...overrides.allocation }),
+		);
+	const evidence: ExperimentAttempt = {
+		schemaVersion: "1",
+		id: "attempt-1",
+		cellId: "e2b-memory-r0",
+		planDigest: PLAN_DIGEST,
+		sha: SHA,
+		workloadRevision: "memory",
+		environmentRevision: "env",
+		artifactIdentity: "image",
+		passes: 2,
+		workflowRun: "4242",
+		workflowAttempt: 1,
+		job: "bench",
+		sequence: 0,
+		outcome: "failed",
+		measurementStarted: false,
+		retryable: false,
+		cleanup: "unresolved",
+		completion: "unknown",
+		rawDigest: rawTreeDigest(raw),
+		...overrides.evidence,
+	};
+	writeFileSync(join(directory, "attempt.json"), JSON.stringify(evidence));
+
+	const records: AccountRecord[] = [intent];
+	const observed: string[] = [];
+	let running = true;
+	const driver: SandboxDriver = {
+		async destroyById() {
+			observed.push("destroy");
+			running = false;
+		},
+		probes: {
+			async observe() {
+				return { state: running ? "running" : "absent" };
+			},
+		},
+	} as unknown as SandboxDriver;
+	return {
+		directory,
+		records,
+		observed,
+		options: {
+			directory,
+			openDriver: async () => driver,
+			journal: {
+				async read() {
+					return records;
+				},
+				async append(record: AccountRecord) {
+					records.push(record);
+				},
+			},
+			assertQuiescent: async () => {
+				observed.push("quiescent");
+			},
+			signal: AbortSignal.timeout(5000),
+		},
+	};
+}
+
+test("releases an unresolved intent after confirming the retained allocation is gone", async () => {
+	const f = fixture();
+	expect(await recoverAllocatedIntent(f.options)).toEqual(REF);
+	// The lost append is replayed, so the release is backed by its allocation.
+	expect(f.records.at(-2)).toEqual({
+		version: "1",
+		kind: "allocated",
+		account: "e2b",
+		attempt: "attempt-1",
+		cellId: "e2b-memory-r0",
+		planDigest: PLAN_DIGEST,
+		ref: REF,
+	});
+	expect(f.records.at(-1)).toEqual({
+		version: "1",
+		kind: "released",
+		account: "e2b",
+		attempt: "attempt-1",
+		cellId: "e2b-memory-r0",
+		planDigest: PLAN_DIGEST,
+		outcome: "absent",
+		ref: REF,
+	});
+	// Quiescence is rechecked after removal, and the sandbox is actually destroyed.
+	expect(f.observed).toEqual(["quiescent", "destroy", "quiescent"]);
+	// The account is admissible again.
+	await recoverAccount(
+		"e2b",
+		new Map([
+			[
+				"e2b",
+				{
+					destroyById: async () => {},
+					probes: { observe: async () => ({ state: "absent" }) },
+				} as unknown as SandboxDriver,
+			],
+		]),
+		f.options.journal,
+		AbortSignal.timeout(1000),
+	);
+});
+
+test("refuses an attempt whose measurement started", async () => {
+	const f = fixture({ evidence: { measurementStarted: true } });
+	expect(recoverAllocatedIntent(f.options)).rejects.toThrow(
+		"attempt does not prove an unresolved allocation",
+	);
+});
+
+test("refuses an attempt whose cleanup was already confirmed", async () => {
+	const f = fixture({ evidence: { cleanup: "confirmed" } });
+	expect(recoverAllocatedIntent(f.options)).rejects.toThrow(
+		"attempt does not prove an unresolved allocation",
+	);
+});
+
+test("refuses a retained allocation belonging to another attempt", async () => {
+	const f = fixture({ allocation: { attempt: "attempt-2" } });
+	expect(recoverAllocatedIntent(f.options)).rejects.toThrow(
+		"retained allocation does not identify this attempt",
+	);
+});
+
+test("refuses when the journal already resolved the intent", async () => {
+	const f = fixture();
+	f.records.push({
+		version: "1",
+		kind: "allocated",
+		account: "e2b",
+		attempt: "attempt-1",
+		cellId: "e2b-memory-r0",
+		planDigest: PLAN_DIGEST,
+		ref: REF,
+	});
+	f.records.push({
+		version: "1",
+		kind: "released",
+		account: "e2b",
+		attempt: "attempt-1",
+		cellId: "e2b-memory-r0",
+		planDigest: PLAN_DIGEST,
+		outcome: "absent",
+		ref: REF,
+	});
+	expect(recoverAllocatedIntent(f.options)).rejects.toThrow(
+		"recovery requires a matching unresolved intent without a release",
+	);
+});
+
+test("does not release ownership when quiescence fails", async () => {
+	const f = fixture();
+	expect(
+		recoverAllocatedIntent({
+			...f.options,
+			assertQuiescent: async () => {
+				throw new Error("repository has in_progress workflows; stop writers before recovery");
+			},
+		}),
+	).rejects.toThrow("stop writers before recovery");
+	expect(f.records).toHaveLength(1);
+});
+
+test("an interrupted recovery leaves the ordinary interrupted-allocation state", async () => {
+	const f = fixture();
+	// Recovery dies after replaying the allocation but before releasing it.
+	expect(
+		recoverAllocatedIntent({
+			...f.options,
+			assertQuiescent: async () => {
+				if (f.records.some((record) => record.kind === "allocated")) throw new Error("worker lost");
+			},
+		}),
+	).rejects.toThrow("worker lost");
+	await Bun.sleep(10);
+	expect(f.records.map((record) => record.kind)).toEqual(["intent", "allocated"]);
+	// Admission recovers that state on its own, with no operator command at all.
+	const driver = {
+		destroyById: async () => {},
+		probes: { observe: async () => ({ state: "absent" }) },
+	} as unknown as SandboxDriver;
+	await recoverAccount(
+		"e2b",
+		new Map([["e2b", driver]]),
+		f.options.journal,
+		AbortSignal.timeout(1000),
+	);
+	expect(f.records.map((record) => record.kind)).toEqual(["intent", "allocated", "released"]);
+});

--- a/apps/cli/src/lib/allocated-intent-recovery.ts
+++ b/apps/cli/src/lib/allocated-intent-recovery.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ProviderId, SandboxDriver, SandboxRef } from "@sandbox-benchmarks/driver";
+import type { AccountJournal, AccountRecord } from "./account-journal.ts";
+import { accountRecordSchema, confirmRemoval, withinSignal } from "./account-journal.ts";
+import { readExperimentAttempt } from "./experiment-artifacts.ts";
+
+/**
+ * Identity-based recovery of an allocation whose durable journal append failed.
+ *
+ * A create can return after the account journal rejects its `allocated` append. The harness never
+ * receives that session, so no execution receipt carries the vendor identity; instead the executor
+ * retains the identity-bound record in the attempt's raw tree before appending it. That retained
+ * record — not an inventory sweep — is what makes the intent resolvable: ownership is released by
+ * observing the removal of that exact sandbox, the same evidence the ordinary release path requires.
+ *
+ * Unlike the historical completed-create clearance, this recovers a known resource, so it records an
+ * ordinary `released/absent` receipt rather than an audited account clearance. It remains an explicit
+ * operator command under exclusive account ownership; it is never part of admission.
+ */
+export async function recoverAllocatedIntent(options: {
+	directory: string;
+	/** Opens the driver for the provider the retained allocation names, and no other. */
+	openDriver: (provider: ProviderId) => Promise<SandboxDriver>;
+	journal: AccountJournal;
+	/** Recheck that the original workflow terminated and no allocating workflows can run. */
+	assertQuiescent: (workflowRun: string, sourceSha: string) => Promise<void>;
+	signal: AbortSignal;
+}): Promise<SandboxRef> {
+	const { evidence, execution, cleanup } = readExperimentAttempt(options.directory);
+	// The journal-append failure happens before the harness owns the session: an attempt that
+	// measured anything, or that produced its own receipts, is a different failure with different
+	// evidence and must not be cleared here.
+	if (
+		evidence.outcome !== "failed" ||
+		evidence.measurementStarted ||
+		evidence.cleanup !== "unresolved" ||
+		!evidence.rawDigest ||
+		execution ||
+		cleanup
+	)
+		throw new Error("attempt does not prove an unresolved allocation");
+	const allocation = accountRecordSchema.assert(
+		JSON.parse(readFileSync(join(options.directory, "raw", "allocation.json"), "utf8")),
+	);
+	if (
+		allocation.kind !== "allocated" ||
+		allocation.attempt !== evidence.id ||
+		allocation.cellId !== evidence.cellId ||
+		allocation.planDigest !== evidence.planDigest
+	)
+		throw new Error("retained allocation does not identify this attempt");
+	const account = allocation.account;
+	const driver = await withinSignal(options.signal, () =>
+		options.openDriver(allocation.ref.provider),
+	);
+	if (!driver.destroyById || !driver.probes)
+		throw new Error("retained allocation has no recovery driver");
+	// The journal stays authoritative: recover only an intent that is still unresolved. Recovery
+	// replays the append that was lost rather than skipping it — a bare `released/absent` without its
+	// allocation would contradict the journal's own consistency rule and wedge admission again.
+	const readRecords = async (expected: readonly AccountRecord["kind"][]) => {
+		const records = (await withinSignal(options.signal, () => options.journal.read(account)))
+			.map((record) => accountRecordSchema.assert(record))
+			.filter((record) => record.attempt === evidence.id);
+		const intent = records[0];
+		if (
+			records.length !== expected.length ||
+			records.some((record, index) => record.kind !== expected[index]) ||
+			intent?.kind !== "intent" ||
+			intent.account !== account ||
+			intent.cellId !== evidence.cellId ||
+			intent.planDigest !== evidence.planDigest
+		)
+			throw new Error("recovery requires a matching unresolved intent without a release");
+		return intent;
+	};
+	const intent = await readRecords(["intent"]);
+	await options.assertQuiescent(evidence.workflowRun, evidence.sha);
+	// Restoring the allocation first is what makes an interrupted recovery safe: intent+allocated is
+	// the ordinary interrupted-allocation state, which admission already recovers on its own.
+	await withinSignal(options.signal, () => options.journal.append(allocation));
+	await confirmRemoval(driver, allocation.ref, options.signal);
+	await options.assertQuiescent(evidence.workflowRun, evidence.sha);
+	await readRecords(["intent", "allocated"]);
+	options.signal.throwIfAborted();
+	await withinSignal(options.signal, () =>
+		options.journal.append(
+			accountRecordSchema.assert({
+				...intent,
+				kind: "released",
+				outcome: "absent",
+				ref: allocation.ref,
+			}),
+		),
+	);
+	return allocation.ref;
+}

--- a/apps/cli/src/lib/execute-experiment.test.ts
+++ b/apps/cli/src/lib/execute-experiment.test.ts
@@ -7,6 +7,8 @@ import { loadDriverModule } from "@sandbox-benchmarks/drivers";
 import { evaluateExperiment } from "@sandbox-benchmarks/results";
 import { TOOLCHAIN_VERSION } from "@sandbox-benchmarks/schema/toolchain";
 import type { AccountRecord } from "./account-journal.ts";
+import { recoverAccount } from "./account-journal.ts";
+import { recoverAllocatedIntent } from "./allocated-intent-recovery.ts";
 import type { OpenedDriver } from "./driver-run.ts";
 import { resolveDriverArtifact } from "./driver-run.ts";
 import { batchIsComplete, executeExperimentBatch } from "./execute-experiment.ts";
@@ -338,4 +340,53 @@ test("a rejected allocation journal append retains recovery identity without adm
 			attempt.rawDigest,
 		);
 	}
+});
+
+test("operator recovery reclaims the leaked sandbox and readmits the account", async () => {
+	const f = await fixture("allocation-journal-recovery", true);
+	const attempts = await executeExperimentBatch({
+		...f.options,
+		journal: {
+			...f.options.journal,
+			append: async (record) => {
+				if (record.kind === "allocated") throw new Error("journal allocation rejected");
+				await f.options.journal.append(record);
+			},
+		},
+	});
+	// The account is wedged: unresolved intents, and the sandboxes really did leak.
+	expect(f.records.every((record) => record.kind === "intent")).toBe(true);
+	expect(f.present.size).toBe(2);
+	await expect(
+		recoverAccount(
+			"tama",
+			new Map([["tama", (await f.options.open()).driver]]),
+			f.options.journal,
+			AbortSignal.timeout(1000),
+		),
+	).rejects.toThrow("no durable sandbox identity");
+
+	for (const attempt of attempts) {
+		expect(
+			await recoverAllocatedIntent({
+				directory: join(f.options.root, attempt.id),
+				openDriver: async () => (await f.options.open()).driver,
+				journal: f.options.journal,
+				assertQuiescent: async () => {},
+				signal: AbortSignal.timeout(10_000),
+			}),
+		).toMatchObject({ provider: "tama" });
+	}
+	// Every leaked sandbox is gone, the journal is consistent, and admission passes again.
+	expect(f.present.size).toBe(0);
+	expect(f.records.filter((record) => record.kind === "allocated")).toHaveLength(2);
+	expect(f.records.filter((record) => record.kind === "released")).toHaveLength(2);
+	await recoverAccount(
+		"tama",
+		new Map([["tama", (await f.options.open()).driver]]),
+		f.options.journal,
+		AbortSignal.timeout(1000),
+	);
+	// The original attempts stay failed; recovery never makes them publishable.
+	expect(attempts.every((attempt) => attempt.outcome === "failed")).toBe(true);
 });

--- a/docs/adr/0010-experiment-completeness.md
+++ b/docs/adr/0010-experiment-completeness.md
@@ -63,6 +63,37 @@ See [GitHub's reference API](https://docs.github.com/en/rest/git/refs) for fast-
 [tree API](https://docs.github.com/en/rest/git/trees) for complete tree enumeration. Truncated histories
 and competing ref updates fail admission rather than discarding ownership facts.
 
+## Operator recovery of a retained allocation identity
+
+From `1b83cdee0272b3cb7131aa3915c6b69db3921b58` onward the executor persists the identity-bound
+`allocated` record to the attempt's raw tree *before* appending it to the journal, so a rejected
+append no longer loses the vendor identity. That retained record — not an inventory sweep — makes
+the intent resolvable, and recovery is therefore identity-based: it is the ordinary release protocol
+replayed by an operator, not a clearance.
+
+Recovery validates the attempt's raw and Run digests, requires a failed attempt with no measurement,
+no execution or cleanup receipt and unresolved cleanup, and requires the retained allocation to name
+the same attempt, cell and plan digest. The journal must still hold exactly that attempt's intent and
+no release. The original workflow must have completed, and repository workflow quiescence is checked
+before and after removal.
+
+It then appends the lost `allocated` record, observes removal of that exact sandbox through the
+control plane (destroying it when it is still running), and appends the ordinary `released/absent`
+receipt. Replaying the allocation first is what makes an interrupted recovery safe: `intent` plus
+`allocated` is the ordinary interrupted-allocation state, which admission already recovers on its
+own, and a bare `released/absent` without its allocation would contradict the journal's consistency
+rule and block admission again. No new evidence kind is recorded, because ownership is released by
+observation of a known resource rather than by audited account clearance.
+
+This does not recover identifiers missing from attempts written before that revision — use the
+completed-create clearance below for that reviewed historical failure — nor an attempt whose evidence
+was never uploaded. It is an explicit operator command, never an automatic admission fallback, and it
+does not modify the original attempt evidence or make it eligible for publication.
+
+Run `recover-allocated-intent --exclusive-account <original-attempt-directory>` with provider
+credentials, `GITHUB_REPOSITORY` and a journal-write `GH_TOKEN`. Obtain the immutable original attempt
+artifact first and stop local account writers.
+
 ## Operator recovery of a completed create with a lost journal append
 
 A returned create is distinct from an interrupted vendor request. At revision


### PR DESCRIPTION
A create can return after the account journal rejects its `allocated` append.
Since 1b83cde the executor retains the identity-bound allocation record in the
attempt's raw tree so the vendor identity survives that failure, but nothing
consumed it: `recoverAccount` still refused the intent forever, and the only
recovery command is pinned to a historical revision whose attempts predate the
retained record. One such intent blocks every later batch for that account.

Add `recover-allocated-intent`, the identity-based recovery ADR-0010 already
describes. It validates the attempt's digests, requires a failed attempt with no
measurement, no receipts and unresolved cleanup, and requires the retained
allocation to name the same attempt, cell and plan digest. Under checked
repository quiescence it replays the lost `allocated` append, observes removal of
that exact sandbox through the control plane, and appends the ordinary
`released/absent` receipt.

Replaying the allocation first is load-bearing twice over: a bare
`released/absent` without its allocation contradicts the journal's own
consistency rule and would wedge admission again, and the intermediate
intent+allocated state is the ordinary interrupted allocation that admission
already recovers unaided, so an interrupted recovery is safe. Ownership is
released by observing a known resource, so no audited clearance is recorded and
no schema changes. Recovery stays an explicit operator command, never an
admission fallback, and leaves the original attempt failed and unpublishable.

Validation: a regression test drives the rejected append through the real
executor, leaks both sandboxes, shows admission blocked, recovers both, and
shows the reclaimed sandboxes, a consistent journal and admission restored.
Full typecheck, lint, spelling and per-package tests pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PVfQAwVj7ePcUPanvPBhvv