### PR TITLE
fix(bench): require real samples from real-world workloads

### DIFF
--- a/apps/cli/src/lib/experiment-plan.test.ts
+++ b/apps/cli/src/lib/experiment-plan.test.ts
@@ -206,6 +206,19 @@ test("all-skipped, missing, partial, unknown completion, and unresolved cleanup 
 	]);
 	expect(evaluateExperiment(plan(), [successful()]).complete).toBe(true);
 });
+test("declared metrics with non-positive samples cannot satisfy coverage", () => {
+	// Empty samples cannot form a schema-valid Run (parseRun rejects them). Non-positive values
+	// can still appear if a producer writes a 0; coverage must treat that as a shortfall.
+	const zero = successful();
+	const zeroMetric = zero.run?.providers[0]?.metrics[0];
+	if (!zeroMetric) throw new Error("fixture missing metric");
+	zeroMetric.samples = [0];
+	zeroMetric.aggregates = aggregate([0]);
+	zero.evidence.runDigest = evidenceDigest(zero.run);
+	expect(evaluateExperiment(plan(), [zero]).complete).toBe(false);
+	expect(evaluateExperiment(plan(), [zero]).cells[0]?.missingMetrics).toEqual(["stream_type_copy"]);
+});
+
 test("provenance, duplicate attempts, and measured reruns cannot satisfy coverage", () => {
 	const valid = successful();
 	expect(evaluateExperiment(plan(), [valid, valid]).complete).toBe(false);

--- a/apps/cli/src/lib/run-replicate.ts
+++ b/apps/cli/src/lib/run-replicate.ts
@@ -108,7 +108,7 @@ export async function runReplicate(ctx: ReplicateContext): Promise<ReplicateOutc
 				// Dimensions (the runtime half of the suite↔dimension↔metric contract).
 				resultsDir: join(rawRoot, provider, suite),
 			});
-			logInfo(`Suite "${suite}" completed on ${provider}`);
+			logInfo(`Suite "${suite}" command finished on ${provider}`);
 		} catch (err) {
 			// A usage error (unknown provider/suite) produced no raw tree and no marker: there is nothing to
 			// normalize, and pretending otherwise would write an empty Run for a cell that never existed.

--- a/packages/results/src/lib/experiment.ts
+++ b/packages/results/src/lib/experiment.ts
@@ -297,7 +297,18 @@ export function evaluateExperiment(
 		const artifact = provider?.artifactEvidence?.find(
 			(entry) => entry.cell.suite === cell.suite && entry.cell.replicateIndex === cell.replicate,
 		);
-		const measured = new Set(provider?.metrics.map((metric) => metric.metricId) ?? []);
+		// Declared metrics need real samples — an empty samples array (or non-positive values) is a
+		// shortfall, not coverage. Frozen CPU run 34672199543 finished PTS exit 0 for mastra/openclaw
+		// while Test Core / Shrinkwrap / Test Unit Fast produced no positive samples.
+		const measured = new Set(
+			(provider?.metrics ?? [])
+				.filter(
+					(metric) =>
+						metric.samples.length > 0 &&
+						metric.samples.every((sample) => Number.isFinite(sample) && sample > 0),
+				)
+				.map((metric) => metric.metricId),
+		);
 		const missingMetrics = eligible.filter((id) => !measured.has(id));
 		const evidence = selected?.evidence;
 		const execution = selected?.execution && executionReceiptSchema.assert(selected.execution);

--- a/packages/schema/src/pts-generated.ts
+++ b/packages/schema/src/pts-generated.ts
@@ -22716,7 +22716,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Cold Install",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Cold Install" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22728,7 +22728,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Git Clone",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Git Clone" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22740,7 +22740,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Lint Extensions",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Lint Extensions" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22752,20 +22752,8 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Lint Oxlint",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Lint Oxlint" },
-		sourceUrl: "https://github.com/openclaw/openclaw",
-	},
-	{
-		id: "realworld_openclaw_task_shrinkwrap_check",
-		dimension: "system",
-		unit: "Seconds",
-		direction: "LIB",
-		headline: false,
-		label: "OpenClaw CI Tasks - Task: Shrinkwrap Check",
-		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
-		pts: { test: "local/realworld-openclaw", description: "Task: Shrinkwrap Check" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
 	{
@@ -22776,20 +22764,8 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Test Types",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Test Types" },
-		sourceUrl: "https://github.com/openclaw/openclaw",
-	},
-	{
-		id: "realworld_openclaw_task_test_unit_fast",
-		dimension: "system",
-		unit: "Seconds",
-		direction: "LIB",
-		headline: false,
-		label: "OpenClaw CI Tasks - Task: Test Unit Fast",
-		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
-		pts: { test: "local/realworld-openclaw", description: "Task: Test Unit Fast" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
 	{
@@ -22800,7 +22776,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Typecheck",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Typecheck" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},

--- a/packages/schema/src/pts-overrides.ts
+++ b/packages/schema/src/pts-overrides.ts
@@ -186,14 +186,6 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 		dimension: "realworld",
 		label: "OpenClaw: typecheck (tsgo)",
 	},
-	realworld_openclaw_task_shrinkwrap_check: {
-		dimension: "realworld",
-		label: "OpenClaw: shrinkwrap check",
-	},
-	realworld_openclaw_task_test_unit_fast: {
-		dimension: "realworld",
-		label: "OpenClaw: test (unit, fast)",
-	},
 	realworld_openclaw_task_test_types: {
 		dimension: "realworld",
 		label: "OpenClaw: typecheck (test tree)",

--- a/packages/schema/src/pts-profiles/local/realworld-mastra-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-mastra-1.0.0/target.env
@@ -17,4 +17,4 @@ TASK_CMD_build_core="pnpm build:core"
 # turbo cache (see realworld-runner.sh's prep reset), leaving the timed command exactly the
 # vitest run.
 TASK_PREP_test_core="pnpm build:core"
-TASK_CMD_test_core="NODE_OPTIONS=--max-old-space-size=4096 VITEST_MAX_WORKERS=1 pnpm test:core"
+TASK_CMD_test_core="NODE_OPTIONS=--max-old-space-size=4096 VITEST_MAX_WORKERS=1 pnpm test:core -- --pool=forks --poolOptions.forks.singleFork=true"

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
@@ -135,7 +135,8 @@ TASK_CMD_typecheck="OPENCLAW_LOCAL_CHECK=0 pnpm tsgo:prod"
 # ever posted. Pin-scoped, not provider-scoped -- nothing the harness does can make it pass.
 # OPENCLAW_LOCAL_CHECK=0 for job fidelity (check-shard sets it for every task in the step); inert
 # here since this check is a plain node script with no tsgo/oxlint throttle path.
-TASK_CMD_shrinkwrap_check="OPENCLAW_LOCAL_CHECK=0 pnpm deps:shrinkwrap:check"
+# Removed from timed menu: never posted samples in frozen CPU run 34672199543.
+# TASK_CMD_shrinkwrap_check="OPENCLAW_LOCAL_CHECK=0 pnpm deps:shrinkwrap:check"
 # Red everywhere, and the fleet's cause differs from the local one -- do NOT assume they are the
 # same bug. Locally vitest dies with EMFILE ("too many open files") writing
 # node_modules/.experimental-vitest-cache at ulimit -n 4096: 11039 tests pass, 44 files error,
@@ -145,7 +146,8 @@ TASK_CMD_shrinkwrap_check="OPENCLAW_LOCAL_CHECK=0 pnpm deps:shrinkwrap:check"
 # "E: [openclaw] Failed to resolve version: Error: version resolution failed". Neither has been run
 # down to a fix; the forensics tarball under data/raw/<runId>/<provider>/realworld-openclaw holds
 # the full task log if someone wants the rest of the story.
-TASK_CMD_test_unit_fast="pnpm test:unit:fast"
+# Removed from timed menu: never posted samples in frozen CPU run 34672199543.
+# TASK_CMD_test_unit_fast="pnpm test:unit:fast"
 # check:test-types (tsgo:core:test && tsgo:extensions:test) is the `test-types` task of CI's
 # check-shard job, and replaced the dropped build task (see the DROPPED TASK section). It was picked
 # over the other in-spec check-shard candidates because it is the only one that both fits and

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
@@ -4,7 +4,7 @@
   <TestInformation>
     <Title>OpenClaw CI Tasks</Title>
     <AppVersion>623534400684eca7c451cf587189fae714f2abe2</AppVersion>
-    <Description>Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.</Description>
+    <Description>Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.</Description>
     <ResultScale>Seconds</ResultScale>
     <Proportion>LIB</Proportion>
     <Executable>realworld-run</Executable>
@@ -46,14 +46,6 @@
         <Entry>
           <Name>Typecheck</Name>
           <Value>typecheck</Value>
-        </Entry>
-        <Entry>
-          <Name>Shrinkwrap Check</Name>
-          <Value>shrinkwrap_check</Value>
-        </Entry>
-        <Entry>
-          <Name>Test Unit Fast</Name>
-          <Value>test_unit_fast</Value>
         </Entry>
         <Entry>
           <Name>Test Types</Name>

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -310,14 +310,15 @@ export const SUITES = {
 		ptsTimesToRun: 1,
 		defaultReplicas: 12,
 		dimensions: ["realworld"],
+		// Declared metrics must be ones that can post real samples under the 4vCPU/8GiB target.
+		// Frozen run 34672199543: shrinkwrap_check and test_unit_fast posted 0 samples (always red
+		// at this pin); lint_oxlint rarely samples but did post Values, so it stays declared.
 		metrics: [
 			"realworld_openclaw_task_git_clone",
 			"realworld_openclaw_task_cold_install",
 			"realworld_openclaw_task_lint_oxlint",
 			"realworld_openclaw_task_lint_extensions",
 			"realworld_openclaw_task_typecheck",
-			"realworld_openclaw_task_shrinkwrap_check",
-			"realworld_openclaw_task_test_unit_fast",
 			"realworld_openclaw_task_test_types",
 		],
 		commands: ["mise run benchmark:realworld:pts:openclaw"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- removes OpenClaw tasks that the pinned profile cannot produce from its declared metric contract while retaining the working lint metric
- requires positive sample counts for declared real-world metrics, so wrapper success cannot masquerade as benchmark completeness
- clarifies suite logs as command completion rather than benchmark completion
- records Mastra Test Core as a visible coverage shortfall when its workload emits no positive samples

## Scope and evidence
The frozen run 34672199543 showed no positive samples for OpenClaw `shrinkwrap_check` and `test_unit_fast`; these are no longer falsely declared. Mastra Test Core still fails at the current pin (`mock-model-id` / `Model 1 failed`) and is intentionally not hidden or claimed fixed. A separate workload/pin correction remains necessary before full Mastra coverage.

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run lint:workflows`
- `bun run spell`
- `bun run check:catalog-drift`
- `bun run check:provider-wiring`

## Stack
1. lifecycle/admission and coverage artifact
2. two-wave CPU provider matrix
3. This PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8ea50ff-9381-4a9a-b719-17a005f1d055?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8ea50ff-9381-4a9a-b719-17a005f1d055&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

