### PR TITLE
fix(bench): recover lifecycle failures and expose admission gaps

### DIFF
--- a/.github/actions/namespace-token/action.yml
+++ b/.github/actions/namespace-token/action.yml
@@ -34,9 +34,9 @@ inputs:
     description: >-
       Name recorded on the minted token, so a leaked one is traceable to the cell that minted it.
       Include github.run_attempt as well as github.run_id: run_id is PRESERVED across re-runs, so
-      without it a retry collides with the first attempt's token — and a caller's
-      `continue-on-error` would turn that name clash into a silent namespace skip on exactly the
-      re-run where the run was wanted.
+      without it a retry collides with the first attempt's token. Bench suite jobs must also include
+      the immutable batch id: two mixed batches in one run share suite/run/attempt and would
+      otherwise mint colliding names.
     required: true
 
 outputs:

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -75,6 +75,11 @@ jobs:
           BENCH_ARTIFACT_VERCEL: ${{ vars.BENCH_ARTIFACT_VERCEL }}
         run: bun apps/cli/src/bin/workflow-experiment.ts plan
 
+      - name: Audit account journals
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun apps/cli/src/bin/audit-account-journals.ts --from-plan experiment/manifest/plan.json
+
   suite:
     name: ${{ matrix.account }}
     needs: plan

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -62,11 +62,22 @@ jobs:
         # >>> generated: preauth-namespace-token-bench — bun run generate-provider-wiring
         if: matrix.provider == 'namespace'
         # <<< end generated: preauth-namespace-token-bench
-        continue-on-error: true
         id: namespace
         uses: ./.github/actions/namespace-token
         with:
-          token-name: sandbox-benchmarks-${{ inputs.suite }}-${{ github.run_id }}-${{ github.run_attempt }}
+          # batch_id is required: two mixed batches in one run otherwise mint the same
+          # suite-run-attempt name and the second job's continue-on-error path left NSC_TOKEN_FILE empty.
+          token-name: sandbox-benchmarks-${{ inputs.suite }}-${{ inputs.batch_id }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Require Namespace credentials
+        if: matrix.provider == 'namespace'
+        env:
+          NSC_TOKEN_FILE: ${{ steps.namespace.outputs.token-file }}
+        run: |
+          if [ -z "${NSC_TOKEN_FILE}" ] || [ ! -s "${NSC_TOKEN_FILE}" ]; then
+            echo "::error::Namespace credential mint failed; refusing to continue without NSC_TOKEN_FILE"
+            exit 1
+          fi
 
       - name: Set up the tama CLI
         if: matrix.provider == 'tama'
@@ -76,7 +87,6 @@ jobs:
         # >>> generated: preauth-vercel-auth-bench — bun run generate-provider-wiring
         if: matrix.provider == 'vercel'
         # <<< end generated: preauth-vercel-auth-bench
-        continue-on-error: true
         id: vercel-auth
         uses: ./.github/actions/vercel-auth
         with:

--- a/.github/workflows/commit-dataset.yml
+++ b/.github/workflows/commit-dataset.yml
@@ -80,9 +80,24 @@ jobs:
           BENCH_EXPERIMENT_ID: ${{ inputs.run_id }}
         run: bun apps/cli/src/bin/workflow-experiment.ts collect
 
-      - name: Aggregate + promote
+      - name: Aggregate
+        id: aggregate
         run: |
           bun apps/cli/src/bin/aggregate-experiment.ts experiment/manifest/plan.json experiment/attempts data/candidate
+
+      # Always retain coverage.json when aggregation writes it, including incomplete experiments.
+      # Promotion below still requires a complete Run; this artifact is diagnostic only.
+      - name: Upload coverage report
+        if: always() && hashFiles('data/candidate/coverage.json') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: experiment-coverage-${{ inputs.run_id }}-attempt-${{ github.run_attempt }}
+          path: data/candidate/coverage.json
+          if-no-files-found: error
+
+      - name: Promote
+        if: success()
+        run: |
           bun apps/cli/src/bin/promote.ts "data/candidate/runs/$RUN_ID.json" data/dataset experiment/manifest/plan.json experiment/attempts
 
       # Canonicalize the promoted dataset to Biome's format before the gate + commit. The promote
@@ -101,6 +116,7 @@ jobs:
       # hand-written source keeps the strict project-wide cap. Note biome.json cannot hold comments —
       # Biome silently discards a commented config and falls back to its defaults — hence this note here.
       - name: Autofix the promoted dataset formatting (Biome)
+        if: success()
         run: bunx biome check data/dataset --write
 
       # Confirm the committed content passes the exact gate ci.yml runs (`biome check .`), scoped to the
@@ -109,6 +125,7 @@ jobs:
       # A pre-existing, unrelated lint failure elsewhere on main can't strand a clean dataset commit;
       # the PR's own `biome check .` still gates the merge.
       - name: Confirm the promoted dataset passes Biome (the PR lint gate)
+        if: success()
         run: bunx biome check data/dataset --error-on-warnings
 
       # main is protected by a "changes must be made through a pull request" ruleset (the public-repo
@@ -119,6 +136,7 @@ jobs:
       # requirement, with data/dataset/ intentionally unowned (see docs/ci-secrets.md operator setup);
       # the in-job Biome pre-flight above already guarantees the content is clean.
       - name: Commit the dataset via pull request
+        if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -26,7 +26,8 @@
     "aggregate-experiment": "./src/bin/aggregate-experiment.ts",
     "workflow-experiment": "./src/bin/workflow-experiment.ts",
     "recover-completed-create": "./src/bin/recover-completed-create.ts",
-    "recover-allocated-intent": "./src/bin/recover-allocated-intent.ts"
+    "recover-allocated-intent": "./src/bin/recover-allocated-intent.ts",
+    "audit-account-journals": "./src/bin/audit-account-journals.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/apps/cli/src/bin/audit-account-journals.ts
+++ b/apps/cli/src/bin/audit-account-journals.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+import { unresolvedJournalAttempts } from "../lib/account-journal.ts";
+import { githubAccountJournal, githubGitRequest } from "../lib/github-account-journal.ts";
+
+const { values } = parseArgs({
+	args: process.argv.slice(2),
+	options: {
+		account: { type: "string", multiple: true },
+		"from-plan": { type: "string" },
+		probe: { type: "boolean", default: false },
+	},
+});
+
+if (values.probe) {
+	throw new Error(
+		"probe mode requires an explicit operator session with live credentials; this command only reads journals and never fabricates releases",
+	);
+}
+
+const accounts = new Set<string>(values.account ?? []);
+if (values["from-plan"]) {
+	const plan = JSON.parse(readFileSync(values["from-plan"], "utf8")) as {
+		accounts?: Array<{ quotaDomain: string }>;
+	};
+	for (const account of plan.accounts ?? []) {
+		if (!account.quotaDomain) throw new Error("plan account lacks quotaDomain");
+		accounts.add(account.quotaDomain);
+	}
+}
+if (accounts.size === 0) {
+	throw new Error("usage: audit-account-journals --account <domain>... | --from-plan <plan.json>");
+}
+
+const journal = githubAccountJournal(githubGitRequest());
+const unresolved = [];
+for (const account of [...accounts].sort()) {
+	const records = await journal.read(account);
+	unresolved.push(...unresolvedJournalAttempts(records));
+}
+
+if (unresolved.length === 0) {
+	console.log(`account journals clean for ${[...accounts].sort().join(", ")}`);
+	process.exit(0);
+}
+
+console.error("unresolved journal ownership (no releases were written):");
+for (const entry of unresolved) {
+	console.error(
+		JSON.stringify({
+			account: entry.account,
+			attempt: entry.attempt,
+			cellId: entry.cellId,
+			allocated: entry.allocated,
+			ref: entry.ref ?? null,
+		}),
+	);
+}
+console.error(
+	`${unresolved.length} unresolved attempt(s); recover with recover-allocated-intent / recover-completed-create before another full matrix`,
+);
+process.exit(1);

--- a/apps/cli/src/lib/account-journal.test.ts
+++ b/apps/cli/src/lib/account-journal.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import type { SandboxDriver } from "@sandbox-benchmarks/driver";
 import type { AccountRecord } from "./account-journal.ts";
-import { recoverAccount } from "./account-journal.ts";
+import { recoverAccount, unresolvedJournalAttempts } from "./account-journal.ts";
 
 const intent = {
 	version: "1",
@@ -106,4 +106,39 @@ test("a delete acknowledgement cannot release a still-running allocation", async
 		recoverAccount("tama", new Map([["tama", driver]]), journal, AbortSignal.timeout(20)),
 	).rejects.toThrow();
 	expect(records).toHaveLength(2);
+});
+
+test("unresolvedJournalAttempts reports open ownership without inventing releases", () => {
+	const records: AccountRecord[] = [
+		intent,
+		{ ...intent, kind: "allocated", ref },
+		{ ...intent, attempt: "attempt-2", cellId: "tama-system-r1" },
+		{
+			...intent,
+			attempt: "attempt-3",
+			cellId: "tama-system-r2",
+			kind: "released",
+			outcome: "not-allocated",
+		},
+	];
+	expect(unresolvedJournalAttempts(records)).toEqual([
+		{
+			account: "tama",
+			attempt: "attempt-1",
+			cellId: "tama-system-r0",
+			planDigest: intent.planDigest,
+			allocated: true,
+			ref,
+		},
+		{
+			account: "tama",
+			attempt: "attempt-2",
+			cellId: "tama-system-r1",
+			planDigest: intent.planDigest,
+			allocated: false,
+		},
+	]);
+	expect(
+		records.some((record) => record.kind === "released" && record.attempt === "attempt-1"),
+	).toBe(false);
 });

--- a/apps/cli/src/lib/account-journal.ts
+++ b/apps/cli/src/lib/account-journal.ts
@@ -128,6 +128,46 @@ export async function confirmRemoval(
 	}
 }
 
+export type UnresolvedJournalAttempt = {
+	readonly account: string;
+	readonly attempt: string;
+	readonly cellId: string;
+	readonly planDigest: string;
+	readonly allocated: boolean;
+	readonly ref?: SandboxRef;
+};
+
+/**
+ * Report ownership still open in a journal snapshot. Read-only: never appends releases or invents
+ * recovery receipts. Operators use this before another full matrix; recovery remains explicit.
+ */
+export function unresolvedJournalAttempts(
+	records: readonly AccountRecord[],
+): UnresolvedJournalAttempt[] {
+	const byAttempt = new Map<string, AccountRecord[]>();
+	for (const record of records) {
+		const rows = byAttempt.get(record.attempt) ?? [];
+		rows.push(record);
+		byAttempt.set(record.attempt, rows);
+	}
+	const unresolved: UnresolvedJournalAttempt[] = [];
+	for (const rows of byAttempt.values()) {
+		const intent = rows.find((record) => record.kind === "intent");
+		if (!intent) continue;
+		if (rows.some((record) => record.kind === "released")) continue;
+		const allocated = rows.find((record) => record.kind === "allocated");
+		unresolved.push({
+			account: intent.account,
+			attempt: intent.attempt,
+			cellId: intent.cellId,
+			planDigest: intent.planDigest,
+			allocated: allocated !== undefined,
+			...(allocated ? { ref: allocated.ref } : {}),
+		});
+	}
+	return unresolved;
+}
+
 /** Bound observation and persistence; a late operation never authorizes subsequent allocation. */
 export async function withinSignal<T>(
 	signal: AbortSignal,

--- a/apps/cli/src/lib/admission-capacity.test.ts
+++ b/apps/cli/src/lib/admission-capacity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { DriverError } from "@sandbox-benchmarks/driver";
+import {
+	concurrentSandboxAdmissionDetail,
+	isConcurrentSandboxAdmissionError,
+} from "./admission-capacity.ts";
+
+describe("concurrent sandbox admission errors", () => {
+	test("recognizes a structured 429 concurrent limit", () => {
+		const error = new DriverError("create-failed", "computesdk create failed", {
+			provider: "runcloud",
+			vendorHttpStatus: 429,
+			vendorMessage: "API 429: concurrent sandbox resource limit reached",
+		});
+		expect(isConcurrentSandboxAdmissionError(error)).toBe(true);
+		expect(
+			concurrentSandboxAdmissionDetail(error, {
+				quotaDomain: "runcloud",
+				declaredSandboxes: 30,
+				batchConcurrency: 30,
+			}),
+		).toContain("declared 30 sandboxes");
+	});
+
+	test("ignores unclassified 429 prose and non-429 create failures", () => {
+		expect(
+			isConcurrentSandboxAdmissionError(
+				new DriverError("create-failed", "API 429: concurrent sandbox resource limit reached", {
+					provider: "runcloud",
+				}),
+			),
+		).toBe(false);
+		expect(
+			isConcurrentSandboxAdmissionError(
+				new DriverError("create-failed", "rate limited", {
+					provider: "runcloud",
+					vendorHttpStatus: 429,
+					vendorMessage: "too many requests",
+				}),
+			),
+		).toBe(false);
+	});
+});

--- a/apps/cli/src/lib/admission-capacity.ts
+++ b/apps/cli/src/lib/admission-capacity.ts
@@ -1,0 +1,25 @@
+import { isDriverError } from "@sandbox-benchmarks/driver";
+
+/** Vendor refused create because the account already holds its concurrent sandbox quota. */
+export function isConcurrentSandboxAdmissionError(error: unknown): boolean {
+	if (!isDriverError(error) || error.code !== "create-failed" || error.vendorHttpStatus !== 429)
+		return false;
+	const text = `${error.message}\n${error.vendorMessage ?? ""}`.toLowerCase();
+	return text.includes("concurrent") && (text.includes("limit") || text.includes("resource"));
+}
+
+export function concurrentSandboxAdmissionDetail(
+	error: unknown,
+	context: { quotaDomain: string; declaredSandboxes: number; batchConcurrency: number },
+): string {
+	const base = isDriverError(error)
+		? `${error.message}${error.vendorMessage ? ` (${error.vendorMessage})` : ""}`
+		: error instanceof Error
+			? error.message
+			: String(error);
+	return (
+		`vendor concurrent sandbox limit refused create for ${context.quotaDomain} while admission ` +
+		`declared ${context.declaredSandboxes} sandboxes and this batch freezes maxConcurrency=` +
+		`${context.batchConcurrency}; reconcile BENCH_ACCOUNT_CAPACITY before retrying: ${base}`
+	);
+}

--- a/apps/cli/src/lib/execute-experiment.test.ts
+++ b/apps/cli/src/lib/execute-experiment.test.ts
@@ -214,13 +214,21 @@ test("a failed terminal upload does not discard its local immutable evidence or 
 	expect(retry.every((attempt) => !attempt.measurementStarted)).toBe(true);
 });
 
-test("a typed clean create refusal releases its intent while an ambiguous failure does not", async () => {
-	const { DriverError, markRetryableDriverCreate } = await import("@sandbox-benchmarks/driver");
+test("a create-failed releases its intent while a failed-create cleanup keeps ownership", async () => {
+	const { DriverError, FailedCreateCleanupError } = await import("@sandbox-benchmarks/driver");
 	for (const clean of [true, false]) {
 		const f = await fixture(`create-refusal-${clean}`);
 		const open = f.options.open;
-		const failure = new DriverError("create-failed", "boot interrupted", { provider: "tama" });
-		if (clean) markRetryableDriverCreate(failure);
+		const primary = new DriverError("create-failed", "boot interrupted", { provider: "tama" });
+		const failure = clean
+			? primary
+			: new FailedCreateCleanupError(new Error("destroy unavailable"), primary, {
+					provider: "tama",
+					locator: { kind: "name", value: "bench-orphan" },
+					cleanup: async () => {
+						throw new Error("destroy unavailable");
+					},
+				});
 		f.options.open = async () => {
 			const opened = await open();
 			return {

--- a/apps/cli/src/lib/execute-experiment.ts
+++ b/apps/cli/src/lib/execute-experiment.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import type { SandboxDriver, SandboxRef } from "@sandbox-benchmarks/driver";
-import { describeDriverFailure, isRetryableDriverCreate } from "@sandbox-benchmarks/driver";
+import { describeDriverFailure, isFailedCreateCleanupError } from "@sandbox-benchmarks/driver";
 import { diagnosticSecretsFromEnv } from "@sandbox-benchmarks/driver/env";
 import { executeSuite } from "@sandbox-benchmarks/harness";
 import {
@@ -26,6 +26,11 @@ import {
 import type { AccountJournal, AccountRecord } from "./account-journal.ts";
 import { recoverAccount, withinSignal } from "./account-journal.ts";
 import { reconcileAccount } from "./account-reconciliation.ts";
+import { logInfo } from "./actions-log.ts";
+import {
+	concurrentSandboxAdmissionDetail,
+	isConcurrentSandboxAdmissionError,
+} from "./admission-capacity.ts";
 import type { OpenedDriver } from "./driver-run.ts";
 import { isDriverProviderId, openDriver } from "./driver-run.ts";
 import {
@@ -62,6 +67,15 @@ export async function executeExperimentBatch(
 		return cell;
 	});
 	if (cells.length > batch.maxConcurrency) throw new Error("batch exceeds frozen concurrency");
+	const account = plan.accounts.find((entry) => entry.quotaDomain === batch.quotaDomain);
+	if (!account) throw new Error("batch quota domain missing from frozen account capacity");
+	logInfo(
+		`admission ${batch.quotaDomain}: declared sandboxes=${account.sandboxes} batchCells=${cells.length} maxConcurrency=${batch.maxConcurrency}`,
+	);
+	if (batch.maxConcurrency > account.sandboxes)
+		throw new Error(
+			`frozen batch maxConcurrency ${batch.maxConcurrency} exceeds declared sandboxes ${account.sandboxes} for ${batch.quotaDomain}`,
+		);
 	const startupDeadline =
 		Date.now() + Math.min(...cells.map((cell) => cell.startupMinutes)) * 60_000;
 	const drivers = new Map<ProviderId, OpenedDriver>();
@@ -153,8 +167,19 @@ export async function executeExperimentBatch(
 							throw new Error("startup deadline exceeded before create");
 						createStarted = true;
 						const session = await opened.driver.create(request, createOptions).catch((error) => {
-							// This marker guarantees that the failed create left no allocation behind.
-							createRejectedCleanly = isRetryableDriverCreate(error);
+							// Drivers throw FailedCreateCleanupError only when cleanup could not prove
+							// absence. Any other create failure has already reconciled or never allocated.
+							createRejectedCleanly = !isFailedCreateCleanupError(error);
+							if (isConcurrentSandboxAdmissionError(error)) {
+								throw new Error(
+									concurrentSandboxAdmissionDetail(error, {
+										quotaDomain: batch.quotaDomain,
+										declaredSandboxes: account.sandboxes,
+										batchConcurrency: batch.maxConcurrency,
+									}),
+									{ cause: error },
+								);
+							}
 							throw error;
 						});
 						allocated = session.sandboxRef;

--- a/apps/cli/src/lib/run-replicate.ts
+++ b/apps/cli/src/lib/run-replicate.ts
@@ -10,6 +10,7 @@ import {
 import { writeNormalizedRun } from "@sandbox-benchmarks/results";
 import type { Run } from "@sandbox-benchmarks/schema";
 import { logInfo, logProviderStatuses, logWarning, withGroup } from "./actions-log.ts";
+import { isConcurrentSandboxAdmissionError } from "./admission-capacity.ts";
 import { runDriverSuite, usesDriverSuite } from "./driver-run.ts";
 
 const describeDriverFailure = (error: unknown): string =>
@@ -116,12 +117,21 @@ export async function runReplicate(ctx: ReplicateContext): Promise<ReplicateOutc
 				return;
 			}
 			suiteError = err;
-			logWarning(
-				`Suite "${suite}" threw on ${provider} — will normalize any failed marker into a gap: ${describeDriverFailure(
-					err,
-				)}`,
-				{ title: cell },
-			);
+			if (isConcurrentSandboxAdmissionError(err)) {
+				logWarning(
+					`Suite "${suite}" hit a vendor concurrent sandbox limit on ${provider} — admission capacity must be reconciled; not a measurement gap: ${describeDriverFailure(
+						err,
+					)}`,
+					{ title: cell },
+				);
+			} else {
+				logWarning(
+					`Suite "${suite}" threw on ${provider} — will normalize any failed marker into a gap: ${describeDriverFailure(
+						err,
+					)}`,
+					{ title: cell },
+				);
+			}
 		}
 	});
 	if (usageError !== undefined) return { ...base, failed: true, detail: usageError };

--- a/tooling/repo-checks/src/lib/workflow-nesting.ts
+++ b/tooling/repo-checks/src/lib/workflow-nesting.ts
@@ -162,18 +162,27 @@ export function checkExperimentNesting(docs: Record<string, unknown>): string[] 
 			publish.needs.includes("plan"),
 		"publication must wait for plan and all account batches",
 	);
-	const promotion = stepByName(
-		job("commit-dataset.yml", "commit"),
-		"Aggregate + promote",
-		"commit-dataset.yml",
+	const commitJob = job("commit-dataset.yml", "commit");
+	const aggregate = stepByName(commitJob, "Aggregate", "commit-dataset.yml");
+	const coverage = stepByName(commitJob, "Upload coverage report", "commit-dataset.yml");
+	const promotion = stepByName(commitJob, "Promote", "commit-dataset.yml");
+	expect(
+		typeof aggregate?.run === "string" &&
+			aggregate.run.includes(
+				"aggregate-experiment.ts experiment/manifest/plan.json experiment/attempts",
+			),
+		"publication must aggregate against the frozen plan and whole attempts",
 	);
 	expect(
-		typeof promotion?.run === "string" &&
-			promotion.run.includes(
-				"aggregate-experiment.ts experiment/manifest/plan.json experiment/attempts",
-			) &&
+		coverage?.if === "always() && hashFiles('data/candidate/coverage.json') != ''" &&
+			asRecord(coverage.with, "coverage").path === "data/candidate/coverage.json",
+		"incomplete aggregation must still upload coverage.json while refusing promotion",
+	);
+	expect(
+		promotion?.if === "success()" &&
+			typeof promotion.run === "string" &&
 			promotion.run.includes("data/dataset experiment/manifest/plan.json experiment/attempts"),
-		"publication must verify original plan and whole attempts",
+		"promotion must verify the original plan and whole attempts only after a complete aggregate",
 	);
 	return errors;
 }

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -242,7 +242,7 @@ describe("Namespace token authentication", () => {
 		expect(workflowText.match(/id: namespace/g)).toHaveLength(3);
 		expect(
 			workflowText.match(/NSC_TOKEN_FILE: \$\{\{ steps\.namespace\.outputs\.token-file \}\}/g),
-		).toHaveLength(3);
+		).toHaveLength(4);
 		expect(workflowText).not.toContain("id: nsc-token");
 		expect(workflowText).not.toContain("id: nsc-setup");
 		expect(workflowText).not.toMatch(/run: \|\s*\n\s*nsc token create/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- recovers clean sandbox-create failures without inventing allocation receipts and adds a journal audit command for unresolved intents
- makes Namespace token names unique per immutable batch identity and fails token minting loudly
- models Runcloud's effective concurrent capacity so HTTP 429 is reported as an admission mismatch instead of hidden
- uploads experiment coverage even when completeness rejects aggregation; incomplete datasets remain ineligible for promotion

## Failure classes addressed
Prospective fixes for lifecycle/admission, Namespace credential collisions between same-suite batches, Runcloud quota mismatch, and missing coverage artifacts observed around failed CPU run 34672199543. That frozen run remains incomplete and is not republished.

## Validation
- execute-experiment tests
- account-journal tests
- admission-capacity tests
- workflow registry/sync checks

## Stack
1. This PR
2. two-wave CPU provider matrix
3. real-world workload metric validity
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8ea50ff-9381-4a9a-b719-17a005f1d055?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8ea50ff-9381-4a9a-b719-17a005f1d055&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

