### PR TITLE
fix(harness): export privilege command to benchmark child tasks

### DIFF
--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -69,6 +69,21 @@ describe("selectTransport", () => {
 });
 
 describe("sandbox preamble", () => {
+	for (const uid of [0, 1000]) {
+		it(`passes the selected privilege command to child tasks for uid ${uid}`, () => {
+			const result = Bun.spawnSync([
+				"bash",
+				"-c",
+				[
+					`unset SUDO; id() { printf '%s\\n' '${uid}'; }; sudo() { :; }`,
+					buildPreamble(),
+					`bash -c 'printf "%s" "\${SUDO-unset}"'`,
+				].join("; "),
+			]);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.toString()).toBe(uid === 0 ? "" : "sudo -E");
+		});
+	}
 	it("does not auto-install repository developer tools when running benchmark tasks", () => {
 		expect(PREAMBLE).toContain("MISE_TASK_RUN_AUTO_INSTALL=0");
 	});

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -397,6 +397,7 @@ export function buildPreamble(policy: PtsPassPolicy = DEFAULT_PTS_PASS_POLICY): 
 		...PREAMBLE_HEAD,
 		...ptsTrialVars(policy),
 		'if [ "$(id -u)" = 0 ]; then SUDO=""; elif command -v sudo >/dev/null 2>&1; then SUDO="sudo -E"; else SUDO=""; fi',
+		"export SUDO",
 	].join("; ");
 }
 


### PR DESCRIPTION
Runloop's non-root disk worker failed while applying the pinned PTS parser repair: the harness selected `sudo -E`, but `SUDO` was a shell-local variable, so mise's child tasks attempted to replace the system-owned parser without elevation.

Export the existing privilege command from the step preamble. Root workers still receive an empty command; non-root workers retain the existing sudo selection. No parser, workload, or measurement changes.

Validation: child-shell regression tests fail before the fix (`SUDO` is unset) and pass for both root and non-root selections afterward. Full tests, typecheck, lint and spelling pass. Live failure: https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/34671108200; its cleanup receipt is confirmed. After merge, verify Runloop in a fresh smoke experiment; preserve the failed attempt.
